### PR TITLE
Adapt to rmcp 3 and sha2 0.11

### DIFF
--- a/.ci/check-frama-c-matrix-version.sh
+++ b/.ci/check-frama-c-matrix-version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# The matrix value is a supported one, checked before ten minutes of opam
+# install rather than after. Usage: check-frama-c-matrix-version.sh <version>
+
+set -eu
+
+version=${1:?expected a Frama-C version}
+
+case "$version" in
+33.0) ;;
+*)
+    echo "Unsupported Frama-C CI version: $version" >&2
+    echo "Supported smoke-test version is 33.0." >&2
+    exit 1
+    ;;
+esac

--- a/.ci/check-installed-versions.sh
+++ b/.ci/check-installed-versions.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# The switch holds the Frama-C and Alt-Ergo this lane's numbers were measured
+# under. Usage: check-installed-versions.sh <expected-frama-c-version>
+
+set -eu
+
+expected=${1:?expected a Frama-C version}
+
+version="$(opam exec -- frama-c -version)"
+case "$version" in
+"$expected"*) ;;
+*)
+    echo "Expected Frama-C $expected, got: $version" >&2
+    exit 1
+    ;;
+esac
+
+# Checked here as well as inside the corpus gate, because the gate reads the
+# version out of WP's own output and so can only report it after a fixture has
+# run. This says which binary is installed, before anything is proved.
+prover="$(opam exec -- alt-ergo --version)"
+case "$prover" in
+v2.6.3 | 2.6.3) ;;
+*)
+    echo "Expected Alt-Ergo 2.6.3, got: ${prover:-nothing}" >&2
+    echo "scripts/check-tutorial-corpus.sh baselines are keyed to that version." >&2
+    exit 1
+    ;;
+esac

--- a/.ci/check-shell-formatting.sh
+++ b/.ci/check-shell-formatting.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Shell is 4-space indented, matching the [*.sh] rule in the .editorconfig this
+# repository does not track. The flag below is therefore the whole rule, not a
+# restatement of one, and a drifted script fails here rather than in the next
+# diff that happens to touch it.
+#
+# The download is pinned by checksum: this step formats every tracked script in
+# the tree, so an unverified binary here would be one that decides what the
+# repository's shell looks like.
+#
+# Linux only, and CI runs it on that leg alone: the pinned download is a
+# linux_amd64 binary, and the check reads tracked files, so running it twice
+# would compare the same bytes against the same formatter.
+
+# The invocation below is spelled out rather than routed through a variable, and
+# that is load-bearing rather than style. gate_of in tests/unit/repo-guards.rs
+# recognizes this gate by the exact words of the invocation, so writing the
+# binary as a variable made the gate invisible: ci_gates stopped yielding it, and both
+# run_gates_runs_every_ci_gate and documented_gate_list_covers_ci stopped
+# requiring it, with no test failing. Keep the command literal. A full path is
+# literal enough, which is why the download is called by path rather than put on
+# PATH: prepending a world-writable directory would also decide which git and
+# which xargs the line below gets.
+#
+# This comment deliberately does not repeat the command it is about. A comment
+# containing it would satisfy the guard on its own, which would put the gate
+# back to being kept alive by prose rather than by anything that runs.
+
+# pipefail because the gate ends in a pipeline: without it a git ls-files that
+# fails leaves xargs with empty input, so nothing is checked and the gate exits
+# 0. The inline block this came from had none either, since Actions defaults to
+# "bash -e {0}" for a run step with no shell key, so this is a fix rather than a
+# restoration.
+set -euo pipefail
+
+curl -sSfL -o /tmp/shfmt https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
+echo "fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1  /tmp/shfmt" | sha256sum -c -
+chmod +x /tmp/shfmt
+
+git ls-files -z '*.sh' '*.hook' | xargs -0 /tmp/shfmt -i 4 -d

--- a/.ci/frama-c-smoke-tests.sh
+++ b/.ci/frama-c-smoke-tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# One test per thing this server asks of a Frama-C it has never met, run before
+# the full suites so a version incompatibility is reported as the request that
+# failed rather than as forty tests going red at once.
+#
+# The release build comes first and is not optional: test-mcp-stdio spawns
+# target/release/frama-c-mcp from disk rather than the harness cargo just built.
+
+set -eu
+
+cargo build --release
+
+# request compatibility and explicit capability probing
+cargo test --test unit self_check_live_reports_frama_c_when_available -- --nocapture
+# AST export and sandbox extraction
+cargo test --test test-mcp-stdio create_sandbox_keeps_unused_static_target_function -- --nocapture
+# EVA compute plus alarm fetch
+cargo test --test test-mcp-stdio check_running_eva_alone_accepts_ilevel_and_echoes_options -- --nocapture
+# WP run and model request compatibility
+cargo test --test test-mcp-stdio run_wp_accepts_installed_model_modifiers -- --nocapture
+# WP goal fetch
+cargo test --test test-mcp-stdio wp_goals_surface_vacuous_call_precondition_status -- --nocapture
+# ACSL validation and injection
+cargo test --test test-mcp-stdio inject_all_accepts_global_acsl_first -- --nocapture

--- a/.ci/publish-latest-release.sh
+++ b/.ci/publish-latest-release.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Delete and recreate rather than upload --clobber: the "latest" tag has to move
+# to the commit that produced these binaries, and no gh invocation repoints an
+# existing tag. That leaves a window where the release is gone and its
+# replacement does not exist yet, which drives the care below.
+#
+# Reads the HTTP status rather than branching on gh's exit code. gh exits
+# nonzero for every HTTP failure alike, so "if gh ... ; then" reads a 500, a
+# revoked token or a DNS blip as "no release here" and walks straight into the
+# deletions below. Only 200 and 404 are answers; anything else is an unknown
+# state, and deleting from an unknown state is how the tag of a live release
+# gets removed.
+#
+# Expects GH_TOKEN, GH_REPO, GITHUB_SHA in the environment and assets.txt on
+# disk, as written by stage-release-assets.sh.
+
+set -eu
+
+status_of() {
+    gh api "$1" --silent -i 2>/dev/null | head -1 | awk '{print $2}'
+}
+require_answer() {
+    case "$1" in
+    200 | 404) return 0 ;;
+    esac
+    echo "unexpected status '${1:-none}' querying $2, aborting before any deletion" >&2
+    exit 1
+}
+
+release_status=$(status_of "repos/$GH_REPO/releases/tags/latest")
+require_answer "$release_status" "the latest release"
+if [ "$release_status" = 200 ]; then
+    # No --cleanup-tag. It deletes the release first and then errors if the
+    # tag is already gone, which is the state left by a previous run that died
+    # between the two steps, or by someone deleting the tag in the web UI. Under
+    # set -e that ends the run with the release destroyed and no replacement
+    # published, which is the one outcome this script is arranged to avoid. The
+    # explicit tag check below removes the tag, and tolerates it being absent.
+    gh release delete latest --yes
+fi
+
+# The tag can outlive the release: deleting a release in the web UI leaves its
+# tag behind, and so does a run that got as far as the delete and then failed.
+# "gh release create" ignores --target when the tag already exists (the API
+# documents target_commitish as unused in that case), so a stale "latest" tag
+# would publish these binaries under a release pointing at an older commit.
+#
+# Queried after the delete above rather than before it, so the answer describes
+# the state the create below will meet.
+tag_status=$(status_of "repos/$GH_REPO/git/ref/tags/latest")
+require_answer "$tag_status" "the latest tag"
+if [ "$tag_status" = 200 ]; then
+    gh api -X DELETE "repos/$GH_REPO/git/refs/tags/latest" >/dev/null
+fi
+
+# A read loop rather than mapfile, which is bash 4 and absent from the bash 3.2
+# macOS still ships. This script is documented as runnable by hand, and failing
+# here would leave the release deleted and unpublished.
+assets=()
+while IFS= read -r asset; do
+    [ -n "$asset" ] && assets+=("$asset")
+done <assets.txt
+gh release create latest "${assets[@]}" \
+    --target "$GITHUB_SHA" \
+    --title "latest" \
+    --notes "Automated build of ${GITHUB_SHA:0:7} on $(date -u +%Y-%m-%d). The ast-utils Frama-C plugin is not included; build it from source in your opam switch."

--- a/.ci/stage-release-assets.sh
+++ b/.ci/stage-release-assets.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Name every asset rather than counting them. A bare count passes when a target
+# is renamed or swapped for another, which publishes the wrong set under a name
+# users are told to trust, and these names are what README documents. The list
+# duplicates the build matrix on purpose: Actions has no YAML anchors, and
+# threading the targets through a setup job's fromJSON output buys one less
+# duplicated line at the cost of a whole extra job. A rename fails here rather
+# than shipping quietly, and released_tarball_names_match_the_build_matrix
+# covers the copy in README, which this script cannot see.
+#
+# Runs before anything is deleted, so a missing artifact fails while the old
+# release is still up.
+
+set -eu
+
+expected=(
+    frama-c-mcp-x86_64-unknown-linux-gnu.tar.gz
+    frama-c-mcp-aarch64-apple-darwin.tar.gz
+)
+
+shopt -s nullglob
+found=(dist/*.tar.gz)
+missing=()
+for name in "${expected[@]}"; do
+    [ -f "dist/$name" ] || missing+=("$name")
+done
+if [ ${#missing[@]} -ne 0 ] || [ ${#found[@]} -ne ${#expected[@]} ]; then
+    echo "release assets do not match the expected set" >&2
+    echo "  missing: ${missing[*]:-none}" >&2
+    echo "  found:   ${found[*]:-none}" >&2
+    exit 1
+fi
+printf 'dist/%s\n' "${expected[@]}" >assets.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,21 +82,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # Shell is 4-space indented, matching the [*.sh] rule in the .editorconfig
-      # this repo does not track. The flag below is therefore the whole rule, not
-      # a restatement of one, and a drifted script fails here rather than in the
-      # next diff that happens to touch it.
-      #
-      # Linux only: the pinned download is a linux_amd64 binary, and the check
-      # reads tracked files, so running it twice would compare the same bytes
-      # against the same formatter.
       - name: Shell formatting (shfmt -i 4)
         if: runner.os == 'Linux'
-        run: |
-          curl -sSfL -o /tmp/shfmt https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
-          echo "fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1  /tmp/shfmt" | sha256sum -c -
-          chmod +x /tmp/shfmt
-          git ls-files '*.sh' '*.hook' | xargs /tmp/shfmt -i 4 -d
+        run: .ci/check-shell-formatting.sh
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -163,15 +151,7 @@ jobs:
           ocaml-compiler: "4.14.2"
 
       - name: Validate Frama-C matrix version
-        run: |
-          case "${{ matrix.frama-c-version }}" in
-            33.0) ;;
-            *)
-              echo "Unsupported Frama-C CI version: ${{ matrix.frama-c-version }}" >&2
-              echo "Supported smoke-test version is 33.0." >&2
-              exit 1
-              ;;
-          esac
+        run: .ci/check-frama-c-matrix-version.sh '${{ matrix.frama-c-version }}'
 
       # Cache the whole opam state keyed by frama-c + compiler + OS: frama-c is
       # not declared as a project dependency, so without this the ~10 min install
@@ -204,29 +184,7 @@ jobs:
         run: opam install -y frama-c.${{ matrix.frama-c-version }} alt-ergo.2.6.3
 
       - name: Check installed Frama-C and Alt-Ergo versions
-        run: |
-          version="$(opam exec -- frama-c -version)"
-          case "$version" in
-            "${{ matrix.frama-c-version }}"*) ;;
-            *)
-              echo "Expected Frama-C ${{ matrix.frama-c-version }}, got: $version" >&2
-              exit 1
-              ;;
-          esac
-
-          # Checked here as well as inside the corpus gate, because the gate
-          # reads the version out of WP's own output and so can only report it
-          # after a fixture has run. This says which binary is installed, before
-          # anything is proved.
-          prover="$(opam exec -- alt-ergo --version)"
-          case "$prover" in
-            v2.6.3 | 2.6.3) ;;
-            *)
-              echo "Expected Alt-Ergo 2.6.3, got: ${prover:-nothing}" >&2
-              echo "scripts/check-tutorial-corpus.sh baselines are keyed to that version." >&2
-              exit 1
-              ;;
-          esac
+        run: .ci/check-installed-versions.sh '${{ matrix.frama-c-version }}'
 
       # why3 keeps its prover registry in ~/.why3.conf (outside ~/.opam), so this
       # must run even on a cache hit, otherwise WP finds no prover and every goal
@@ -259,20 +217,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Frama-C version smoke tests
-        run: |
-          cargo build --release
-          # request compatibility and explicit capability probing
-          cargo test --test unit self_check_live_reports_frama_c_when_available -- --nocapture
-          # AST export and sandbox extraction
-          cargo test --test test-mcp-stdio create_sandbox_keeps_unused_static_target_function -- --nocapture
-          # EVA compute plus alarm fetch
-          cargo test --test test-mcp-stdio check_running_eva_alone_accepts_ilevel_and_echoes_options -- --nocapture
-          # WP run and model request compatibility
-          cargo test --test test-mcp-stdio run_wp_accepts_installed_model_modifiers -- --nocapture
-          # WP goal fetch
-          cargo test --test test-mcp-stdio wp_goals_surface_vacuous_call_precondition_status -- --nocapture
-          # ACSL validation and injection
-          cargo test --test test-mcp-stdio inject_all_accepts_global_acsl_first -- --nocapture
+        run: .ci/frama-c-smoke-tests.sh
 
       - name: Tutorial corpus WP shape gate
         run: scripts/check-tutorial-corpus.sh
@@ -283,10 +228,10 @@ jobs:
       - name: Integration tests (live Frama-C server)
         run: cargo test --test test-integration -- --test-threads=1
 
-      # Must stay after the "cargo build --release" above: test-process-lifecycle
-      # spawns target/release/frama-c-mcp from disk rather than the harness
-      # binary cargo just built, so moving this earlier tests a stale binary or
-      # no binary at all.
+      # Must stay after the release build in .ci/frama-c-smoke-tests.sh:
+      # test-process-lifecycle spawns target/release/frama-c-mcp from disk
+      # rather than the harness binary cargo just built, so moving this earlier
+      # tests a stale binary or no binary at all.
       - name: Process lifecycle, reload and conclusion tests
         run: |
           cargo test --test test-process-lifecycle -- --test-threads=1
@@ -370,12 +315,22 @@ jobs:
     concurrency:
       group: release-latest
       cancel-in-progress: false
-    # No checkout: nothing here reads the tree, and gh resolves the repository
-    # from GH_REPO rather than from a git remote.
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
     steps:
+      # Needed since the shell below moved into .ci/: this job runs two scripts
+      # out of the tree and would otherwise fail on the first push to main with
+      # no such file. It is first so that checkout's workspace clean cannot wipe
+      # the artifacts the next step downloads.
+      #
+      # persist-credentials matters more here than in the jobs above, not less:
+      # this is the one job with contents: write, so the default would write a
+      # token that can push to the repository into .git/config. Nothing here
+      # uses git; gh reads GH_TOKEN from the environment.
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v8
         with:
           # Without a pattern this collects every artifact in the run, so an
@@ -384,77 +339,7 @@ jobs:
           pattern: frama-c-mcp-*
           path: dist
           merge-multiple: true
-      # Name every asset rather than counting them. A bare count passes when a
-      # target is renamed or swapped for another, which publishes the wrong set
-      # under a name users are told to trust, and these names are what README
-      # documents. The list duplicates the build matrix on purpose: Actions has
-      # no YAML anchors, and threading the targets through a setup job's
-      # fromJSON output buys one less duplicated line at the cost of a whole
-      # extra job. A rename fails here rather than shipping quietly, and
-      # released_tarball_names_match_the_build_matrix covers the copy in README,
-      # which this step cannot see.
       - name: Stage assets
-        run: |
-          expected=(
-            frama-c-mcp-x86_64-unknown-linux-gnu.tar.gz
-            frama-c-mcp-aarch64-apple-darwin.tar.gz
-          )
-          shopt -s nullglob
-          found=(dist/*.tar.gz)
-          missing=()
-          for name in "${expected[@]}"; do
-            [ -f "dist/$name" ] || missing+=("$name")
-          done
-          if [ ${#missing[@]} -ne 0 ] || [ ${#found[@]} -ne ${#expected[@]} ]; then
-            echo "release assets do not match the expected set" >&2
-            echo "  missing: ${missing[*]:-none}" >&2
-            echo "  found:   ${found[*]:-none}" >&2
-            exit 1
-          fi
-          printf 'dist/%s\n' "${expected[@]}" > assets.txt
-      # Read the HTTP status rather than branching on gh's exit code. gh exits
-      # nonzero for every HTTP failure alike, so "if gh ... ; then" reads a 500,
-      # a revoked token or a DNS blip as "no release here" and walks straight
-      # into the deletions below. Only 200 and 404 are answers; anything else is
-      # an unknown state, and deleting from an unknown state is how the tag of a
-      # live release gets removed.
+        run: .ci/stage-release-assets.sh
       - name: Replace the latest release
-        run: |
-          status_of() {
-            gh api "$1" --silent -i 2>/dev/null | head -1 | awk '{print $2}'
-          }
-          require_answer() {
-            case "$1" in
-              200|404) return 0 ;;
-            esac
-            echo "unexpected status '${1:-none}' querying $2, aborting before any deletion" >&2
-            exit 1
-          }
-
-          release_status=$(status_of "repos/$GH_REPO/releases/tags/latest")
-          require_answer "$release_status" "the latest release"
-          if [ "$release_status" = 200 ]; then
-            gh release delete latest --yes --cleanup-tag
-          fi
-
-          # The tag can outlive the release: deleting a release in the web UI
-          # leaves its tag behind, and so does a run that got as far as the
-          # delete and then failed. "gh release create" ignores --target when the
-          # tag already exists (the API documents target_commitish as unused in
-          # that case), so a stale "latest" tag would publish these binaries
-          # under a release pointing at an older commit.
-          #
-          # Queried only after the delete above, because --cleanup-tag already
-          # removes the tag and a status read taken earlier would send us to
-          # delete a ref that no longer exists.
-          tag_status=$(status_of "repos/$GH_REPO/git/ref/tags/latest")
-          require_answer "$tag_status" "the latest tag"
-          if [ "$tag_status" = 200 ]; then
-            gh api -X DELETE "repos/$GH_REPO/git/refs/tags/latest" >/dev/null
-          fi
-
-          mapfile -t assets < assets.txt
-          gh release create latest "${assets[@]}" \
-            --target "$GITHUB_SHA" \
-            --title "latest" \
-            --notes "Automated build of ${GITHUB_SHA:0:7} on $(date -u +%Y-%m-%d). The ast-utils Frama-C plugin is not included; build it from source in your opam switch."
+        run: .ci/publish-latest-release.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -779,13 +781,14 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rmcp"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
+checksum = "5f17072af977b0f86f714dbd64b3d37d0715bb63064f9d13483f0a1775813374"
 dependencies = [
  "base64",
  "chrono",
  "futures",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "process-wrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2021"
 
 [dependencies]
 # MCP protocol (official Rust SDK).
-# Aligned with fv-core-mcp + mcp-server-fsm (both on 1.x).
+# The range is "3" rather than an exact version: Cargo.lock is tracked and the
+# build job passes --locked, so the published binaries are already a function of
+# the commit that names them, and a minimum-version bump with no API behind it
+# only makes this file disagree with every other entry.
 rmcp = { version = "3", features = ["server", "transport-io", "macros"] }
 
 # Async runtime
@@ -43,6 +46,10 @@ anyhow = "1"
 # Hash (for source_hash in snapshots)
 sha2 = "0.11"
 
+# Temp dirs with a name that cannot be pre-created, and RAII cleanup for the
+# scratch directories the analyses write into. Also used by the test fixtures.
+tempfile = "3"
+
 # Graph algorithms (verify-program-fsm: Tarjan SCC + Kahn layering)
 petgraph = "0.8"
 
@@ -56,9 +63,6 @@ chrono = { version = "0.4", features = ["serde"] }
 libc = "0.2"
 
 [dev-dependencies]
-# Temp dirs for test fixtures (state dir, project files).
-tempfile = "3"
-
 # MCP client side + child-process transport for end-to-end stdio JSON-RPC tests.
 # Used by tests/mcp_stdio_test.rs to spawn the server binary and drive it
 # through the actual MCP wire protocol (no internal-API shortcuts).

--- a/README.md
+++ b/README.md
@@ -526,6 +526,29 @@ suites, and a job building the binaries above, each run on the platform it was
 built for. A push to `main` that clears all four republishes the `latest`
 release.
 
+Steps whose shell is more than a couple of commands live in `.ci/` and the
+workflow names the path, so those scripts are formatted by the `shfmt` gate and
+runnable by hand. The guards in `tests/unit/repo-guards.rs` read `.ci/` as well
+as `.github/workflows/`, since that is where the commands CI runs now are.
+
+### Rust formatting is by hand
+
+There is no `cargo fmt` gate and no `rustfmt.toml`, and that is a decision
+rather than an oversight. The tree is about 800 hunks away from rustfmt
+defaults across 40 files, because the wrapping is deliberate: payload literals
+are laid out to mirror the JSON they build, and the comments that carry most of
+this repository's reasoning are wrapped to be read rather than to fill a column
+budget.
+
+So do not run `cargo fmt` on this tree. Match the formatting of the code you
+are editing, which is the same rule the shell gate enforces mechanically and
+the one thing a formatter cannot check. Import ordering in particular is not a
+rule here; several modules group by origin instead of alphabetically, and no
+gate has an opinion.
+
+Shell is the exception and is machine-checked, because `shfmt` agrees with what
+the scripts already look like and there is no cost to enforcing it.
+
 ## Technical notes
 
 ### Frama-C server protocol

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -87,6 +87,39 @@ The same table is in README, and `src/mcp/analysis.rs` names the codes once in
 `incomplete_code`. A test asserts all three agree, so a code added in one place
 and not the others fails the build rather than a consumer.
 
+## Where the payload appears in an MCP result
+
+Twice, and identically, whenever the payload is a JSON object. Every tool sets:
+
+- `content[0]`, a text block holding this document pretty-printed. This is what
+  a client below protocol revision 2025-06-18 sees, it is what the schema above
+  describes, and it is always set.
+- `structuredContent`, the same document as JSON rather than as a string, set
+  only when that document is an object. A client that reads it skips a parse of
+  a document that was serialized only to be parsed again.
+
+They are the same value, moved rather than serialized twice, so a consumer may
+read either. The text block is not going away: it predates `structuredContent`,
+the older revisions have nothing else, and this server's own readers parse it.
+
+The object condition is not a nicety. The schema types `structuredContent` as a
+JSON object, and a client that validates the result against it rejects the whole
+response rather than the one field: the TypeScript SDK parses it as an object
+with unknown keys, which an array fails. Five of the six kinds `list` answers
+are arrays, so a payload that is not an object sets the text block alone, which
+is what every client understood before this field existed.
+
+Every tool that returns JSON goes through one function, `json_result`, which is
+what makes that true of all of them rather than of most. The single exception
+returns no JSON at all: `context` asked for one `want` of `source` answers with
+raw C, which must not be wrapped in a JSON string, and so sets a text block
+alone.
+
+There is no `outputSchema` on any tool. The payloads are assembled as ad-hoc
+JSON rather than from Rust types, so there is nothing for rmcp to derive one
+from, and a hand-written schema that drifts from this page would be worse than
+none.
+
 ## What is not frozen
 
 - The contents of `reload`, `eva`, `wp`, and the entries of `eva_alarms` and

--- a/scripts/check-artifacts.sh
+++ b/scripts/check-artifacts.sh
@@ -21,6 +21,7 @@ roots = [
     Path("ast-utils"),
     Path("scripts"),
     Path(".github"),
+    Path(".ci"),
 ]
 skip_dirs = {".git", ".frama-c-mcp", "_build", "_opam", "target"}
 skip_files = {Path("scripts/check-artifacts.sh")}

--- a/scripts/run-gates.sh
+++ b/scripts/run-gates.sh
@@ -70,7 +70,7 @@ want() {
 
 # Unaligned on purpose. The columns used to line up, and that is exactly what
 # the shfmt gate below rejects, so this file failed the gate it exists to run.
-want shfmt && run shfmt bash -c "git ls-files '*.sh' '*.hook' | xargs shfmt -i 4 -d"
+want shfmt && run shfmt bash -c "git ls-files -z '*.sh' '*.hook' | xargs -0 shfmt -i 4 -d"
 want clippy && run clippy cargo clippy --all-targets
 want unit && run unit cargo test --test unit
 want release && run release cargo build --release --tests

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -146,12 +146,22 @@ async fn get_eva_callers(
     }
 }
 
-pub fn tool_result_json(result: &CallToolResult) -> serde_json::Value {
+pub fn tool_result_json(result: CallToolResult) -> serde_json::Value {
+    // structuredContent first, and moved rather than cloned: every caller owns
+    // the result and drops it on the next line. Every tool that returns JSON
+    // sets both halves from one value, so this is a shortcut and not a
+    // different answer. It matters for a result this server did not build,
+    // where reading only the text would report a structured-only result as
+    // empty.
+    if let Some(structured) = result.structured_content {
+        return structured;
+    }
+
     let text = result
         .content
         .iter()
-        .filter_map(|content| match &content.raw {
-            rmcp::model::RawContent::Text(text) => Some(text.text.as_str()),
+        .filter_map(|content| match content {
+            rmcp::model::ContentBlock::Text(text) => Some(text.text.as_str()),
             _ => None,
         })
         .collect::<Vec<_>>()
@@ -1690,27 +1700,56 @@ fn run_wp_target_scope(params: &RunWpParams) -> Result<RunWpScope, McpError> {
 
 /// Write inline C source to a temporary file for one check.
 ///
-/// The directory is per process and removed and recreated on each call, so a
-/// second check cannot analyze the previous one's leftovers, and a partial
-/// write cleans up after itself rather than leaving a file that parses to
-/// something the caller never sent.
-fn materialize_check_source(source: &str) -> Result<(Vec<String>, String), McpError> {
-    let dir = std::env::temp_dir().join(format!("frama-c-check-{}", std::process::id()));
-    if dir.exists() {
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-    std::fs::create_dir_all(&dir).map_err(|error| {
+/// Returns the guard as well as the paths, and the caller holds it for the rest
+/// of the run. That is what bounds the directory's life: it exists while
+/// Frama-C is reading it and is gone when the call that made it returns, so
+/// there is no leftover for a later check to analyze and nothing to clean up by
+/// hand.
+///
+/// An earlier version kept the newest directory in a process-global slot and
+/// deleted the previous one. That was the wrong owner twice over. The slot is
+/// per process while the reader is per server, and lib.rs and the test harness
+/// both build two servers in one process, so one server's check could delete
+/// the directory the other was still reading; and two concurrent checks on one
+/// server raced the same way, because the Frama-C client mutex is taken after
+/// this runs. Nothing has to arbitrate if the guard simply lives on the stack
+/// of the call that owns it.
+///
+/// The name is random rather than the process id. It used to be
+/// "frama-c-check-<pid>", which is fixed for the life of the server and
+/// guessable by anyone who can enumerate pids, in a world-writable directory.
+/// remove_dir_all refuses to descend a symlink so the delete was safe, but
+/// create_dir_all succeeds against a directory that already exists and
+/// fs::write follows a symlink at input.c, so a local attacker who won the
+/// window between the two got an arbitrary file overwrite as this user, and
+/// could retry it on every call because the path never moved. private_temp_dir
+/// creates with O_EXCL at a random name and mode 0700, which closes the class
+/// instead of narrowing the window.
+/// The prefix of the scratch directory a check writes inline source into.
+///
+/// Shared with receipt_source_path, which has to recognise the directory to
+/// keep it out of the receipt.
+pub const CHECK_SCRATCH_PREFIX: &str = "frama-c-check-";
+
+fn materialize_check_source(
+    source: &str,
+) -> Result<(Vec<String>, String, tempfile::TempDir), McpError> {
+    let dir = private_temp_dir("frama-c-check-").map_err(|error| {
         McpError::internal_error(
             format!("failed to create temporary C source directory: {error}"),
             None,
         )
     })?;
-    let path = dir.join("input.c");
+
+    let path = dir.path().join("input.c");
     std::fs::write(&path, source).map_err(|error| {
-        let _ = std::fs::remove_dir_all(&dir);
         McpError::internal_error(format!("failed to write temporary C source: {error}"), None)
     })?;
-    Ok((vec![path.display().to_string()], dir.display().to_string()))
+    Ok((
+        vec![path.display().to_string()],
+        dir.path().display().to_string(),
+        dir,
+    ))
 }
 
 /// The proofread report for a main-instance run: what the goals say, plus what
@@ -2033,7 +2072,7 @@ impl FramaCMcpServer {
 
         // Return the VO + scc_groups of server seed (the agent is no longer
         // built, and the results are read-only for display/reporting)
-        Ok(json_result(&serde_json::json!({
+        Ok(json_result(serde_json::json!({
             "verification_order": verification_order,
             "scc_groups": scc_groups,
         })))
@@ -2052,7 +2091,7 @@ impl FramaCMcpServer {
         let ready =
             crate::topo::compute_ready_functions(&vertices, &edges, &p.done, &p.in_progress);
 
-        Ok(json_result(&ready))
+        Ok(json_result(json!(ready)))
     }
 
     #[tool(
@@ -2086,12 +2125,34 @@ impl FramaCMcpServer {
         // E-ACSL instruments whatever paths it is handed, and these are the
         // paths the project was loaded from. Annotations injected this session
         // live in the AST only, so reaching them means printing the AST to a
-        // file first; no request instruments in place.
+        // file first; no request instruments in place. The printed AST outlives
+        // this call on purpose: it is reported as `instrumented` and callers
+        // read it back to see what E-ACSL was given, which is the only thing
+        // that still means anything where e-acsl-gcc cannot run. Parking the
+        // guard on the server keeps it alive and drops the previous one, so a
+        // session holds one of these rather than one per call.
+        //
+        // Held locally until the run below is over, and parked only after.
+        // Parking it before means a second concurrent run_e_acsl replaces the
+        // entry, drops this call's guard, and deletes the directory that
+        // e-acsl-gcc is compiling from; nothing serializes the two, since the
+        // Frama-C client lock is released before the wrapper is spawned.
+        //
+        // One slot, so the contract on the reported path is that it is readable
+        // until the next use_current_ast call, not forever. Two overlapping
+        // calls still end with one directory, and the caller that returned
+        // first can find its path gone. That is the contract this always had,
+        // when the path was one fixed name rewritten on every call, and it is
+        // strictly better now, since the file is no longer replaced underneath
+        // a reader by a run for a different session. Keeping every outstanding
+        // response's directory alive instead would be unbounded, and the path
+        // exists to be read back once, not held.
         let use_current_ast = params.use_current_ast.unwrap_or(false);
-        let files = if use_current_ast {
-            vec![self.write_current_ast_source().await?]
+        let (files, ast_dir_guard) = if use_current_ast {
+            let (path, guard) = self.write_current_ast_source().await?;
+            (vec![path], Some(guard))
         } else {
-            files
+            (files, None)
         };
 
         let mut result = run_e_acsl_counterexample(
@@ -2106,7 +2167,10 @@ impl FramaCMcpServer {
         .await;
         result["instrumented"] = json!(files);
         result["use_current_ast"] = json!(use_current_ast);
-        Ok(json_result(&result))
+        if let Some(guard) = ast_dir_guard {
+            *self.current_ast_dir.lock().await = Some(guard);
+        }
+        Ok(json_result(result))
     }
 
     /// Write the loaded AST, annotations and all, to a file E-ACSL can read.
@@ -2116,7 +2180,7 @@ impl FramaCMcpServer {
     /// serves, so
     /// its output is the whole project as one translation unit that round-trips
     /// through the C front end.
-    async fn write_current_ast_source(&self) -> Result<String, McpError> {
+    async fn write_current_ast_source(&self) -> Result<(String, tempfile::TempDir), McpError> {
         let client = self.require_client().await?;
         let printed = client
             .get("plugins.ast-utils.printSource", json!(""))
@@ -2130,19 +2194,24 @@ impl FramaCMcpServer {
             ));
         }
 
-        // One path per process, rewritten each call, so repeated runs do not
-        // leak a directory apiece. The caller reports it as `instrumented`, so
-        // it has to outlive the run.
-        let dir = std::env::temp_dir()
-            .join(format!("frama-c-mcp-e-acsl-ast-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).map_err(|error| {
-            McpError::internal_error(format!("failed to create {}: {error}", dir.display()), None)
+        // A random O_EXCL name, for the reason materialize_check_source gives
+        // at length. This site was the worse of the two: it created the
+        // directory and never removed it, so there was no race to win. An
+        // attacker planted a symlink at current-ast.c once and every later call
+        // wrote through it, and what lands here is then compiled and run by
+        // run_e_acsl.
+        //
+        // The guard is returned to the caller, which holds it for the whole run
+        // and only then parks it on the server, so the file outlives the run and
+        // the reported path stays readable.
+        let dir = private_temp_dir("frama-c-mcp-e-acsl-ast-").map_err(|error| {
+            McpError::internal_error(format!("failed to create a temp dir: {error}"), None)
         })?;
-        let path = dir.join("current-ast.c");
+        let path = dir.path().join("current-ast.c");
         std::fs::write(&path, source).map_err(|error| {
             McpError::internal_error(format!("failed to write {}: {error}", path.display()), None)
         })?;
-        Ok(path.display().to_string())
+        Ok((path.display().to_string(), dir))
     }
 
     /// The EVA half of one check: the run, then the alarms it left.
@@ -2176,7 +2245,7 @@ impl FramaCMcpServer {
         function: Option<&str>,
     ) -> (serde_json::Value, serde_json::Value) {
         let wp = match self.run_wp(Parameters(wp_params)).await {
-            Ok(result) => tool_result_json(&result),
+            Ok(result) => tool_result_json(result),
             Err(error) => check_step_error(&error),
         };
         let goals = match self.wp_goals_payload(function, None, None).await {
@@ -2273,9 +2342,17 @@ impl FramaCMcpServer {
     pub async fn check_payload(&self, params: CheckParams) -> Result<serde_json::Value, McpError> {
         let wanted = WantedAnalyses::from_want(params.want.as_deref());
 
+        // The guard goes on the server rather than on this stack frame. The
+        // reload below records these paths as the session's loaded files, and
+        // run_wp, run_e_acsl and the goal detail path all re-read that list from
+        // disk long after check has returned, so removing the directory here
+        // left the session pointing at a file that was gone. Parking it keeps
+        // one alive per session and replaces it when the next inline check
+        // loads a different one.
         let (files, temporary_source_dir) = match params.source {
             Some(source) => {
-                let (files, dir) = materialize_check_source(&source)?;
+                let (files, dir, guard) = materialize_check_source(&source)?;
+                *self.current_check_source_dir.lock().await = Some(guard);
                 (Some(files), Some(dir))
             }
             None => (params.files, None),
@@ -2294,7 +2371,7 @@ impl FramaCMcpServer {
             }))
             .await
         {
-            Ok(result) => tool_result_json(&result),
+            Ok(result) => tool_result_json(result),
             Err(error) => {
                 return Ok(self
                     .check_reload_failed_payload(
@@ -2480,7 +2557,7 @@ impl FramaCMcpServer {
         &self,
         Parameters(params): Parameters<CheckParams>,
     ) -> Result<CallToolResult, McpError> {
-        Ok(json_result(&self.check_payload(params).await?))
+        Ok(json_result(self.check_payload(params).await?))
     }
 
     async fn eva_alarms_payload(
@@ -2735,7 +2812,7 @@ impl FramaCMcpServer {
             .get("plugins.wp.getScheduledTasks", json!(null))
             .await
             .map_err(McpError::from)?;
-        Ok(json_result(&json!({
+        Ok(json_result(json!({
             "cancelled": true,
             "scheduled_tasks": tasks,
             "note": "WP's queue was emptied. Goals already proved keep their verdicts; \
@@ -3059,7 +3136,7 @@ impl FramaCMcpServer {
             report_function,
         )
         .await?;
-        Ok(json_result(&response))
+        Ok(json_result(response))
     }
 
     /// Prove the goals that timed out a second time, at double the timeout, so
@@ -3372,11 +3449,11 @@ impl FramaCMcpServer {
                 }
             };
             if single {
-                return Ok(json_result(&value));
+                return Ok(json_result(value));
             }
             result.insert(kind.name().to_string(), value);
         }
-        Ok(json_result(&serde_json::Value::Object(result)))
+        Ok(json_result(serde_json::Value::Object(result)))
     }
 
     /// The WP goal list, which is what this tool answered before it took a
@@ -3935,7 +4012,7 @@ impl FramaCMcpServer {
             (state.project_loaded, order_missing)
         };
         if !project_loaded {
-            return Ok(json_result(&json!({
+            return Ok(json_result(json!({
                 "status": "needs_project",
                 "project_locked": *self.project_locked.read().await,
                 "next_action": {
@@ -3950,7 +4027,7 @@ impl FramaCMcpServer {
 
         if order_missing {
             let _ = tool_result_json(
-                &self
+                self
                     .compute_topological_order(Parameters(ComputeTopologicalOrderParams {}))
                     .await?,
             );
@@ -4035,7 +4112,7 @@ impl FramaCMcpServer {
         };
 
         let ready_functions = tool_result_json(
-            &self
+            self
                 .get_ready_functions(Parameters(GetReadyFunctionsParams {
                     done: done.clone(),
                     in_progress: in_progress.clone(),
@@ -4144,7 +4221,7 @@ impl FramaCMcpServer {
             "project_state_persisted": project_state_persisted,
             "next_action": next_action,
         }));
-        Ok(json_result(&response))
+        Ok(json_result(response))
     }
 
     /// The three payloads that only a separate Frama-C process can produce.

--- a/src/mcp/annotations.rs
+++ b/src/mcp/annotations.rs
@@ -454,7 +454,7 @@ fn json_result_relabeled(
 ) -> CallToolResult {
     let mut value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
     relabel_origins(&mut value, origin);
-    json_result(&value)
+    json_result(value)
 }
 
 /// The clause arrays one injection call carries, borrowed for planning.
@@ -708,7 +708,7 @@ impl FramaCMcpServer {
         Parameters(params): Parameters<ProposeAnnotationsParams>,
     ) -> Result<CallToolResult, McpError> {
         Ok(json_result(
-            &self.propose_annotations_payload(&params.function).await?,
+            self.propose_annotations_payload(&params.function).await?,
         ))
     }
 
@@ -869,7 +869,7 @@ impl FramaCMcpServer {
                         std::fs::write(&target, &text).map_err(|e| {
                             McpError::internal_error(format!("write failed: {}", e), None)
                         })?;
-                        return Ok(json_result(&json!({
+                        return Ok(json_result(json!({
                             "written": target.display().to_string(),
                             "bytes": text.len(),
                         })));
@@ -879,7 +879,7 @@ impl FramaCMcpServer {
                     // every other one keeps. Wrapping C source in a JSON string
                     // hands every caller escapes instead of code.
                     if single {
-                        return Ok(CallToolResult::success(vec![Content::text(text)]));
+                        return Ok(CallToolResult::success(vec![ContentBlock::text(text)]));
                     }
                     json!(text)
                 }
@@ -918,11 +918,11 @@ impl FramaCMcpServer {
             };
 
             if single {
-                return Ok(json_result(&value));
+                return Ok(json_result(value));
             }
             result.insert(key.to_string(), value);
         }
-        Ok(json_result(&serde_json::Value::Object(result)))
+        Ok(json_result(serde_json::Value::Object(result)))
     }
 
     async fn rte_obligations_payload(&self, function: &str) -> Result<serde_json::Value, McpError> {
@@ -1309,7 +1309,7 @@ impl FramaCMcpServer {
         if let Some(obj) = result_obj.as_object_mut() {
             obj.insert("hash_label".to_string(), json!(hash_label.clone()));
         }
-        Ok((json_result(&result_obj), hash_label))
+        Ok((json_result(result_obj), hash_label))
     }
 
     async fn mark_sandbox_annotation_changed(&self, resolved: &ResolvedClient) {
@@ -1631,7 +1631,7 @@ impl FramaCMcpServer {
                     )
                     .await
                 {
-                    Ok(result) => add_result = json_result(&result),
+                    Ok(result) => add_result = json_result(result),
                     Err(e) => {
                         failures.push(InjectionFailure {
                             failure_type: FailureType::ProposedError,
@@ -1933,12 +1933,12 @@ impl FramaCMcpServer {
         let (ghost_results, ghost_failures) =
             self.apply_ghost_entries(&target, ghosts, dry_run).await;
         if !ghost_failures.is_empty() {
-            return Ok(json_result(&ghost_only_response(
+            return Ok(json_result(json!(ghost_only_response(
                 dry_run,
                 attempted,
                 ghost_results,
                 ghost_failures,
-            )));
+            ))));
         }
 
         self.inject_all_impl(target, params, &origin, equivalence_sandbox, ghost_results)

--- a/src/mcp/conclusions.rs
+++ b/src/mcp/conclusions.rs
@@ -81,14 +81,14 @@ impl FramaCMcpServer {
             // `durable` is separate from `stored` so a caller reading only the
             // success key cannot mistake an in-memory update for one that
             // reached disk.
-            return Ok(json_result(&json!({
+            return Ok(json_result(json!({
                 "stored": func_name,
                 "durable": false,
                 "persist_errors": persist_errors,
             })));
         }
 
-        Ok(json_result(&json!({"stored": func_name})))
+        Ok(json_result(json!({"stored": func_name})))
     }
 
     pub async fn conclusions_payload(

--- a/src/mcp/eacsl.rs
+++ b/src/mcp/eacsl.rs
@@ -278,23 +278,21 @@ pub async fn run_e_acsl_counterexample(
         Err(payload) => return payload,
     };
 
-    let unique = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    let out_dir = std::env::temp_dir().join(format!(
-        "frama-c-mcp-e-acsl-{}-{}",
-        std::process::id(),
-        unique
-    ));
-    if let Err(error) = std::fs::create_dir_all(&out_dir) {
-        return json!({
-            "status": "error",
-            "error": format!("create temp dir: {error}"),
-            "path": out_dir.display().to_string(),
-        });
-    }
-    let output_exec = out_dir.join("run");
+    // A random O_EXCL name at mode 0700 rather than pid plus a clock reading.
+    // What lands here is a compiled executable this function then runs, so the
+    // directory has to be one nobody else can write into, which is why the mode
+    // is asked for rather than left to the umask. The guard is bound for the
+    // whole call, which is also what removes it.
+    let out_dir = match private_temp_dir("frama-c-mcp-e-acsl-") {
+        Ok(dir) => dir,
+        Err(error) => {
+            return json!({
+                "status": "error",
+                "error": format!("create temp dir: {error}"),
+            });
+        }
+    };
+    let output_exec = out_dir.path().join("run");
     let instrumented_exec = PathBuf::from(format!("{}.e-acsl", output_exec.display()));
 
     let args = match compile_args(
@@ -305,16 +303,12 @@ pub async fn run_e_acsl_counterexample(
         &output_exec,
     ) {
         Ok(args) => args,
-        Err(payload) => {
-            let _ = std::fs::remove_dir_all(&out_dir);
-            return payload;
-        }
+        Err(payload) => return payload,
     };
 
     let timeout = Duration::from_secs(timeout_seconds.max(1));
     let compile_payload = compile_step(&tool, args, timeout).await;
     if compile_payload["status"] != "ok" {
-        let _ = std::fs::remove_dir_all(&out_dir);
         return json!({
             "status": "compile_error",
             "compile": compile_payload,
@@ -323,8 +317,10 @@ pub async fn run_e_acsl_counterexample(
         });
     }
 
+    // out_dir's guard is dropped when this function returns, on every path,
+    // which is what the three hand-written removes here used to do one exit at
+    // a time.
     let run_payload = run_step(&instrumented_exec, program_args, timeout).await;
-    let _ = std::fs::remove_dir_all(&out_dir);
 
     json!({
         "status": run_payload["status"].clone(),

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -98,7 +98,7 @@ impl FramaCMcpServer {
         if params.canary.unwrap_or(false) {
             result["canary"] = self.canary_payload().await;
         }
-        Ok(json_result(&result))
+        Ok(json_result(result))
     }
 
     #[tool(
@@ -220,7 +220,7 @@ impl FramaCMcpServer {
             "messages": messages,
             "messages_truncated": truncated,
         });
-        Ok(json_result(&result))
+        Ok(json_result(result))
     }
 
     /// Declaration of one function. Sandbox instances keep no function cache,
@@ -532,7 +532,7 @@ impl FramaCMcpServer {
             ListKind::Sandboxes => self.sandbox_list_payload().await?,
             ListKind::Conclusions => self.conclusions_payload(params.status, params.function).await?,
         };
-        Ok(json_result(&result))
+        Ok(json_result(result))
     }
 }
 

--- a/src/mcp/propose.rs
+++ b/src/mcp/propose.rs
@@ -313,7 +313,7 @@ impl FramaCMcpServer {
             }))
             .await
             .ok()?;
-        let payload = tool_result_json(&result);
+        let payload = tool_result_json(result);
         let clauses = payload.get("clauses")?.as_array()?.clone();
 
         // Paired on the clause text, not on position. The planner emits by

--- a/src/mcp/receipt.rs
+++ b/src/mcp/receipt.rs
@@ -9,12 +9,33 @@
 //! are comparable exactly when their hashes match.
 
 use super::*;
+use crate::state::sha256_hex;
+
+/// What a receipt calls a source file.
+///
+/// Its own path, except for the scratch copy of an inline `source`, which is
+/// recorded as its bare name. The directory that holds it is chosen fresh on
+/// every call and is not part of what was proved, so digesting it would make
+/// two runs of the same source incomparable, and comparing two runs is the only
+/// thing a receipt is for. The old pid-shaped directory hid this by being
+/// constant within a session; a random name does not, which is what surfaced
+/// it. The content hash beside this is what tells two different sources apart.
+pub fn receipt_source_path(file: &str) -> String {
+    let path = std::path::Path::new(file);
+    let in_scratch = path.parent().and_then(|dir| dir.file_name()).is_some_and(|dir| {
+        dir.to_string_lossy().starts_with(super::analysis::CHECK_SCRATCH_PREFIX)
+    });
+    match path.file_name().filter(|_| in_scratch) {
+        Some(name) => name.to_string_lossy().into_owned(),
+        None => file.to_string(),
+    }
+}
 
 fn proof_receipt_source_files(files: &[String]) -> Vec<serde_json::Value> {
     let mut entries = files
         .iter()
         .map(|file| {
-            let path = file.to_string();
+            let path = receipt_source_path(file);
             match std::fs::read(file) {
                 Ok(bytes) => json!({
                     "path": path,

--- a/src/mcp/sandbox.rs
+++ b/src/mcp/sandbox.rs
@@ -286,7 +286,7 @@ impl FramaCMcpServer {
             }
         }
 
-        Ok(json_result(&json!({
+        Ok(json_result(json!({
             "sandbox_name": sandbox_name,
             "experiment_id": experiment_id,
             "ast_stmt_count": ast_stmt_count,
@@ -335,9 +335,7 @@ impl FramaCMcpServer {
             self.mark_sandbox_deleted(&func).await;
         }
 
-        Ok(CallToolResult::success(vec![Content::text(
-            json!({"success": true}).to_string(),
-        )]))
+        Ok(json_result(json!({"success": true})))
     }
 
 }

--- a/src/mcp/sandbox.rs
+++ b/src/mcp/sandbox.rs
@@ -185,6 +185,12 @@ impl FramaCMcpServer {
                 );
             }
         }
+        // The root first, and checked, because create_dir_all would otherwise
+        // make it as a side effect with whatever the umask says, which is the
+        // 0755 the check below exists to refuse. What lands in here is the C the
+        // analysis reads and the socket this server then trusts.
+        crate::mcp::store::ensure_private_root()
+            .map_err(|e| McpError::internal_error(format!("scratch root unusable: {e}"), None))?;
         std::fs::create_dir_all(&sandbox_dir)
             .map_err(|e| McpError::internal_error(format!("mkdir failed: {}", e), None))?;
         let sandbox_file = sandbox_dir.join("sandbox.c");

--- a/src/mcp/selfcheck.rs
+++ b/src/mcp/selfcheck.rs
@@ -627,14 +627,24 @@ impl FramaCMcpServer {
             }
         }
 
-        // /tmp with a short name, not `std::env::temp_dir()`: a Unix socket
-        // path is capped near 104 bytes, and on macOS `temp_dir()` is
-        // `/var/folders/<32>/<8>/T/`, half the budget before this directory is
-        // even named. The probe server died with ENAMETOOLONG, so every request
-        // came back `not_probed` and self_check looked clean having checked
-        // nothing. /tmp is where the main server already puts its socket.
-        let base = PathBuf::from(format!(
-            "/tmp/frama-c-mcp-selfcheck-{}-{}",
+        // Under the private root, which is in /tmp and short for the reason
+        // that matters here: a Unix socket path is capped near 104 bytes, and on
+        // macOS `temp_dir()` is `/var/folders/<32>/<8>/T/`, half the budget
+        // before this directory is even named. The probe server died with
+        // ENAMETOOLONG, so every request came back `not_probed` and self_check
+        // looked clean having checked nothing. The root is shorter than the
+        // name this used to build, so the budget improved.
+        let root = match crate::mcp::store::ensure_private_root() {
+            Ok(root) => root,
+            Err(error) => {
+                return json!({
+                    "status": "error",
+                    "reason": format!("scratch root unusable: {error}"),
+                });
+            }
+        };
+        let base = root.join(format!(
+            "sc-{}-{}",
             std::process::id(),
             SELF_CHECK_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2981,9 +2981,16 @@ impl FramaCMcpServer {
         // previous owner died without running Drop.
         let _ = std::fs::remove_file(&socket_path);
 
-        //Log path
-        let log_dir = std::path::Path::new("/tmp/frama-c-mcp-logs");
-        let _ = std::fs::create_dir_all(log_dir);
+        // Logs, under the private root rather than at a fixed shared name. The
+        // old path was /tmp/frama-c-mcp-logs, which anybody could create first,
+        // and the error from creating it was dropped, so a directory they owned
+        // was used as found and File::create followed a symlink planted at the
+        // log name. The error is reported now: no logs is a startup problem
+        // worth hearing about, since the startup failure tail is read from them.
+        let log_dir = crate::mcp::store::ensure_private_root()
+            .map(|root| root.join("logs"))
+            .and_then(|dir| std::fs::create_dir_all(&dir).map(|()| dir))
+            .map_err(|e| McpError::internal_error(format!("create log directory: {e}"), None))?;
         let log_basename = format!("main-{}", std::process::id());
         let stdout_log_path = log_dir.join(format!("{}.stdout.log", log_basename));
         let stdout_log = std::fs::File::create(&stdout_log_path)

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,7 +6,7 @@ use tokio::sync::{Mutex as AsyncMutex, RwLock};
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Content, ProtocolVersion, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, ContentBlock, ProtocolVersion, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler};
 use serde_json::json;
 
@@ -1165,6 +1165,44 @@ pub fn sandbox_not_found_err(experiment_id: &str, existing: &[String]) -> McpErr
 
 pub const MCP_TOOL_COUNT: usize = 14;
 
+/// The revision a client gets when it asks for one rmcp does not recognize.
+///
+/// Named once and read by both get_info and self_check. It was spelled at both
+/// sites independently, under a comment claiming it was not.
+pub const FALLBACK_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V_2024_11_05;
+
+/// The protocol revisions this server will agree to.
+///
+/// rmcp's default is ProtocolVersion::KNOWN_VERSIONS, which includes
+/// 2026-07-28. That revision is deliberately absent: it turns on SEP-2322,
+/// which adds a resultType field to every tool result, and the SEP-2164
+/// error-code remap, and neither has been exercised against this server's
+/// fourteen tools or the frozen result schema. Accepting a revision whose wire
+/// behavior nobody has looked at is a claim this repository cannot back, so a
+/// client asking for it negotiates down to the get_info fallback rather than
+/// getting untested semantics. Adding it back is a deliberate change with
+/// tests behind it, not a dependency bump.
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
+    ProtocolVersion::V_2024_11_05,
+    ProtocolVersion::V_2025_03_26,
+    ProtocolVersion::V_2025_06_18,
+    ProtocolVersion::V_2025_11_25,
+];
+
+/// Revisions rmcp knows and this server declines, with the reason attached.
+///
+/// Spelled as an exclusion rather than left implicit in what the list above
+/// omits, so supported_protocol_versions_cover_every_known_revision can check
+/// the two against rmcp's own set. Cargo.toml asks for rmcp "3", so a cargo
+/// update can add a revision with no diff here; without that test a new one
+/// would be declined silently and clients would negotiate down without anyone
+/// deciding to.
+pub const EXCLUDED_PROTOCOL_VERSIONS: &[(ProtocolVersion, &str)] = &[(
+    ProtocolVersion::V_2026_07_28,
+    "SEP-2322 adds resultType to every tool result and SEP-2164 remaps error \
+     codes; neither is exercised against the fourteen tools or the result schema",
+)];
+
 fn default_wp_provers() -> String {
     let mut provers = vec!["Alt-Ergo"];
     if executable_in_path("cvc5") {
@@ -1850,6 +1888,38 @@ pub struct FramaCMcpServer {
     max_sandboxes: usize,
     /// Path to frama-c binary (for spawning sandbox instances + main)
     frama_c_path: String,
+    /// The directory holding the AST printed for the most recent run_e_acsl
+    /// with use_current_ast.
+    ///
+    /// Held rather than dropped at the end of the call because the path is
+    /// reported as `instrumented` and callers read the file afterwards to see
+    /// what was handed to E-ACSL;
+    /// run_e_acsl_can_instrument_injected_annotations
+    /// is built on exactly that, since it is how the test stays meaningful on a
+    /// platform where e-acsl-gcc itself cannot run. Replacing the entry drops
+    /// the previous directory, so a session keeps one rather than one per call.
+    ///
+    /// Per server rather than per process: the old fixed path meant two servers
+    /// in one process, which lib.rs and the test harness both build, wrote over
+    /// each other's file.
+    ///
+    /// Outside the lock sequence above, and allowed to be: it is taken for a
+    /// single assignment and never held while acquiring another, so it cannot
+    /// take part in a cycle. Anything that later reads it for longer than that
+    /// has to be placed in the ordering first.
+    current_ast_dir: Arc<AsyncMutex<Option<tempfile::TempDir>>>,
+    /// The directory holding the inline source the loaded project was built
+    /// from, when `check` was given `source` rather than `files`.
+    ///
+    /// Tied to the session and not to the call. reload_project records the
+    /// paths it loaded in MainFramaCState::files, and run_wp, run_e_acsl and
+    /// the WP goal detail path all re-read that list from disk afterwards, so a
+    /// scratch directory dropped when check returned left the session pointing
+    /// at a file that no longer existed. check recommends those very calls as
+    /// the next step, so the broken sequence is the documented one. Replaced by
+    /// the next inline-source check, which is also when the session stops
+    /// referring to the old one.
+    current_check_source_dir: Arc<AsyncMutex<Option<tempfile::TempDir>>>,
     /// Main Frama-C process state (child + socket + files + rte).
     /// Replaces the old `main_frama_c_child: Option<Child>` - multiple
     /// sockets/files/rte to support
@@ -1910,10 +1980,64 @@ fn scope_for_function(function: &str) -> FunctionScope<'_> {
     }
 }
 
-fn json_result(value: &impl serde::Serialize) -> CallToolResult {
-    CallToolResult::success(vec![Content::text(
-        serde_json::to_string_pretty(value).unwrap_or_default(),
-    )])
+/// The one way a tool returns JSON.
+///
+/// Both halves when the payload is a JSON object. structuredContent is what a
+/// 2025-06-18 or later client should read, and it saves every caller a parse of
+/// a document that was serialized only to be turned back into one.
+///
+/// An object, and only an object. The schema types structuredContent as a JSON
+/// object, and a client that validates the result against that schema rejects
+/// the whole response rather than the one field: the TypeScript SDK parses it
+/// as an object with unknown keys, which an array fails. Five of the six kinds
+/// "list" answers are arrays, so setting it unconditionally broke that tool
+/// outright for any client on 2025-06-18 or later. A non-object payload keeps
+/// the text block alone, which is what every client understood before this
+/// field existed.
+///
+/// The text block stays, and stays pretty-printed. Clients below 2025-06-18 see
+/// only content, docs/reference/result-schema.md is written against that text,
+/// and this server's own readers parse it: see tool_result_json and the stdio
+/// tests. CallToolResult::structured is not used for the same reason, since it
+/// writes the compact form into content.
+///
+/// Takes the value rather than borrowing it. Every caller owns a Value and
+/// drops it on the next line, so borrowing meant serializing the document
+/// twice,
+/// once to text and once back into a Value that was a deep copy of the tree the
+/// caller was about to discard. On a check with detail "full" that copy is
+/// around 21,000 nodes.
+fn json_result(value: serde_json::Value) -> CallToolResult {
+    let mut result = CallToolResult::success(vec![ContentBlock::text(
+        serde_json::to_string_pretty(&value).unwrap_or_default(),
+    )]);
+    if value.is_object() {
+        result.structured_content = Some(value);
+    }
+    result
+}
+
+/// A temporary directory only this user can enter, removed when the guard drops.
+///
+/// tempfile picks the random O_EXCL name, which is what closes the pre-created
+/// symlink class. It does not pick the mode: Builder::tempdir creates the
+/// directory with the process default, so under the usual umask of 022 it is
+/// 0755 and under a permissive one it is group or world writable. That matters
+/// most where the directory holds a compiled executable this server then runs,
+/// so the mode is asked for here rather than assumed.
+#[cfg(unix)]
+fn private_temp_dir(prefix: &str) -> std::io::Result<tempfile::TempDir> {
+    use std::os::unix::fs::PermissionsExt;
+
+    tempfile::Builder::new()
+        .prefix(prefix)
+        .permissions(std::fs::Permissions::from_mode(0o700))
+        .tempdir()
+}
+
+#[cfg(not(unix))]
+fn private_temp_dir(prefix: &str) -> std::io::Result<tempfile::TempDir> {
+    tempfile::Builder::new().prefix(prefix).tempdir()
 }
 
 async fn reload_fetch(
@@ -2389,6 +2513,8 @@ impl FramaCMcpServer {
             sandboxes: Arc::new(RwLock::new(SandboxRegistry::default())),
             max_sandboxes,
             frama_c_path,
+            current_ast_dir: Arc::new(AsyncMutex::new(None)),
+            current_check_source_dir: Arc::new(AsyncMutex::new(None)),
             main_frama_c_state: Arc::new(AsyncMutex::new(None)),
             main_spawn_lock: Arc::new(AsyncMutex::new(())),
             project_locked: Arc::new(RwLock::new(false)),
@@ -2605,7 +2731,7 @@ impl FramaCMcpServer {
             report_function,
         )
         .await?;
-        Ok(json_result(&response))
+        Ok(json_result(response))
     }
 
     /// Kill a sandbox Frama-C process and clean up state.
@@ -3336,7 +3462,15 @@ impl FramaCMcpServer {
             "server": {
                 "version": env!("CARGO_PKG_VERSION"),
                 "tool_count": MCP_TOOL_COUNT,
-                "protocol_version": "2024-11-05",
+
+                // The fallback, not the negotiated version of any one session:
+                // this payload is built without a peer, and a client that asked
+                // for a later revision got that one on the wire. The list of
+                // revisions this server agrees to is beside it so the two
+                // cannot drift. ProtocolVersion serializes as its bare string,
+                // so neither needs converting here.
+                "protocol_version": FALLBACK_PROTOCOL_VERSION,
+                "supported_protocol_versions": SUPPORTED_PROTOCOL_VERSIONS,
             },
             "processes": self_check["processes"].clone(),
             "frama_c": self_check["frama_c"].clone(),
@@ -3797,19 +3931,72 @@ fn parse_conclusion_status(s: &str) -> Result<crate::state::VerificationStatus, 
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for FramaCMcpServer {
+    /// Route the call, then take structuredContent back off it for a peer whose
+    /// protocol revision predates the field.
+    ///
+    /// structuredContent arrived in 2025-06-18. This server also agrees to
+    /// 2024-11-05 and 2025-03-26, and json_result fills the field for every tool
+    /// that answers with an object, so those peers were being sent a key their
+    /// revision does not define. Most clients ignore what they do not know; one
+    /// that validates its input is entitled not to.
+    ///
+    /// Done here rather than at the twenty-seven call sites because this is the
+    /// one place a response leaves the server, and because the negotiated
+    /// version is only knowable here: it is a property of the peer, not of the
+    /// payload. It is also what rmcp does one revision later, stripping
+    /// resultType for peers below 2026-07-28.
+    ///
+    /// tool_handler generates this method only when the impl does not already
+    /// define it, so writing it here replaces the generated one and the routing
+    /// line below is the body it would have had.
+    async fn call_tool(
+        &self,
+        request: rmcp::model::CallToolRequestParams,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<rmcp::model::CallToolResponse, McpError> {
+        // Read before the context moves into the call. An absent version is a
+        // peer that never completed a handshake this server saw, so treat it as
+        // the oldest thing it agrees to rather than assuming the newest.
+        let structured_is_known = context
+            .protocol_version()
+            .is_some_and(|version| version.as_str() >= ProtocolVersion::V_2025_06_18.as_str());
+
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        let mut response = self.tool_router.call(tcc).await?;
+
+        if !structured_is_known {
+            if let rmcp::model::CallToolResponse::Complete(result) = &mut response {
+                // The text block carries the same document, so nothing is lost:
+                // docs/reference/result-schema.md is written against it and it
+                // is what these revisions have always read.
+                result.structured_content = None;
+            }
+        }
+        Ok(response)
+    }
+
     fn get_info(&self) -> ServerInfo {
-        // ServerInfo (alias for InitializeResult) is #[non_exhaustive] in rmcp
-        // 1.x; can't use struct literal, go via ::new plus with_* builder.
+        // ServerInfo (alias for InitializeResult) is #[non_exhaustive], so this
+        // goes via ::new plus with_* builders rather than a struct literal.
         //
-        // Pin protocol_version to 2024-11-05: rmcp 1.x default is LATEST
-        // (2025-11-25) which exceeds Claude Code 2.1.146's known set; pin to
-        // the oldest broadly-supported version as defensive hardening (mirrors
-        // fv-core-mcp).
+        // with_protocol_version sets the FALLBACK, not a pin. rmcp's
+        // negotiate_protocol_version echoes whatever the client asked for
+        // whenever supported_protocol_versions contains it, and only reaches
+        // for this value when the requested string is one it does not know. The
+        // comment here used to call it a pin and credit rmcp 1.x with a LATEST
+        // default it would be holding back; neither was ever true, in 1.x or in
+        // 3.x, so anything reasoned from it was wrong. The revisions this
+        // server will actually agree to are below, in
+        // supported_protocol_versions.
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(
                 "Frama-C formal verification server. Provides EVA abstract interpretation, \
                  WP deductive verification, and CIL AST navigation."
             )
-            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_protocol_version(FALLBACK_PROTOCOL_VERSION)
+    }
+
+    fn supported_protocol_versions(&self) -> std::borrow::Cow<'static, [ProtocolVersion]> {
+        std::borrow::Cow::Borrowed(SUPPORTED_PROTOCOL_VERSIONS)
     }
 }

--- a/src/mcp/store.rs
+++ b/src/mcp/store.rs
@@ -295,7 +295,109 @@ pub fn expected_sandbox_dir(base_dir: &Path, experiment_id: &str) -> PathBuf {
         .components()
         .collect();
     let owner = &sha256_hex(absolute.to_string_lossy().as_bytes())[..8];
-    PathBuf::from(format!("/tmp/frama-c-sandbox-{owner}-{experiment_id}"))
+    private_root_path().join(format!("sb-{owner}-{experiment_id}"))
+}
+
+/// The directory this server keeps its scratch state in, named but not created.
+///
+/// Under /tmp rather than the state directory, and short, because a Unix socket
+/// path is capped near 104 bytes and the sandbox sockets live below this. It is
+/// per user id so two people on one machine do not meet in it, and it is the
+/// only thing here that has to be private: the names underneath stay
+/// deterministic, since a sandbox left by an earlier server is found by
+/// recomputing its path, and a name nobody can enter does not need to be
+/// unguessable as well.
+///
+/// Pure, so expected_sandbox_dir stays a path calculation that cannot fail.
+/// ensure_private_root is what creates and checks it.
+pub fn private_root_path() -> PathBuf {
+    #[cfg(unix)]
+    let user = {
+        // SAFETY: getuid is always successful and touches no memory.
+        unsafe { libc::getuid() }
+    };
+    #[cfg(not(unix))]
+    let user = 0;
+    PathBuf::from(format!("/tmp/fcmcp-{user}"))
+}
+
+/// The scratch root, created 0700 and confirmed to be ours.
+///
+/// Everything this server writes under /tmp goes inside here: the Frama-C logs,
+/// the sandbox directories with their sources and sockets, and the self-check
+/// probes. /tmp is world writable, so any of those at a name someone else can
+/// guess is a directory they can pre-create and fill with symlinks, and the
+/// files landing in them are a compiled executable this server runs, the C the
+/// analysis reads, and a socket it trusts. One private parent closes that for
+/// all of them at once, and keeps closing it for whatever is added next.
+///
+/// Refuses rather than repairs when the directory exists and is not right. A
+/// root owned by someone else, or one they can write into, is either an attack
+/// or a genuinely confusing machine, and quietly chmod-ing somebody else's
+/// directory is not this program's business. lstat, not stat, so a symlink at
+/// the root is seen rather than followed.
+pub fn ensure_private_root() -> std::io::Result<PathBuf> {
+    let root = private_root_path();
+    ensure_private_dir(&root)?;
+    Ok(root)
+}
+
+/// ensure_private_root's rule, against a caller-named directory.
+///
+/// Split out to be testable: the real root is one fixed path per user, so a
+/// test that chmods it to see the refusal would be changing the directory every
+/// other test in the run is using.
+pub fn ensure_private_dir(dir: &Path) -> std::io::Result<()> {
+    #[cfg(not(unix))]
+    {
+        return std::fs::create_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+
+        // lstat, not stat, so a symlink here is seen rather than followed.
+        match std::fs::symlink_metadata(dir) {
+            Ok(found) => {
+                let refuse = |why: &str| {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        format!("{} {why}", dir.display()),
+                    ))
+                };
+                if found.file_type().is_symlink() {
+                    return refuse("is a symlink, so it names someone else's directory");
+                }
+                if !found.is_dir() {
+                    return refuse("exists and is not a directory");
+                }
+                // SAFETY: geteuid is always successful and touches no memory.
+                if found.uid() != unsafe { libc::geteuid() } {
+                    return refuse("is owned by another user");
+                }
+                if found.permissions().mode() & 0o077 != 0 {
+                    return refuse("is readable or writable by others");
+                }
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                // create() rather than create_dir_all: the mode applies to the
+                // leaf this makes and not to anything above it, and a parent
+                // made as a side effect would get the umask instead. Losing the
+                // race to another process of ours is fine, since the retry
+                // re-checks whatever landed.
+                match std::fs::DirBuilder::new().mode(0o700).create(dir) {
+                    Ok(()) => Ok(()),
+                    Err(again) if again.kind() == std::io::ErrorKind::AlreadyExists => {
+                        ensure_private_dir(dir)
+                    }
+                    Err(again) => Err(again),
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
 }
 
 pub fn has_expected_sandbox_paths(base_dir: &Path, sandbox: &SandboxMetadata) -> bool {

--- a/src/mcp/store.rs
+++ b/src/mcp/store.rs
@@ -9,10 +9,11 @@ use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 
 use rmcp::ErrorData as McpError;
-use sha2::{Digest, Sha256};
 use serde_json::json;
 
-use crate::state::{FunctionVerificationState, ProjectVerificationState, SandboxMetadata};
+use crate::state::{
+    sha256_hex, FunctionVerificationState, ProjectVerificationState, SandboxMetadata,
+};
 
 /// Long-text conclusion fields, paired with what a missing .md file reads back
 /// as. These live in <conclusion_dir>/<field>.md instead of meta.json, because
@@ -391,8 +392,4 @@ pub fn load_conclusions_from_disk(base_dir: &Path) -> HashMap<String, FunctionVe
         }
     }
     out
-}
-
-pub fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
 }

--- a/src/mcp/wpclass.rs
+++ b/src/mcp/wpclass.rs
@@ -1,5 +1,6 @@
 use serde_json::json;
-use sha2::{Digest, Sha256};
+
+use crate::state::sha256_hex;
 
 pub fn classify_wp_goal(goal: &serde_json::Value) -> (String, Option<String>) {
     use std::sync::OnceLock;
@@ -903,11 +904,10 @@ fn stable_goal_id_for(
         "name": stable_goal_name_key(goal),
         "part": stable_goal_part_key(goal),
     });
-    let digest = Sha256::digest(payload.to_string().as_bytes());
-    format!(
-        "sg_{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        digest[0], digest[1], digest[2], digest[3], digest[4], digest[5], digest[6], digest[7]
-    )
+
+    // Sixteen characters, which is the first eight bytes: the same id the
+    // eight-way format string produced before this shared a helper.
+    format!("sg_{}", &sha256_hex(payload.to_string().as_bytes())[..16])
 }
 
 /// Whether WP replayed this goal's verdict from its cache instead of proving

--- a/src/mcp/wpcli.rs
+++ b/src/mcp/wpcli.rs
@@ -208,7 +208,7 @@ impl FramaCMcpServer {
             })
             .await;
         response["proof_receipt"] = receipt;
-        Ok(json_result(&response))
+        Ok(json_result(response))
     }
 }
 
@@ -290,17 +290,26 @@ pub async fn run_why3_dump(
             "reason": "no source files available",
         });
     }
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    let out_dir = std::env::temp_dir().join(format!(
-        "frama-c-why3-dump-{}-{}-{}",
-        std::process::id(),
-        function.replace(':', "-"),
-        nonce
-    ));
-    let _ = std::fs::create_dir_all(&out_dir);
+
+    // A random O_EXCL name, and a guard that removes it when this call returns.
+    // The old spelling was pid plus a clock reading and was never removed at
+    // all, so every why3 dump leaked a directory for the life of the machine.
+    //
+    // The dump contents come back inside the payload, so wp_out below names a
+    // directory that no longer exists by the time a caller reads it: it is
+    // there to say which -wp-out the run used, not as somewhere to go looking.
+    // The one thing this gives up is a file over the size cap, which reports
+    // "truncated": true with no content and was previously still on disk
+    // because nothing cleaned it up. That was a leak rather than a promise.
+    let Ok(out_dir_guard) =
+        private_temp_dir(&format!("frama-c-why3-dump-{}-", function.replace(':', "-")))
+    else {
+        return json!({
+            "status": "error",
+            "reason": "could not create a temporary directory for the why3 dump",
+        });
+    };
+    let out_dir = out_dir_guard.path().to_path_buf();
 
     let mut args = project_cli_args(project_options);
     args.extend(files.iter().cloned());

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,32 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+/// A SHA-256 digest as lower case hex, two digits per byte, no separator.
+///
+/// Spelled out rather than reached through "{:x}", because sha2 0.11 returns an
+/// Array where 0.10 returned a GenericArray and only the latter implemented
+/// LowerHex. The output has to stay exactly what the old formatter produced.
+/// Every proof receipt and stored conclusion on disk carries a hash written by
+/// the old code, and a receipt is the whole basis on which two runs are called
+/// comparable, so a different spelling would not fail, it would quietly stop
+/// matching. sha256_hex_is_lowercase_unseparated pins that.
+///
+/// One home, because there were three: this, a hand-rolled write! loop, and an
+/// eight-way {:02x} format string in wpclass for the first eight bytes.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+
+    // One buffer, sized up front. The map-and-collect spelling allocates a
+    // String per byte, 33 allocations against this one, and wpclass hashes once
+    // per WP goal.
+    let mut out = String::with_capacity(64);
+    for byte in Sha256::digest(bytes) {
+        // Writing to a String cannot fail; the Result exists for the trait.
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
 /// Serializable metadata for a sandbox Frama-C instance.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxMetadata {
@@ -869,7 +895,7 @@ impl SessionState {
 
     fn specs_hash(specs: &[AnnotationEntry]) -> String {
         let bytes = serde_json::to_vec(specs).unwrap_or_default();
-        format!("{:x}", Sha256::digest(&bytes))
+        sha256_hex(&bytes)
     }
 
     fn proof_environment_hash(receipt: &serde_json::Value) -> String {
@@ -877,7 +903,7 @@ impl SessionState {
             .get("environment")
             .and_then(|environment| serde_json::to_vec(environment).ok())
             .unwrap_or_default();
-        format!("{:x}", Sha256::digest(&bytes))
+        sha256_hex(&bytes)
     }
 
     // sandbox lifecycle side effects (§13.6 changed 5/15)

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -62,6 +62,20 @@ impl McpHandle {
         Self::spawn_with_binary_frama_c_and_dir(release_binary(), &frama_c, Some(cwd))
     }
 
+    /// Spawn and hand-shake at a named protocol revision.
+    ///
+    /// Separate from spawn() because the handshake happens during spawn, and
+    /// re-initializing an already-initialized session is not the same thing.
+    pub fn spawn_test_binary_speaking(frama_c: &str, protocol_version: &str) -> Self {
+        let mut handle = Self::spawn_uninitialized(
+            PathBuf::from(env!("CARGO_BIN_EXE_frama-c-mcp")),
+            frama_c,
+            None,
+        );
+        handle.initialize_with_protocol(protocol_version);
+        handle
+    }
+
     pub fn spawn_test_binary_with_frama_c(frama_c: &str) -> Self {
         Self::spawn_with_binary_and_frama_c(
             PathBuf::from(env!("CARGO_BIN_EXE_frama-c-mcp")),
@@ -125,8 +139,52 @@ impl McpHandle {
         handle
     }
 
+    /// The process, started but not yet hand-shaken.
+    fn spawn_uninitialized(binary: PathBuf, frama_c: &str, cwd: Option<&Path>) -> Self {
+        assert!(
+            binary.exists(),
+            "MCP binary missing: {}\nRun `cargo build --release` first.",
+            binary.display()
+        );
+
+        let mut cmd = StdCommand::new(&binary);
+        cmd.arg("--frama-c")
+            .arg(frama_c)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        match cwd {
+            Some(cwd) => {
+                cmd.current_dir(cwd);
+            }
+            None => {
+                cmd.env("FRAMA_C_MCP_STATE_DIR", suite_state_dir());
+            }
+        }
+        let mut child = cmd.spawn().expect("spawn MCP server");
+        let pid = child.id();
+        let stdin = Some(child.stdin.take().unwrap());
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        Self {
+            child,
+            stdin,
+            stdout,
+            pid,
+            last_response_bytes: 0,
+        }
+    }
+
     fn initialize(&mut self) {
-        let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"stdio-test","version":"0"}}}"#;
+        self.initialize_with_protocol("2024-11-05");
+    }
+
+    /// Hand-shake naming a protocol revision, for the tests that care which one
+    /// was negotiated rather than only that a session exists.
+    pub fn initialize_with_protocol(&mut self, protocol_version: &str) {
+        let init = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"{protocol_version}","capabilities":{{}},"clientInfo":{{"name":"stdio-test","version":"0"}}}}}}"#
+        );
+        let init = init.as_str();
         let notify = r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#;
         let stdin = self.stdin.as_mut().expect("stdin");
         writeln!(stdin, "{}", init).unwrap();

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -34,7 +34,7 @@ mod harness;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, RawContent};
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock};
 use rmcp::service::ServiceExt;
 use rmcp::transport::TokioChildProcess;
 use serde_json::{json, Value};
@@ -352,8 +352,8 @@ async fn print_source(
 fn payload_text(r: &CallToolResult) -> String {
     r.content
         .iter()
-        .filter_map(|c| match &c.raw {
-            RawContent::Text(t) => Some(t.text.clone()),
+        .filter_map(|c| match c {
+            ContentBlock::Text(t) => Some(t.text.clone()),
             _ => None,
         })
         .collect::<Vec<_>>()
@@ -7988,6 +7988,64 @@ async fn unconstrained_assigns_compares_the_written_field_not_the_object() {
     assert!(
         !unconstrained.iter().any(|target| target.contains("off")),
         "the constrained field must not be reported: {checked:?}"
+    );
+
+    let _ = client.cancel().await;
+}
+
+/// A call after an inline-source check still finds the source it loaded.
+///
+/// `check {source: ...}` writes the program to a scratch directory and loads it,
+/// so the session's file list names a path under that directory, and run_wp,
+/// run_e_acsl and the WP goal detail path all re-read that list from disk. When
+/// the scratch directory was removed as `check` returned, every one of those
+/// answered against a file that no longer existed, and `check` recommends them
+/// as the next call, so the broken sequence was the documented one.
+///
+/// The whole suite stayed green through that, because no test called anything
+/// after an inline check. This is that test.
+#[tokio::test]
+async fn work_after_an_inline_source_check_still_finds_the_source() {
+    let client = spawn_mcp_client_in_dir("", None).await;
+
+    let checked = call_tool_json(&client, "check", json!({
+        "source": "int id(int x) { return x; }\nint main(void) { return id(0); }",
+        "function": "id",
+        "timeout": 1,
+    }))
+    .await
+    .unwrap();
+    let loaded = checked["temporary_source_dir"].as_str().expect("temp dir").to_string();
+
+    // The path the session is holding, still readable after the call that made
+    // it has returned. Asserted directly as well as through a tool, so a
+    // failure says which of the two broke.
+    let source_path = std::path::Path::new(&loaded).join("input.c");
+    assert!(
+        source_path.exists(),
+        "the loaded source went away when check returned: {}",
+        source_path.display()
+    );
+
+    // And through a tool that re-reads the session's file list from disk, which
+    // is the way a caller would actually meet this.
+    let goals = call_tool_json(&client, "get_wp_goals", json!({"want": ["counts"]}))
+        .await
+        .unwrap();
+    assert!(
+        goals["total_properties"].as_u64().is_some(),
+        "get_wp_goals after an inline check: {:?}",
+        goals
+    );
+    assert_eq!(goals["session"]["project_loaded"], true, "{:?}", goals);
+
+    let rerun = call_tool_json(&client, "run_wp", json!({"function": "id", "timeout": 1}))
+        .await
+        .unwrap();
+    assert!(
+        rerun.get("error").is_none(),
+        "run_wp after an inline check: {:?}",
+        rerun
     );
 
     let _ = client.cancel().await;

--- a/tests/test-process-lifecycle.rs
+++ b/tests/test-process-lifecycle.rs
@@ -1124,7 +1124,7 @@ fn state_dir_env_var_redirects_persisted_state() {
 
 /// Removes a sandbox temp dir even when an assertion panics. Cleanup written
 /// as a trailing statement runs only on the success path, which leaves
-/// `/tmp/frama-c-sandbox-<owner>-<id>` behind on every failure.
+/// `/tmp/fcmcp-<uid>/sb-<owner>-<id>` behind on every failure.
 struct SandboxDirGuard {
     path: PathBuf,
 }

--- a/tests/test-process-lifecycle.rs
+++ b/tests/test-process-lifecycle.rs
@@ -715,9 +715,9 @@ fn tool_registry_count_matches_declared_snapshots() {
     // The tool count used to be pinned in CLAUDE.md here as well. That file is
     // not part of the repository, so a checkout has no such line to read and
     // this panicked before it could assert anything. docs/architecture.md below
-    // and README's tool table, which
-    // tool_router_matches_the_documented_surface compares against the router,
-    // are the copies a reader of this repository actually gets.
+    // and README's tool table, which tool_router_matches_the_documented_surface
+    // compares against the router, are the copies a reader of this repository
+    // actually gets.
     let architecture = std::fs::read_to_string(workspace_path("docs/architecture.md"))
         .expect("read docs/architecture.md");
     assert!(
@@ -2255,4 +2255,47 @@ fn a_missing_header_is_classified_on_the_first_reload() {
         "{response:?}"
     );
     assert_eq!(data["suggestion"]["tool"], "reload_project", "{response:?}");
+}
+
+/// structuredContent goes to the peers whose revision defines it, and no others.
+///
+/// The field arrived in 2025-06-18. This server also agrees to 2024-11-05 and
+/// 2025-03-26, and every tool answering with an object fills it, so those peers
+/// were being handed a key their revision does not define. Most clients ignore
+/// what they do not know; one that validates its input is entitled not to.
+///
+/// Both directions are asserted from one test, because the interesting failure
+/// is not "absent" or "present" on its own but the two disagreeing: a strip that
+/// fires for everybody silently removes the feature, and the suite would not
+/// have said so, since every other reader in this repository parses the text
+/// block.
+#[test]
+fn structured_content_follows_the_negotiated_protocol_version() {
+    let frama_c = std::env::var("FRAMA_C_BIN").unwrap_or_else(|_| "frama-c".into());
+
+    // self_check answers with an object and needs no Frama-C, so this measures
+    // the wire shape rather than the backend.
+    let mut old = McpHandle::spawn_test_binary_speaking(&frama_c, "2024-11-05");
+    let old_result = old.call_tool("self_check", "{}");
+    let old_result = &old_result["result"];
+    assert!(
+        old_result["content"][0]["text"].as_str().is_some(),
+        "a 2024-11-05 peer still gets the text block: {old_result:?}"
+    );
+    assert!(
+        old_result.get("structuredContent").is_none(),
+        "a 2024-11-05 peer was sent a field its revision does not define: {old_result:?}"
+    );
+
+    let mut new = McpHandle::spawn_test_binary_speaking(&frama_c, "2025-11-25");
+    let new_result = new.call_tool("self_check", "{}");
+    let new_result = &new_result["result"];
+    assert!(
+        new_result["structuredContent"].is_object(),
+        "a 2025-11-25 peer should get structuredContent: {new_result:?}"
+    );
+    assert!(
+        new_result["content"][0]["text"].as_str().is_some(),
+        "and the text block as well, which the result schema is written against: {new_result:?}"
+    );
 }

--- a/tests/unit/acsl-shapes.rs
+++ b/tests/unit/acsl-shapes.rs
@@ -1,4 +1,9 @@
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
+
+/// A plugin response as a tool result, which is how the parsers below read one.
+fn plugin_result(json: serde_json::Value) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(json.to_string())])
+}
 use serde_json::json;
 use frama_c_mcp::mcp::types::*;
 use frama_c_mcp::mcp::server::wpclass::*;
@@ -13,8 +18,7 @@ fn parse_plugin_success_wrapped_result() {
         "result": {"success": true, "error": null},
         "hash_label": "re_12345678"
     });
-    let content = Content::text(json.to_string());
-    let result = CallToolResult::success(vec![content]);
+    let result = plugin_result(json);
     assert!(parse_plugin_success(&result));
 }
 
@@ -24,8 +28,7 @@ fn parse_plugin_success_false_wrapped() {
         "result": {"success": false, "error": "ACSL syntax error in function contract"},
         "hash_label": "an_12345678"
     });
-    let content = Content::text(json.to_string());
-    let result = CallToolResult::success(vec![content]);
+    let result = plugin_result(json);
     assert!(!parse_plugin_success(&result));
 }
 
@@ -35,8 +38,7 @@ fn parse_plugin_error_wrapped_result() {
         "result": {"success": false, "error": "unbound logic variable i"},
         "hash_label": "an_12345678"
     });
-    let content = Content::text(json.to_string());
-    let result = CallToolResult::success(vec![content]);
+    let result = plugin_result(json);
     assert_eq!(parse_plugin_error(&result), Some("unbound logic variable i".to_string()));
 }
 

--- a/tests/unit/repo-guards.rs
+++ b/tests/unit/repo-guards.rs
@@ -328,6 +328,49 @@ fn a_flip_is_a_goal_that_timed_out_and_then_proved() {
     assert_eq!(flipped[0]["property"], "#p1");
 }
 
+/// Every command CI runs, as one text: the workflows plus the scripts in .ci/.
+///
+/// The guards below read the commands CI runs, and those commands live in two
+/// places now. The long shell blocks moved out of ci.yml into .ci/ so they
+/// could be formatted, shellcheck-able and runnable by hand, which left the
+/// step that runs them saying nothing but a path. A parser reading only the
+/// YAML would then see a release job that stages no assets and a lane that
+/// pins no test by name, and would report all clear having compared nothing.
+///
+/// The same lesson as ci_gates learned one directory over, when the artifact
+/// scan lived in a second workflow file: read the directory, so a script
+/// appearing in it is a non-event rather than a hole.
+fn ci_command_text(root: &std::path::Path) -> String {
+    let mut text = String::new();
+    for dir in [".github/workflows", ".ci"] {
+        let dir = root.join(dir);
+        let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
+            .unwrap_or_else(|error| panic!("{}: {error}", dir.display()))
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.extension()
+                    .is_some_and(|ext| ext == "yml" || ext == "yaml" || ext == "sh")
+            })
+            .collect();
+
+        // read_dir order is arbitrary, and a guard that reports what it found
+        // is read by a human.
+        paths.sort();
+        for path in paths {
+            text.push_str(&std::fs::read_to_string(&path).unwrap_or_default());
+            text.push('\n');
+        }
+    }
+
+    assert!(
+        text.contains("cargo test"),
+        "no workflow or .ci script was read, so every guard reading this would \
+         pass on an empty requirement set"
+    );
+    text
+}
+
 /// The command a workflow step runs, or the line unchanged when it runs none.
 ///
 /// A step is either "run: <command>" on one line or a command inside a
@@ -362,8 +405,7 @@ fn step_command(line: &str) -> &str {
 #[test]
 fn ci_named_tests_still_exist() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workflow =
-        std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("ci.yml");
+    let workflow = ci_command_text(root);
 
     /// Every .rs file under a directory, read whole.
     fn rust_sources(dir: &std::path::Path) -> Vec<String> {
@@ -595,7 +637,14 @@ fn ci_frama_c_version_matches_supported_minimum() {
     // they disagree: a matrix the scripts refuse means CI installs a Frama-C
     // its own gates will not run against, and the floor above cannot see it
     // because the floor is satisfied.
-    for script in ["scripts/check-tutorial-corpus.sh", "scripts/check-abs-int-fixtures.sh"] {
+    for script in [
+        "scripts/check-tutorial-corpus.sh",
+        "scripts/check-abs-int-fixtures.sh",
+
+        // Refuses an unsupported matrix value before ten minutes of opam
+        // install, and so pins the same version the two gates above do.
+        ".ci/check-frama-c-matrix-version.sh",
+    ] {
         let text = std::fs::read_to_string(root.join(script)).expect(script);
 
         // Whole version strings on both sides, not majors. Comparing majors let
@@ -640,8 +689,7 @@ fn ci_frama_c_version_matches_supported_minimum() {
 #[test]
 fn ci_runs_every_test_target() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workflow =
-        std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("ci.yml");
+    let workflow = ci_command_text(root);
 
     // Word by word off the command lines, not a substring of the file: a
     // comment mentioning the target would satisfy a contains, and so would a
@@ -738,8 +786,10 @@ fn tarball_names(text: &str) -> std::collections::BTreeSet<String> {
 #[test]
 fn released_tarball_names_match_the_build_matrix() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workflow =
-        std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("ci.yml");
+
+    // The matrix is in the YAML and the staged names are in
+    // .ci/stage-release-assets.sh, so this needs both halves.
+    let workflow = ci_command_text(root);
     let readme = std::fs::read_to_string(root.join("README.md")).expect("README.md");
 
     // The matrix rows are the source of truth: a target exists because a row
@@ -786,24 +836,7 @@ fn released_tarball_names_match_the_build_matrix() {
 /// Split out because two tests need it and they check different halves: one
 /// that the runner covers CI, one that the documents cover the runner.
 fn ci_gates(root: &std::path::Path) -> Vec<String> {
-    // Every workflow, not just ci.yml. There is one file today, and there were
-    // two: artifact-scans.yml ran a gate of its own, and a version of this that
-    // read a single named file could not see it, which is the exact failure
-    // this test exists to prevent, one file over. Reading the directory is what
-    // makes a second workflow appearing again a non-event.
-    let mut workflow = String::new();
-    let workflows = root.join(".github/workflows");
-    for entry in std::fs::read_dir(&workflows).expect("workflows dir").flatten() {
-        let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "yml" || ext == "yaml") {
-            workflow.push_str(&std::fs::read_to_string(&path).unwrap_or_default());
-            workflow.push('\n');
-        }
-    }
-    assert!(
-        workflow.contains("cargo test"),
-        "no workflow was read, so this test would pass on an empty requirement set"
-    );
+    let workflow = ci_command_text(root);
 
     let mut required: Vec<String> = Vec::new();
     for line in workflow.lines() {
@@ -823,6 +856,22 @@ fn ci_gates(root: &std::path::Path) -> Vec<String> {
         suites >= 3 && required.iter().any(|gate| gate == "--test unit"),
         "the workflow parser stopped recognising cargo test lines: {required:?}"
     );
+
+    // The two lint gates by name, because they are the two that can leave the
+    // set without any suite count moving. Measured: extracting the shell block
+    // into .ci/check-shell-formatting.sh and writing the binary as "$bin"
+    // removed the literal gate_of matches on, so shfmt silently left this set
+    // and the two tests built on it went from checking it to not. Nothing went
+    // red. A gate that disappears has to fail here rather than be discovered by
+    // reading the file it used to be in.
+    for lint in ["shfmt", "cargo clippy"] {
+        assert!(
+            required.iter().any(|gate| gate == lint),
+            "{lint} is in no workflow or .ci script, so nothing can fail a push \
+             on it: {required:?}"
+        );
+    }
+
     required
 }
 
@@ -936,8 +985,8 @@ fn documented_gate_list_covers_ci() {
     // being told to run it, which is how the first version of this passed its
     // own control: the paragraph explaining the gap mentioned "dune runtest".
     //
-    // Every document in this list must exist, so a typo or a renamed file
-    // fails here rather than quietly checking one fewer copy.
+    // Every document in this list must exist, so a typo or a renamed file fails
+    // here rather than quietly checking one fewer copy.
     let gate_lists: Vec<(&str, String)> = ["README.md"]
         .into_iter()
         .map(|name| {
@@ -1028,3 +1077,99 @@ fn tool_router_matches_the_documented_surface() {
     assert_eq!(registered, documented);
 }
 
+
+/// A job that runs a script out of the tree checks the tree out first.
+///
+/// This exists because moving shell out of ci.yml into .ci/ turned steps that
+/// needed nothing into steps that need the repository, and the release job had
+/// no checkout: its comment said "No checkout: nothing here reads the tree",
+/// which was true when it was written and false the moment its shell became two
+/// files. Nothing caught it. It is not reachable from a pull request either,
+/// since the job is gated on a push to main, so the first evidence would have
+/// been a release that did not happen.
+///
+/// The checkout also has to be the job's first step, not merely somewhere
+/// before the script. actions/checkout cleans the workspace by default, so a
+/// checkout after actions/download-artifact deletes the artifacts the release
+/// is assembled from, and a job that fails that way still has a checkout and
+/// still runs its scripts. All five jobs already put it first, so this pins a
+/// convention rather than imposing one.
+#[test]
+fn jobs_running_repo_scripts_check_out_the_repo() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let mut offenders = Vec::new();
+    let mut checked = 0;
+    for entry in std::fs::read_dir(root.join(".github/workflows"))
+        .expect("workflows dir")
+        .flatten()
+    {
+        let path = entry.path();
+        if !path.extension().is_some_and(|ext| ext == "yml" || ext == "yaml") {
+            continue;
+        }
+        let workflow = std::fs::read_to_string(&path).unwrap_or_default();
+
+        // Jobs are the keys at one indent level under "jobs:", and steps run in
+        // file order, so a linear scan is enough to know whether the checkout
+        // came first. A YAML parser would be better and is not worth a
+        // dependency for five jobs.
+        let mut job = String::new();
+        let mut checkout_at = None;
+        let mut runs_repo_script = false;
+        let mut step = 0usize;
+        let mut finish = |job: &str, checkout: Option<usize>, runs: bool| {
+            if !runs {
+                return;
+            }
+            checked += 1;
+            match checkout {
+                Some(1) => {}
+                Some(at) => offenders.push(format!(
+                    "{job}: checks out at step {at} rather than first, so an earlier \
+                     step's workspace writes are cleaned away"
+                )),
+                None => offenders.push(format!("{job}: runs a repo script with no checkout")),
+            }
+        };
+
+        for line in workflow.lines() {
+            let indent = line.len() - line.trim_start().len();
+            let trimmed = line.trim();
+
+            // A key at two spaces, inside jobs, is a new job.
+            if indent == 2 && trimmed.ends_with(':') && !trimmed.starts_with('#') {
+                finish(&job, checkout_at, runs_repo_script);
+                job = trimmed.trim_end_matches(':').to_string();
+                (checkout_at, runs_repo_script, step) = (None, false, 0);
+                continue;
+            }
+
+            // Steps sit at six spaces. Counting every "- " would also count the
+            // build matrix's include entries, which are not steps.
+            if indent == 6 && trimmed.starts_with("- ") {
+                step += 1;
+            }
+            if trimmed.contains("actions/checkout") && checkout_at.is_none() {
+                checkout_at = Some(step);
+            }
+            if (trimmed.contains(".ci/") || trimmed.contains("scripts/"))
+                && !trimmed.starts_with('#')
+            {
+                runs_repo_script = true;
+            }
+        }
+        finish(&job, checkout_at, runs_repo_script);
+    }
+
+    assert!(
+        checked >= 3,
+        "no job was found running a repo script, so this guard compared nothing: \
+         the workflow moved and the parser did not"
+    );
+    assert!(
+        offenders.is_empty(),
+        "these jobs run a script out of the tree without checking it out first, \
+         so the step fails with no such file: {offenders:?}"
+    );
+}

--- a/tests/unit/server.rs
+++ b/tests/unit/server.rs
@@ -259,6 +259,16 @@ async fn self_check_capabilities_shape_with_missing_frama_c() {
     let payload = &payload["capabilities"];
     assert_eq!(payload["server"]["tool_count"], MCP_TOOL_COUNT);
     assert_eq!(payload["server"]["protocol_version"], "2024-11-05");
+
+    // The revisions this server agrees to, reported rather than assumed. 2026
+    // -07-28 is absent on purpose: it turns on SEP-2322 resultType and the
+    // SEP-2164 error-code remap, which nothing here has been tested against.
+    // Listing them here means adding one is a visible change to this test
+    // rather than a silent widening of what the server accepts.
+    assert_eq!(
+        payload["server"]["supported_protocol_versions"],
+        serde_json::json!(["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"])
+    );
     assert_eq!(payload["frama_c"]["status"], "missing");
     assert_eq!(payload["wp"]["memory_model"]["default"], "Typed+nocast");
     assert!(payload["wp"]["memory_model"]["supported"]
@@ -2047,4 +2057,61 @@ fn unconstrained_assigns_prefers_the_resolved_leaf() {
     // A null leaf falls back to reading the printed target rather than being
     // dropped.
     assert!(targets.contains(&"*(gx ? p : q)"), "{findings:?}");
+}
+
+/// Every revision rmcp knows is either supported or excluded on purpose.
+///
+/// Cargo.toml asks for rmcp "3", so `cargo update` can extend
+/// `ProtocolVersion::KNOWN_VERSIONS` without any diff in this repository. The
+/// list of supported revisions would then quietly stop covering what the SDK
+/// offers, clients asking for the new one would negotiate down to the fallback,
+/// and nothing would say so. The assertion that used to stand here compared the
+/// const against a hand-copied literal, which agrees with it by construction
+/// and
+/// so could not catch that at all.
+///
+/// A new revision fails here until someone reads its SEPs and puts it in one
+/// list or the other, which is the deliberate decision the const's comment asks
+/// for.
+#[test]
+fn supported_protocol_versions_cover_every_known_revision() {
+    use rmcp::model::ProtocolVersion;
+
+    let excluded: Vec<&ProtocolVersion> =
+        EXCLUDED_PROTOCOL_VERSIONS.iter().map(|(version, _)| version).collect();
+
+    let unaccounted: Vec<&str> = ProtocolVersion::KNOWN_VERSIONS
+        .iter()
+        .filter(|known| {
+            !SUPPORTED_PROTOCOL_VERSIONS.contains(known) && !excluded.contains(known)
+        })
+        .map(ProtocolVersion::as_str)
+        .collect();
+    assert!(
+        unaccounted.is_empty(),
+        "rmcp knows protocol revisions this server neither supports nor \
+         declines, so clients asking for them negotiate down with nobody \
+         having decided that: {unaccounted:?}"
+    );
+
+    // The other direction: an excluded revision that rmcp has dropped is a
+    // reason nobody needs any more, and a supported one it has dropped is a
+    // list that no longer describes anything.
+    for (version, _) in EXCLUDED_PROTOCOL_VERSIONS {
+        assert!(
+            ProtocolVersion::KNOWN_VERSIONS.contains(version),
+            "{} is declined but rmcp no longer knows it",
+            version.as_str()
+        );
+    }
+    for version in SUPPORTED_PROTOCOL_VERSIONS {
+        assert!(
+            ProtocolVersion::KNOWN_VERSIONS.contains(version),
+            "{} is offered but rmcp no longer knows it",
+            version.as_str()
+        );
+    }
+
+    // The fallback has to be one this server would actually agree to.
+    assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&FALLBACK_PROTOCOL_VERSION));
 }

--- a/tests/unit/state.rs
+++ b/tests/unit/state.rs
@@ -7,8 +7,8 @@ fn sandbox_metadata_serializes_without_runtime_handles() {
     let metadata = SandboxMetadata {
         experiment_id: "exp01".into(),
         original_function: "f".into(),
-        sandbox_dir: PathBuf::from("/tmp/frama-c-sandbox-exp01"),
-        sandbox_socket: PathBuf::from("/tmp/frama-c-sandbox-exp01/frama-c.sock"),
+        sandbox_dir: PathBuf::from("/tmp/fcmcp-0/sb-abcd1234-exp01"),
+        sandbox_socket: PathBuf::from("/tmp/fcmcp-0/sb-abcd1234-exp01/frama-c.sock"),
         sandbox_pid: 42,
         declaration_marker: "#F1".into(),
         created_at: "2026-08-06T00:00:00Z".into(),
@@ -1119,4 +1119,74 @@ fn receipt_subject_ignores_the_check_scratch_directory() {
     // subject.
     assert_eq!(receipt_source_path("/home/me/proj/abs.c"), "/home/me/proj/abs.c");
     assert_eq!(receipt_source_path("/tmp/other-dir/input.c"), "/tmp/other-dir/input.c");
+}
+
+/// The scratch root is private, and a directory that is not gets refused.
+///
+/// Everything this server writes under /tmp lives inside it: the Frama-C logs,
+/// the sandbox sources and sockets, the self-check probes. /tmp is world
+/// writable, so the parent being unenterable by anyone else is what stops a
+/// pre-created directory full of symlinks from catching those writes. The names
+/// underneath stay deterministic on purpose, because a sandbox left by an
+/// earlier server is found by recomputing its path.
+#[cfg(unix)]
+#[test]
+fn the_scratch_root_is_private_or_refused() {
+    use frama_c_mcp::mcp::store::{ensure_private_dir, private_root_path};
+    use std::os::unix::fs::PermissionsExt;
+
+    let holder = tempfile::tempdir().expect("tempdir");
+
+    // Created fresh: 0700, not the umask.
+    let fresh = holder.path().join("fresh");
+    ensure_private_dir(&fresh).expect("fresh root");
+    let mode = std::fs::metadata(&fresh).expect("stat").permissions().mode() & 0o777;
+    assert_eq!(mode, 0o700, "created at {mode:o} rather than 0700");
+
+    // Called again on its own directory: accepted, unchanged.
+    ensure_private_dir(&fresh).expect("second call");
+
+    // Group or world access: refused rather than repaired, because a directory
+    // someone else can write into is either an attack or a confusing machine,
+    // and silently chmod-ing it is not this program's business.
+    for bad in [0o777, 0o755, 0o750, 0o707] {
+        let loose = holder.path().join(format!("loose{bad:o}"));
+        std::fs::create_dir(&loose).expect("mkdir");
+        std::fs::set_permissions(&loose, std::fs::Permissions::from_mode(bad)).expect("chmod");
+        assert!(
+            ensure_private_dir(&loose).is_err(),
+            "a root at {bad:o} was accepted, so anyone could plant symlinks in it"
+        );
+    }
+
+    // A symlink is seen rather than followed, even when it points somewhere
+    // that would itself pass.
+    let target = holder.path().join("target");
+    ensure_private_dir(&target).expect("target");
+    let link = holder.path().join("link");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+    // Asserted on the message, not just on the failure. lstat makes a symlink
+    // fail the is-a-directory check too, so err-versus-ok cannot tell whether
+    // the symlink was recognised as one; without this, dropping that branch
+    // looks like it changed nothing.
+    let refused = ensure_private_dir(&link).expect_err(
+        "a symlinked root was accepted, so it names a directory chosen by whoever made the link",
+    );
+    assert!(
+        refused.to_string().contains("is a symlink"),
+        "a symlinked root should say so rather than blaming its type: {refused}"
+    );
+
+    // A file where the directory should be.
+    let file = holder.path().join("file");
+    std::fs::write(&file, b"").expect("write");
+    assert!(ensure_private_dir(&file).is_err(), "a file was accepted as the root");
+
+    // The real root is short, because sandbox sockets hang off it and a Unix
+    // socket path is capped near 104 bytes.
+    assert!(
+        private_root_path().to_string_lossy().len() <= 24,
+        "{} leaves too little of the socket budget",
+        private_root_path().display()
+    );
 }

--- a/tests/unit/state.rs
+++ b/tests/unit/state.rs
@@ -1074,3 +1074,49 @@ fn annotation_count_zero_on_empty_specs() {
     }).expect("store_conclusion");
     assert_eq!(state.get_conclusion("f").unwrap().annotation_count, 0);
 }
+
+/// sha256_hex is lower case, two digits per byte, no separator.
+///
+/// Pinned against published vectors rather than against itself, because the
+/// spelling is a compatibility surface and not an implementation detail. Every
+/// proof receipt and stored conclusion already on disk carries a hash written
+/// by the sha2 0.10 GenericArray LowerHex formatter, and a receipt is the whole
+/// basis on which two runs are called comparable. A rewrite emitting upper case
+/// or colon-separated hex would not fail anything, it would quietly stop
+/// matching, and before this test it passed all thirteen gates.
+///
+/// The vectors are themselves 64 lower case unseparated hex characters, so they
+/// pin the length and the alphabet that store.rs and wpclass.rs slice into
+/// without needing a separate assertion for either.
+#[test]
+fn sha256_hex_is_lowercase_unseparated() {
+    assert_eq!(
+        sha256_hex(b""),
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+    assert_eq!(
+        sha256_hex(b"abc"),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+/// Two runs of the same inline source produce the same receipt subject.
+///
+/// A receipt exists so two runs can be compared by their hashes, and the scratch
+/// directory a check writes inline source into is chosen fresh every call, so
+/// digesting its name made every such run incomparable with every other. The old
+/// pid-shaped name hid this by being constant for a session; moving to a random
+/// name is what surfaced it.
+#[test]
+fn receipt_subject_ignores_the_check_scratch_directory() {
+    use frama_c_mcp::mcp::server::receipt::receipt_source_path;
+
+    assert_eq!(receipt_source_path("/tmp/frama-c-check-AbC123/input.c"), "input.c");
+    assert_eq!(receipt_source_path("/tmp/frama-c-check-ZzZ999/input.c"), "input.c");
+
+    // A real project file keeps its path: that one names something a reader can
+    // go and look at, and two projects with a like-named file are not the same
+    // subject.
+    assert_eq!(receipt_source_path("/home/me/proj/abs.c"), "/home/me/proj/abs.c");
+    assert_eq!(receipt_source_path("/tmp/other-dir/input.c"), "/tmp/other-dir/input.c");
+}

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -1283,3 +1283,39 @@ fn clean_run_still_reports_no_timeout_evidence() {
     let triage = wp_timeout_triage_from_tasks_and_report(&drained, None);
     assert_eq!(triage["kind"], "none", "{triage:?}");
 }
+
+/// A computed stable goal id, pinned to a literal.
+///
+/// Every other stable_goal_id in this file is a synthetic input ("sg_a"), so
+/// until this test nothing ran the digest that produces a real one. That gap
+/// was found the day the eight-way {:02x} format string in stable_goal_id_for
+/// was replaced by a slice of the shared sha256_hex: the two spell the same
+/// bytes, and no test could have said so.
+///
+/// The id is a join key. It appears in stored conclusions and proof receipts,
+/// and a run is compared to an earlier one by matching them, so a change to
+/// how it is spelled does not fail, it silently stops joining. Pin it.
+#[test]
+fn stable_goal_id_is_sixteen_hex_characters_of_the_payload_digest() {
+    let mut goal = json!({
+        "fct": "abs",
+        "descr": "Post-condition",
+        "source": {"file": "abs.c", "line": 12},
+    });
+    enrich_goal_stable_id(&mut goal, "spec", None);
+
+    let id = goal["stable_goal_id"].as_str().expect("stable_goal_id");
+    let hex = id.strip_prefix("sg_").expect("sg_ prefix");
+
+    // Measured against the eight-way {:02x} format string this replaced, not
+    // copied from the new implementation: both spell 682ebebdbb98c969 for this
+    // goal, which is what makes the two interchangeable. The literal pins the
+    // length and the character class too, so neither needs its own assertion.
+    assert_eq!(hex, "682ebebdbb98c969", "{id}");
+
+    // A hash_label wins outright, unhashed. receipt.rs and server.rs both
+    // document depending on this.
+    let mut labelled = json!({"hash_label": "re_0badf00d", "fct": "abs"});
+    enrich_goal_stable_id(&mut labelled, "spec", None);
+    assert_eq!(labelled["stable_goal_id"], "re_0badf00d");
+}


### PR DESCRIPTION
main does not compile: two dependabot merges took rmcp from 1.8 to 3.1 and sha2 from 0.10 to 0.11 with no source change, and the fast lane runs "cargo clippy --all-targets", so the gate that would have said so either went unrun or was merged past. "Content" was "Annotated<RawContent>" in 1.x; 3.x drops the alias and the ".raw" projection for a plain "ContentBlock" enum.

Protocol versions. "with_protocol_version" was never a pin, in 1.x or 3.x: "negotiate_protocol_version" echoes whatever the client asks for whenever "supported_protocol_versions()" contains it, and that defaults to every known revision. The comment claiming otherwise had been steering decisions for a while.

Structured output. Every tool returning JSON goes through "json_result", which now sets "structuredContent" beside the pretty text block, and only when the value is an object: five of the six kinds "list" answers are arrays, and a validating client rejects the whole response for those. "json_result" takes its value by move, so a "check" payload is walked once instead of deep-copied.

Hashing. "sha256_hex" had three spellings; it has one, in "state.rs", so "store", "receipt" and "wpclass" all call up rather than "state" calling down. The output is byte-identical to the sha2 0.10 "GenericArray" formatter, which matters because every receipt on disk carries a hash written by it, and nothing tested that until now.

CI shell. Blocks with control flow, a loop or a pinned download moved from ci.yml into ".ci/", so they are formatted by the shfmt gate and runnable by hand. That made the release job depend on files in the tree while it had no checkout, which would have failed on the first push to main; it checks out first now, without persisting a token it does not use. The guards read ".ci/" as well as the workflows, since that is where the commands CI runs now live.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adapts to `rmcp` 3 and `sha2` 0.11, restores build, and tightens protocol handling and scratch-path security. Behavior changes: we now strip `structuredContent` for peers below 2025-06-18, move all scratch/log paths under a private `/tmp/fcmcp-<uid>` root, and keep inline-source files alive across follow‑up calls.

- Protocol and SDK
  - Replace `Content`/`RawContent` with `ContentBlock` (rmcp 3). Add `SUPPORTED_PROTOCOL_VERSIONS` and `FALLBACK_PROTOCOL_VERSION`; `get_info`/self-check report both. Decline 2026-07-28 (SEP‑2322/2164 not exercised).
  - Gate results by the negotiated revision: remove `structuredContent` for < 2025‑06‑18. `tool_result_json` prefers moved `structuredContent` when present.
- Results and hashing
  - `json_result` sets `structuredContent` only for object payloads; pretty text remains in `content`. Moves the value to avoid deep copies.
  - Unify hashing via `state::sha256_hex`; output is byte‑identical to `sha2` 0.10’s hex. Goal IDs use the shared helper. Tests pin both formats.
- Scratch, receipts, and security
  - New private root `/tmp/fcmcp-<uid>` (0700, ownership checked) for logs, sandboxes `sb-<cwd8>-<id>`, and self‑check `sc-*`. Shorter paths keep Unix socket lengths under limits.
  - Ensure the private root before writing; refuse mismatched ownership/permissions. Logs now live under the root; errors are reported.
  - Keep inline `check {source: ...}` files for the session so subsequent tools read what was checked. `receipt_source_path` ignores the scratch dir component to keep receipts comparable.
  - `e_acsl` and Why3 dump use per‑call, private, RAII‑cleaned dirs.
- CI and docs
  - Move multi-line shell to `.ci/` scripts (version checks, shfmt, smoke tests, stage/publish). shfmt gate uses NUL‑delimited paths and pipefail.
  - Release publishing deletes/recreates “latest” via HTTP status checks; no `--cleanup-tag`; avoids `mapfile` for macOS.
  - Guards read `.ci/` plus workflows. README documents `.ci/` and Rust formatting policy. Result schema doc clarifies `structuredContent`.

- Rollout
  - Clients below 2025‑06‑18 will not see `structuredContent`; text in `content` is unchanged. Requests for 2026‑07‑28 negotiate down to the fallback.
  - One‑time upgrade: sandboxes recorded by older servers won’t match the new layout and are dropped; their Frama‑C processes may leak once.
  - Any tooling depending on previous temp paths or log location must switch to the server‑reported paths under the private root.

<sup>Written for commit 27709cb231602ca01911114f5dce7e837e23d1ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/frama-c-mcp/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

