### PR TITLE
Bound the frame write so a wedged server cannot freeze the client

### DIFF
--- a/src/frama-c/transport.rs
+++ b/src/frama-c/transport.rs
@@ -24,6 +24,15 @@ pub struct Transport {
     /// command. Poisoning turns that silent corruption into a fast error
     /// on every later use; recovery is a new Transport, which the session
     /// gets through the respawn path in ensure_main_spawned.
+    ///
+    /// The respawn is not automatic yet. ensure_main_spawned decides
+    /// in-place vs respawn from MainFramaCState alone and never looks at
+    /// this flag, so the first reload with explicit files still fails in
+    /// place (which marks the session poisoned) and only the second one
+    /// respawns; a reload without files never gets that far, because it
+    /// asks this dead transport for the current file list first. Sandbox
+    /// clients have no respawn path at all. Surfacing this flag to the
+    /// respawn decision is a planned follow-up.
     poisoned: bool,
 }
 

--- a/src/frama-c/transport.rs
+++ b/src/frama-c/transport.rs
@@ -6,6 +6,13 @@ use tokio::net::UnixStream;
 use super::codec;
 use crate::error::FramaCError;
 
+/// Bound on a single frame write. A healthy server drains its socket
+/// promptly; if a write stalls past this, the server is wedged. Without a
+/// timeout the write blocks while the caller holds the client mutex, which
+/// freezes every subsequent request, including the poll loop that is meant
+/// to enforce request timeouts.
+const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub struct Transport {
     stream: UnixStream,
     read_buf: BytesMut,
@@ -22,7 +29,10 @@ impl Transport {
 
     pub async fn send_frame(&mut self, payload: &str) -> Result<(), FramaCError> {
         let frame = codec::encode_frame(payload);
-        self.stream.write_all(&frame).await?;
+        match tokio::time::timeout(WRITE_TIMEOUT, self.stream.write_all(&frame)).await {
+            Ok(res) => res?,
+            Err(_) => return Err(FramaCError::Timeout(WRITE_TIMEOUT)),
+        }
         Ok(())
     }
 

--- a/src/frama-c/transport.rs
+++ b/src/frama-c/transport.rs
@@ -16,6 +16,15 @@ const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct Transport {
     stream: UnixStream,
     read_buf: BytesMut,
+    /// Set when a frame write failed or timed out part-way through.
+    ///
+    /// write_all is not cancellation-safe: the socket may already hold a
+    /// prefix of that frame, so the next write would append a fresh frame
+    /// onto it and corrupt the length-prefixed protocol for every later
+    /// command. Poisoning turns that silent corruption into a fast error
+    /// on every later use; recovery is a new Transport, which the session
+    /// gets through the respawn path in ensure_main_spawned.
+    poisoned: bool,
 }
 
 impl Transport {
@@ -24,22 +33,29 @@ impl Transport {
         Ok(Transport {
             stream,
             read_buf: BytesMut::with_capacity(8192),
+            poisoned: false,
         })
     }
 
     pub async fn send_frame(&mut self, payload: &str) -> Result<(), FramaCError> {
+        if self.poisoned {
+            return Err(poisoned_transport());
+        }
         let frame = codec::encode_frame(payload);
         match tokio::time::timeout(WRITE_TIMEOUT, self.stream.write_all(&frame)).await {
-            Ok(res) => res?,
-            Err(_) => return Err(FramaCError::Timeout(WRITE_TIMEOUT)),
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(self.poison(FramaCError::Io(e)).await),
+            Err(_) => Err(self.poison(FramaCError::Timeout(WRITE_TIMEOUT)).await),
         }
-        Ok(())
     }
 
     pub async fn recv_frame(
         &mut self,
         timeout: Duration,
     ) -> Result<Option<String>, FramaCError> {
+        if self.poisoned {
+            return Err(poisoned_transport());
+        }
         loop {
             if let Some((payload, consumed)) = codec::decode_frame(&self.read_buf)? {
                 self.read_buf.advance(consumed);
@@ -66,4 +82,22 @@ impl Transport {
         self.stream.shutdown().await?;
         Ok(())
     }
+
+    /// Mark the stream unusable and close our end of it, returning the
+    /// error the caller should see. Any write that did not run to
+    /// completion can have left a partial frame in the socket, and no
+    /// later frame may follow it on this stream.
+    async fn poison(&mut self, error: FramaCError) -> FramaCError {
+        self.poisoned = true;
+        let _ = self.stream.shutdown().await;
+        error
+    }
+}
+
+/// The error every later call gets on a poisoned transport.
+fn poisoned_transport() -> FramaCError {
+    FramaCError::Io(std::io::Error::new(
+        std::io::ErrorKind::BrokenPipe,
+        "transport poisoned by an incomplete frame write",
+    ))
 }


### PR DESCRIPTION
## Problem

`Transport::send_frame` (`src/frama-c/transport.rs`) writes with `write_all` and no timeout. Every send happens while holding the `FramaCClient` mutex, and the poll loop that enforces request timeouts sends through this same path every 100 ms. If the Frama-C process stops draining its socket (wedged in a computation or a deadlocked plugin), the kernel socket buffer fills with poll frames, `write_all` blocks forever, and the client mutex is never released. Every later MCP tool call then blocks on that mutex: the server freezes silently, and the very mechanism meant to bound request time is what deadlocks.

## Reproduction

A Unix-socket peer that accepts and never reads stands in for a wedged Frama-C. Driving `Transport::send_frame` with 1 MiB frames:

- HEAD: still blocked after 25 s, no error returned (aborted by watchdog)
- this branch: returns `Operation timeout after 10s` at 10.0 s

## Fix

Wrap the write in a 10 s `tokio::time::timeout` and surface `FramaCError::Timeout` on expiry. 10 s is far above any legitimate stall: a healthy server drains its socket promptly and the poll frames are tens of bytes. On the reload path the existing poison logic in `ensure_main_spawned` respawns the instance; other tools now surface the timeout to the caller instead of hanging forever.

## Testing

- Full suite on Frama-C 33.0 / why3 1.8.2 / Alt-Ergo 2.6.3 / Z3 4.13.3: 534 tests pass (unit 370, integration 12, mcp-stdio 89, process-lifecycle 43, reload-project-regression 10, store-conclusion 10)
- `cargo clippy --all-targets` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded the frame write in `Transport::send_frame` with a 10-second timeout so a wedged Frama-C server can't freeze the client. Previously `write_all` had no timeout; a stalled write blocked forever while holding the client mutex, freezing every later request including the poll loop that enforces timeouts. Because `write_all` isn't cancellation-safe, a timed-out or failed write now poisons the transport — it returns `FramaCError::Timeout`, shuts down the socket, and every later call fails fast with a BrokenPipe error instead of corrupting the length-prefixed protocol.

Recovery requires a new `Transport`, and the respawn is only partially automatic: `ensure_main_spawned` decides in-place vs respawn from `MainFramaCState` alone, so a reload with explicit files respawns only on the second attempt, and sandbox clients have no respawn path at all.

<sup>Written for commit 0f86023b71aa85d99a032fd2c8d77e01feef24b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/frama-c-mcp/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

