### PR TITLE
Serialize each run_wp transaction with a per-instance lock

### DIFF
--- a/src/frama-c/client.rs
+++ b/src/frama-c/client.rs
@@ -349,6 +349,10 @@ impl ClientInner {
 
 pub struct FramaCClient {
     inner: Mutex<ClientInner>,
+    /// Serializes reload_fetch pairs. inner covers one request at a time,
+    /// but a reload and the fetch behind it are two requests, and the table
+    /// cursor they share is process-global.
+    fetch_lock: Mutex<()>,
 }
 
 impl FramaCClient {
@@ -413,6 +417,7 @@ impl FramaCClient {
 
         let client = FramaCClient {
             inner: Mutex::new(inner),
+            fetch_lock: Mutex::new(()),
         };
 
         // Auto-fetch function info to populate marker cache
@@ -589,6 +594,24 @@ impl FramaCClient {
             }
         }
         Ok(all_entries)
+    }
+
+    /// A reload and the fetch behind it as one atomic pair.
+    ///
+    /// The table cursor is process-global: a reload resets it, a fetch
+    /// drains it. inner serializes single requests only, so without its own
+    /// lock two pairs can interleave (A reload, B reload, A fetch, B fetch)
+    /// and the later fetch comes back a delta. Measured before this lock
+    /// existed: 79 of 80 concurrent goal reads returned an empty list on an
+    /// 11-goal table, and an empty goal list reads like "everything proved".
+    pub async fn reload_fetch(
+        &self,
+        reload_request: &str,
+        fetch_request: &str,
+    ) -> Result<Vec<serde_json::Value>, FramaCError> {
+        let _fetch_guard = self.fetch_lock.lock().await;
+        self.get(reload_request, serde_json::Value::Null).await?;
+        self.fetch_all(fetch_request).await
     }
 
     pub async fn shutdown(&self) -> Result<(), FramaCError> {

--- a/src/frama-c/client.rs
+++ b/src/frama-c/client.rs
@@ -614,6 +614,13 @@ impl FramaCClient {
         self.fetch_all(fetch_request).await
     }
 
+    /// The fetch_lock guard, for the one caller that labels the reload and
+    /// fetch steps differently in its errors (the reload health check in
+    /// project.rs). Everyone else wants reload_fetch.
+    pub(crate) async fn fetch_guard(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.fetch_lock.lock().await
+    }
+
     pub async fn shutdown(&self) -> Result<(), FramaCError> {
         let mut inner = self.inner.lock().await;
         inner.send_command(&FramaCCommand::Shutdown).await?;

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -3329,6 +3329,18 @@ impl FramaCMcpServer {
         // takes no lock, so a run stuck in drain can still be cancelled.
         let _wp_op_guard = self.main_wp_lock.lock().await;
 
+        // Rechecked under the lock: verify_program_step can set the flag
+        // while this call waits for a run ahead of it, and the check at
+        // the top of the handler was read before that wait.
+        if *self.project_locked.read().await {
+            return Err(project_locked_error(
+                "run_wp",
+                "Project is locked. run_wp is blocked during Phase 2 to prevent state pollution. \
+                 If you are in verify-function, pass sandbox-prefixed functions. \
+                 Do NOT touch the main Frama-C instance. Call verify_program_step with lock_project=false first if this is the final main-project gate.",
+            ));
+        }
+
         // Recorded, not enforced. Frama-C aborts on SOME memory model changes
         // within one process and not others: Typed+cast to Typed+nocast is
         // routine and the suite depends on it, while Bytes to Typed+cast comes

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -4472,7 +4472,16 @@ impl FramaCMcpServer {
                 .await?,
         );
 
+        // The writer takes the WP transaction lock too: setting the flag
+        // declares that no WP run is mutating the main instance from here
+        // on, and without the lock that declaration can go out while a run
+        // that rechecked the flag is still mid-flight. Queuing behind it
+        // makes the ordering real; the recheck in run_wp closes the other
+        // half, a run starting after the flag is already set. This can wait
+        // as long as a run can; cancel_wp_queue takes no lock and remains
+        // the escape.
         if params.lock_project != Some(false) {
+            let _wp_op_guard = self.main_wp_lock.lock().await;
             *self.project_locked.write().await = true;
         }
         let project_locked = *self.project_locked.read().await;

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -3321,6 +3321,14 @@ impl FramaCMcpServer {
                 .await;
         }
 
+        // Held across the whole transaction below: config, target resolution,
+        // scheduling, drain, and goal fetch all act on process-global WP state,
+        // and the client mutex only covers one request at a time. Without
+        // this, two concurrent runs overwrite each other's config mid-flight
+        // and each reports the union of both runs' goals. cancel_wp_queue
+        // takes no lock, so a run stuck in drain can still be cancelled.
+        let _wp_op_guard = self.main_wp_lock.lock().await;
+
         // Recorded, not enforced. Frama-C aborts on SOME memory model changes
         // within one process and not others: Typed+cast to Typed+nocast is
         // routine and the suite depends on it, while Bytes to Typed+cast comes

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -23,18 +23,24 @@ async fn reload_health_get(
         .map_err(|error| reload_health_error(request, error))
 }
 
-// Routed through the client's reload_fetch so the pair holds fetch_lock:
-// these are the same process-global cursors every other reader uses, and a
-// health check that bypasses the lock can split one cursor with a
-// concurrent reader (measured: 2 of 50 concurrent counts reads came back
-// empty mid-reload before this).
+// Holds fetch_lock across the pair: these are the same process-global
+// cursors every other reader uses, and a health check that bypasses the
+// lock can split one cursor with a concurrent reader (measured: 2 of 50
+// concurrent counts reads came back empty mid-reload before this). The
+// guard is taken directly rather than via client.reload_fetch so each
+// step's error keeps its own request label.
 async fn reload_health_fetch_all(
     client: &FramaCClient,
     reload_request: &str,
     fetch_request: &str,
 ) -> Result<Vec<serde_json::Value>, McpError> {
+    let _guard = client.fetch_guard().await;
     client
-        .reload_fetch(reload_request, fetch_request)
+        .get(reload_request, json!(null))
+        .await
+        .map_err(|error| reload_health_error(reload_request, error))?;
+    client
+        .fetch_all(fetch_request)
         .await
         .map_err(|error| reload_health_error(fetch_request, error))
 }

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -23,19 +23,18 @@ async fn reload_health_get(
         .map_err(|error| reload_health_error(request, error))
 }
 
+// Routed through the client's reload_fetch so the pair holds fetch_lock:
+// these are the same process-global cursors every other reader uses, and a
+// health check that bypasses the lock can split one cursor with a
+// concurrent reader (measured: 2 of 50 concurrent counts reads came back
+// empty mid-reload before this).
 async fn reload_health_fetch_all(
     client: &FramaCClient,
-    reload_request: Option<&str>,
+    reload_request: &str,
     fetch_request: &str,
 ) -> Result<Vec<serde_json::Value>, McpError> {
-    if let Some(request) = reload_request {
-        client
-            .get(request, json!(null))
-            .await
-            .map_err(|error| reload_health_error(request, error))?;
-    }
     client
-        .fetch_all(fetch_request)
+        .reload_fetch(reload_request, fetch_request)
         .await
         .map_err(|error| reload_health_error(fetch_request, error))
 }
@@ -51,19 +50,19 @@ async fn ast_reload_health(
     let files = reload_health_get(client, "kernel.ast.getFiles", json!(null)).await?;
     let functions = reload_health_fetch_all(
         client,
-        Some("kernel.ast.reloadFunctions"),
+        "kernel.ast.reloadFunctions",
         "kernel.ast.fetchFunctions",
     )
     .await?;
     let globals = reload_health_fetch_all(
         client,
-        Some("kernel.ast.reloadGlobals"),
+        "kernel.ast.reloadGlobals",
         "kernel.ast.fetchGlobals",
     )
     .await?;
     let properties = reload_health_fetch_all(
         client,
-        Some("kernel.properties.reloadStatus"),
+        "kernel.properties.reloadStatus",
         "kernel.properties.fetchStatus",
     )
     .await?;

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -129,6 +129,22 @@ impl FramaCMcpServer {
         };
         validate_project_options(&project_options)?;
 
+        // Serialized with run_wp on the main instance: the steps below
+        // read the live instance (marker snapshot) and ensure_main_spawned
+        // can respawn or re-parse the very process a proof run is draining
+        // on. The flag is rechecked under the lock because
+        // verify_program_step can set it while this call waits for a run
+        // ahead of it.
+        let _wp_op_guard = self.main_wp_lock.lock().await;
+        if *self.project_locked.read().await {
+            return Err(project_locked_error(
+                "reload_project",
+                "Project is locked. reload_project is blocked during Phase 2 to prevent annotation loss. \
+                 If you are verifying in a sandbox, do NOT call reload_project; use create_sandbox or delete_sandbox instead. \
+                 Call verify_program_step with lock_project=false first if this is the final main-project gate.",
+            ));
+        }
+
         let previous_markers = {
             let client = self.client.lock().await.clone();
             match client {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2754,6 +2754,17 @@ impl FramaCMcpServer {
                 .ok_or_else(|| sandbox_not_found_err(exp_id, &sandboxes.keys()))?
         };
 
+        // A delete can still land after this point: cleanup_sandbox never
+        // takes wp_lock, on purpose. A WP run can hold this lock for tens
+        // of minutes, and delete_sandbox is the force-kill escape for a
+        // wedged sandbox, so queuing deletion behind the lock would remove
+        // the only way to kill one. A delete that lands mid-run kills the
+        // process group, and the next request on this client fails with a
+        // broken pipe rather than silently corrupting the run. The cloned
+        // client is bound to the killed process's pipes, so it can never
+        // reach a sandbox recreated under the same id, and sandbox clients
+        // never respawn (that path is main-instance-only), so nothing
+        // outlives the kill.
         self.apply_wp_config(&client, params, requested_provers.as_ref())
             .await?;
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1849,6 +1849,19 @@ impl SandboxRegistry {
             .map(|entry| entry.runtime.wp_lock.clone())
     }
 
+    /// The client only while the entry still owns this exact lock. A waiter
+    /// holding a cloned Arc must not send requests to a client it resolved
+    /// before the wait when the entry was removed, or removed and recreated
+    /// under the same id, in between.
+    fn client_if_current(
+        &self,
+        experiment_id: &str,
+        lock: &Arc<AsyncMutex<()>>,
+    ) -> Option<Arc<FramaCClient>> {
+        let entry = self.entries.get(experiment_id)?;
+        Arc::ptr_eq(&entry.runtime.wp_lock, lock).then(|| entry.runtime.client.clone())
+    }
+
     pub fn metadata_list(&self) -> Vec<SandboxMetadata> {
         self.entries
             .values()
@@ -2664,8 +2677,6 @@ impl FramaCMcpServer {
                 None,
             ));
         };
-        let resolved = self.resolve_client(first).await?;
-        let client = &resolved.client;
         let mut target_names = Vec::new();
         for name in names {
             match scope_for_function(name) {
@@ -2730,28 +2741,24 @@ impl FramaCMcpServer {
         };
         let _wp_op_guard = wp_lock.lock().await;
 
-        // A delete_sandbox that landed while this call waited has already
-        // removed the entry and killed the process; the cloned Arc above
-        // kept the lock alive, so acquiring it says nothing about the
-        // sandbox still existing. Re-check membership before touching the
-        // client: same id, and the same lock instance, since a re-created
-        // sandbox under a reused id gets a fresh lock this waiter never
-        // queued for.
-        {
+        // The client comes from the same registry read that revalidates the
+        // lock. A delete_sandbox that landed while this call waited has
+        // already removed the entry and killed the process, and a sandbox
+        // recreated under the same id owns a fresh lock and a fresh client;
+        // either way a client resolved before the wait belongs to a process
+        // this transaction must not talk to.
+        let client = {
             let sandboxes = self.sandboxes.read().await;
-            let still_registered = sandboxes
-                .wp_lock(exp_id)
-                .is_some_and(|current| Arc::ptr_eq(&current, &wp_lock));
-            if !still_registered {
-                return Err(sandbox_not_found_err(exp_id, &sandboxes.keys()));
-            }
-        }
+            sandboxes
+                .client_if_current(exp_id, &wp_lock)
+                .ok_or_else(|| sandbox_not_found_err(exp_id, &sandboxes.keys()))?
+        };
 
-        self.apply_wp_config(client, params, requested_provers.as_ref())
+        self.apply_wp_config(&client, params, requested_provers.as_ref())
             .await?;
 
         let funcs = reload_fetch(
-            client,
+            &client,
             "kernel.ast.reloadFunctions",
             "kernel.ast.fetchFunctions",
         )
@@ -2773,12 +2780,12 @@ impl FramaCMcpServer {
                     .ok_or_else(|| McpError::from(FramaCError::FunctionNotFound(function.clone())))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let protocol_diagnostics = start_wp_proofs(client, Some(&decl_markers)).await?;
+        let protocol_diagnostics = start_wp_proofs(&client, Some(&decl_markers)).await?;
 
-        let tasks = drain_wp_tasks(client, WP_DRAIN_BUDGET).await?;
+        let tasks = drain_wp_tasks(&client, WP_DRAIN_BUDGET).await?;
         let report_function = (names.len() == 1).then(|| target_names[0].as_str());
         let wp_goals = reload_fetch(
-            client,
+            &client,
             "plugins.wp.reloadGoals",
             "plugins.wp.fetchGoals",
         )
@@ -2805,7 +2812,7 @@ impl FramaCMcpServer {
         // The property table read here is the sandbox's own, which is the only
         // difference from the main path.
         self.attach_run_wp_receipt(
-            client,
+            &client,
             &mut response,
             source_files,
             &wp_goals,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1808,7 +1808,8 @@ struct SandboxRuntime {
     child: Arc<AsyncMutex<Option<tokio::process::Child>>>,
     /// Same role as the server's main_wp_lock, for this sandbox's process:
     /// one run_wp transaction (config, schedule, drain, fetch) at a time.
-    /// Kept on the entry so delete_sandbox drops the lock with the sandbox.
+    /// Waiters clone the Arc, so the lock can outlive the entry it came
+    /// from; run_wp_on_sandbox re-checks membership after acquiring it.
     wp_lock: Arc<AsyncMutex<()>>,
 }
 
@@ -2720,6 +2721,23 @@ impl FramaCMcpServer {
                 .ok_or_else(|| sandbox_not_found_err(exp_id, &sandboxes.keys()))?
         };
         let _wp_op_guard = wp_lock.lock().await;
+
+        // A delete_sandbox that landed while this call waited has already
+        // removed the entry and killed the process; the cloned Arc above
+        // kept the lock alive, so acquiring it says nothing about the
+        // sandbox still existing. Re-check membership before touching the
+        // client: same id, and the same lock instance, since a re-created
+        // sandbox under a reused id gets a fresh lock this waiter never
+        // queued for.
+        {
+            let sandboxes = self.sandboxes.read().await;
+            let still_registered = sandboxes
+                .wp_lock(exp_id)
+                .is_some_and(|current| Arc::ptr_eq(&current, &wp_lock));
+            if !still_registered {
+                return Err(sandbox_not_found_err(exp_id, &sandboxes.keys()));
+            }
+        }
 
         self.apply_wp_config(client, params, requested_provers.as_ref())
             .await?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2083,10 +2083,9 @@ async fn reload_fetch(
     fetch_request: &str,
 ) -> Result<Vec<serde_json::Value>, McpError> {
     client
-        .get(reload_request, json!(null))
+        .reload_fetch(reload_request, fetch_request)
         .await
-        .map_err(McpError::from)?;
-    client.fetch_all(fetch_request).await.map_err(McpError::from)
+        .map_err(McpError::from)
 }
 
 /// Every property Frama-C holds, enriched the way every reader of them wants.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1972,6 +1972,15 @@ pub struct FramaCMcpServer {
     /// the union of the shared goal table, so each reports goals it never
     /// scheduled. Held from before apply_wp_config to the end of the handler.
     ///
+    /// What a waiter can end up waiting on: the proof loop budgets
+    /// WP_PROOF_BUDGET (600s) per function, the drain up to WP_DRAIN_BUDGET,
+    /// and the timeout-retry pass runs proof and drain again, so a stuck
+    /// multi-function run holds this far past any client timeout.
+    /// reload_project (re-parse) and verify_program_step (the lock write)
+    /// queue here too, and the re-parse has no budget of its own. A
+    /// disconnected MCP client shortens none of this: request cancellation
+    /// is cooperative, so the handler runs to completion.
+    ///
     /// cancel_wp_queue stays outside this lock on purpose: it is the way out
     /// of a run that is holding it, and taking the lock there would deadlock
     /// the escape.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1806,6 +1806,10 @@ pub struct ProjectLoadOptions {
 struct SandboxRuntime {
     client: Arc<FramaCClient>,
     child: Arc<AsyncMutex<Option<tokio::process::Child>>>,
+    /// Same role as the server's main_wp_lock, for this sandbox's process:
+    /// one run_wp transaction (config, schedule, drain, fetch) at a time.
+    /// Kept on the entry so delete_sandbox drops the lock with the sandbox.
+    wp_lock: Arc<AsyncMutex<()>>,
 }
 
 #[derive(Clone)]
@@ -1838,6 +1842,12 @@ impl SandboxRegistry {
         })
     }
 
+    fn wp_lock(&self, experiment_id: &str) -> Option<Arc<AsyncMutex<()>>> {
+        self.entries
+            .get(experiment_id)
+            .map(|entry| entry.runtime.wp_lock.clone())
+    }
+
     pub fn metadata_list(&self) -> Vec<SandboxMetadata> {
         self.entries
             .values()
@@ -1858,6 +1868,7 @@ impl SandboxRegistry {
                 runtime: SandboxRuntime {
                     client,
                     child: Arc::new(AsyncMutex::new(Some(child))),
+                    wp_lock: Arc::new(AsyncMutex::new(())),
                 },
             },
         );
@@ -1951,6 +1962,21 @@ pub struct FramaCMcpServer {
     /// apart, so the waiter reads this counter before scheduling and again
     /// after draining, and a change means somebody stopped its run.
     wp_cancel_epoch: Arc<std::sync::atomic::AtomicU64>,
+    /// Held across a whole run_wp transaction on the main instance: config,
+    /// schedule, drain, and goal fetch.
+    ///
+    /// WP's config, scheduler, and goal table are process-global state, while
+    /// the client mutex covers one request only. Two runs that interleave see
+    /// the second one's config govern the first one's goals, and both fetch
+    /// the union of the shared goal table, so each reports goals it never
+    /// scheduled. Held from before apply_wp_config to the end of the handler.
+    ///
+    /// cancel_wp_queue stays outside this lock on purpose: it is the way out
+    /// of a run that is holding it, and taking the lock there would deadlock
+    /// the escape.
+    ///
+    /// Outermost lock: taken before the client lock, never inside it.
+    main_wp_lock: Arc<AsyncMutex<()>>,
     tool_router: ToolRouter<Self>,
 }
 
@@ -2522,6 +2548,7 @@ impl FramaCMcpServer {
             main_spawn_lock: Arc::new(AsyncMutex::new(())),
             project_locked: Arc::new(RwLock::new(false)),
             wp_cancel_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            main_wp_lock: Arc::new(AsyncMutex::new(())),
             tool_router: Self::tool_router(),
         }
     }
@@ -2681,6 +2708,18 @@ impl FramaCMcpServer {
                 })
                 .await;
         }
+
+        // One WP transaction per sandbox process, same reason as main_wp_lock
+        // on the main path: config through goal fetch must not interleave with
+        // a second run on this sandbox. The registry read ends before the
+        // await, so the registry lock plays no part in the hold.
+        let wp_lock = {
+            let sandboxes = self.sandboxes.read().await;
+            sandboxes
+                .wp_lock(exp_id)
+                .ok_or_else(|| sandbox_not_found_err(exp_id, &sandboxes.keys()))?
+        };
+        let _wp_op_guard = wp_lock.lock().await;
 
         self.apply_wp_config(client, params, requested_provers.as_ref())
             .await?;


### PR DESCRIPTION
## Problem

A `run_wp` call is a multi-request transaction over process-global WP state: `apply_wp_config` (provers, timeout, cache mode, memory model) → schedule → drain → fetch the instance-wide goal table. The client mutex covers a single request only, so two concurrent `run_wp` calls interleave: the later run's config overwrites the earlier one's before its proofs are scheduled, and both runs drain the same queue and fetch the same shared goal table. Each response then reports goals it never scheduled, with no error anywhere.

Protocol trace of concurrent `run_wp(foo)` and `run_wp(bar)` on HEAD:

```
RQ.15 SET setTimeout          (run A)
RQ.16 SET setTimeout          (run B, overwrites A)
RQ.17/18 SET setCacheMode     (A, then B)
RQ.19/20 EXEC execSetWpConfig (A, then B)
RQ.27/28 EXEC startProofs     (both runs prove under B's configuration)
```

Both responses contained the other run's goals.

## Fix

Hold a per-instance async mutex across the whole transaction:

- `main_wp_lock` on the server for the main instance
- `wp_lock` on each sandbox entry (sandbox processes are independent, so runs on different sandboxes still proceed in parallel)

`cancel_wp_queue` deliberately takes no lock: it is the escape from a run that is holding one. The same trace with this branch shows A's full transaction completing before B's first config write, and each response carries only its own run's data.

Out of scope, noted for follow-up: `inject_all_annotations` does not take this lock, so an annotation injection can still interleave with a proof run on the same instance.

## Testing

- Full suite on Frama-C 33.0 / why3 1.8.2 / Alt-Ergo 2.6.3 / Z3 4.13.3: 534 tests pass (unit 370, integration 12, mcp-stdio 89, process-lifecycle 43, reload-project-regression 10, store-conclusion 10)
- `cargo clippy --all-targets` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where concurrent `run_wp` calls on the same instance interleaved their config, schedule, drain, and goal-fetch steps, causing each response to report goals from other runs. Each `run_wp` transaction now holds a per-instance async mutex for its full duration, `reload_project` on the main instance takes the same lock, and reload-fetch pairs hold their own lock so concurrent readers cannot split the shared table cursor.

**Bug Fixes**

- Two interleaved runs previously overwrote each other's config mid-flight and both drained the same shared goal table; each response reported goals it never scheduled.
- The main instance uses a server-level `main_wp_lock`; each sandbox process holds its own `wp_lock`, and after acquiring it the waiter rechecks the sandbox still exists and resolves the client from the revalidated entry, because `delete_sandbox` may have removed or recreated it while it waited.
- `reload_project` takes the main lock, and reload-fetch pairs hold a per-client `fetch_lock`, because the shared table cursor can otherwise be split mid-reload and read as "everything proved"; the reload health check takes the same lock directly so each step keeps its own error label.
- The project-lock write and the post-wait flag recheck both hold the lock, so `verify_program_step` cannot set the flag while a run that already rechecked it is still mid-flight.
- `cancel_wp_queue` deliberately takes no lock, so a run stuck in drain can still be cancelled.
- `inject_all_annotations` does not take this lock, so annotation injection can still interleave with a proof run on the same instance.

<sup>Written for commit a6f83963ce783a8e12d7e2e78968fcdac89b721b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/frama-c-mcp/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

