### PR TITLE
Respawn the session when the transport is poisoned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,7 @@ jobs:
           cargo test --test test-process-lifecycle -- --test-threads=1
           cargo test --test test-reload-project-regression -- --test-threads=1
           cargo test --test test-store-conclusion -- --test-threads=1
+          cargo test --test test-transport-poison-recovery -- --test-threads=1
 
       - name: MCP stdio E2E tests
         id: stdio

--- a/scripts/run-gates.sh
+++ b/scripts/run-gates.sh
@@ -92,6 +92,7 @@ want integration && run integration cargo test --test test-integration -- --test
 want lifecycle && run lifecycle cargo test --test test-process-lifecycle -- --test-threads=1
 want reload && run reload cargo test --test test-reload-project-regression -- --test-threads=1
 want store && run store cargo test --test test-store-conclusion -- --test-threads=1
+want poison && run poison cargo test --test test-transport-poison-recovery -- --test-threads=1
 want abs-int && run abs-int scripts/check-abs-int-fixtures.sh
 want wp-model && run wp-model scripts/check-wp-model-fixtures.sh
 want artifacts && run artifacts scripts/check-artifacts.sh

--- a/src/frama-c/client.rs
+++ b/src/frama-c/client.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, RwLock};
 
@@ -353,6 +354,10 @@ pub struct FramaCClient {
     /// but a reload and the fetch behind it are two requests, and the table
     /// cursor they share is process-global.
     fetch_lock: Mutex<()>,
+    /// The transport's poison flag, shared with the Transport inside
+    /// `inner` so ensure_main_spawned can read it without taking the
+    /// request lock.
+    poisoned: Arc<AtomicBool>,
 }
 
 impl FramaCClient {
@@ -361,6 +366,7 @@ impl FramaCClient {
         state: Arc<RwLock<SessionState>>,
     ) -> Result<Self, FramaCError> {
         let transport = Transport::connect(path).await?;
+        let poisoned = transport.poison_flag();
         let mut inner = ClientInner {
             transport,
             counter: 0,
@@ -418,6 +424,7 @@ impl FramaCClient {
         let client = FramaCClient {
             inner: Mutex::new(inner),
             fetch_lock: Mutex::new(()),
+            poisoned,
         };
 
         // Auto-fetch function info to populate marker cache
@@ -429,6 +436,14 @@ impl FramaCClient {
         }
 
         Ok(client)
+    }
+
+    /// Whether the transport under this client can no longer carry a
+    /// frame. Read straight off the shared flag rather than through
+    /// `inner`: ensure_main_spawned asks while holding the client slot,
+    /// and the answer does not depend on the request in flight.
+    pub fn is_poisoned(&self) -> bool {
+        self.poisoned.load(Ordering::Relaxed)
     }
 
     pub async fn get(

--- a/src/frama-c/transport.rs
+++ b/src/frama-c/transport.rs
@@ -1,4 +1,6 @@
 use bytes::{Buf, BufMut, BytesMut};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
@@ -25,15 +27,13 @@ pub struct Transport {
     /// on every later use; recovery is a new Transport, which the session
     /// gets through the respawn path in ensure_main_spawned.
     ///
-    /// The respawn is not automatic yet. ensure_main_spawned decides
-    /// in-place vs respawn from MainFramaCState alone and never looks at
-    /// this flag, so the first reload with explicit files still fails in
-    /// place (which marks the session poisoned) and only the second one
-    /// respawns; a reload without files never gets that far, because it
-    /// asks this dead transport for the current file list first. Sandbox
-    /// clients have no respawn path at all. Surfacing this flag to the
-    /// respawn decision is a planned follow-up.
-    poisoned: bool,
+    /// Shared with the FramaCClient that owns this transport, so
+    /// ensure_main_spawned can read it without taking the request lock.
+    /// It is the last disjunct of the respawn decision there, so the first
+    /// reload with files respawns instead of failing in place and marking
+    /// the session poisoned for the next caller to find. Sandbox clients
+    /// still have no respawn path at all.
+    poisoned: Arc<AtomicBool>,
 }
 
 impl Transport {
@@ -42,12 +42,12 @@ impl Transport {
         Ok(Transport {
             stream,
             read_buf: BytesMut::with_capacity(8192),
-            poisoned: false,
+            poisoned: Arc::new(AtomicBool::new(false)),
         })
     }
 
     pub async fn send_frame(&mut self, payload: &str) -> Result<(), FramaCError> {
-        if self.poisoned {
+        if self.poisoned.load(Ordering::Relaxed) {
             return Err(poisoned_transport());
         }
         let frame = codec::encode_frame(payload);
@@ -62,7 +62,7 @@ impl Transport {
         &mut self,
         timeout: Duration,
     ) -> Result<Option<String>, FramaCError> {
-        if self.poisoned {
+        if self.poisoned.load(Ordering::Relaxed) {
             return Err(poisoned_transport());
         }
         loop {
@@ -97,9 +97,16 @@ impl Transport {
     /// completion can have left a partial frame in the socket, and no
     /// later frame may follow it on this stream.
     async fn poison(&mut self, error: FramaCError) -> FramaCError {
-        self.poisoned = true;
+        self.poisoned.store(true, Ordering::Relaxed);
         let _ = self.stream.shutdown().await;
         error
+    }
+
+    /// A shared handle on the poison flag. The FramaCClient takes one at
+    /// connect so it can answer is_poisoned without taking the request
+    /// lock that guards this transport.
+    pub fn poison_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.poisoned)
     }
 }
 

--- a/src/frama-c/transport.rs
+++ b/src/frama-c/transport.rs
@@ -18,14 +18,19 @@ const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct Transport {
     stream: UnixStream,
     read_buf: BytesMut,
-    /// Set when a frame write failed or timed out part-way through.
+    /// Set when a frame write failed or timed out part-way through, or the
+    /// read side saw the peer die (EOF or a read error).
     ///
     /// write_all is not cancellation-safe: the socket may already hold a
     /// prefix of that frame, so the next write would append a fresh frame
     /// onto it and corrupt the length-prefixed protocol for every later
     /// command. Poisoning turns that silent corruption into a fast error
     /// on every later use; recovery is a new Transport, which the session
-    /// gets through the respawn path in ensure_main_spawned.
+    /// gets through the respawn path in ensure_main_spawned. Read-side
+    /// death poisons too: after EOF the peer is gone for good, and a read
+    /// error leaves the stream state unknowable. A read that merely times
+    /// out does NOT poison; the poll loop times out routinely on healthy
+    /// servers.
     ///
     /// Shared with the FramaCClient that owns this transport, so
     /// ensure_main_spawned can read it without taking the request lock.
@@ -73,15 +78,17 @@ impl Transport {
             let mut tmp = [0u8; 4096];
             match tokio::time::timeout(timeout, self.stream.read(&mut tmp)).await {
                 Ok(Ok(0)) => {
-                    return Err(FramaCError::Io(std::io::Error::new(
-                        std::io::ErrorKind::UnexpectedEof,
-                        "connection closed",
-                    )));
+                    return Err(self
+                        .poison(FramaCError::Io(std::io::Error::new(
+                            std::io::ErrorKind::UnexpectedEof,
+                            "connection closed",
+                        )))
+                        .await);
                 }
                 Ok(Ok(n)) => {
                     self.read_buf.put_slice(&tmp[..n]);
                 }
-                Ok(Err(e)) => return Err(FramaCError::Io(e)),
+                Ok(Err(e)) => return Err(self.poison(FramaCError::Io(e)).await),
                 Err(_) => return Ok(None),
             }
         }
@@ -95,7 +102,8 @@ impl Transport {
     /// Mark the stream unusable and close our end of it, returning the
     /// error the caller should see. Any write that did not run to
     /// completion can have left a partial frame in the socket, and no
-    /// later frame may follow it on this stream.
+    /// later frame may follow it on this stream; a read that ended in EOF
+    /// or an error means the peer is gone, which is just as final.
     async fn poison(&mut self, error: FramaCError) -> FramaCError {
         self.poisoned.store(true, Ordering::Relaxed);
         let _ = self.stream.shutdown().await;

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -174,6 +174,35 @@ impl FramaCMcpServer {
             (None, None) => {
                 let client_opt = self.client.lock().await.clone();
                 match client_opt {
+                    Some(c) if c.is_poisoned() => {
+                        // The dead transport cannot answer getFiles, so the
+                        // file list comes from the session's cache of the
+                        // last load instead. ensure_main_spawned reads the
+                        // same flag and respawns, which is what makes the
+                        // fallback a recovery rather than a stale answer.
+                        let files = self
+                            .main_frama_c_state
+                            .lock()
+                            .await
+                            .as_ref()
+                            .map(|s| s.files.clone())
+                            .unwrap_or_default();
+                        if files.is_empty() {
+                            return Err(McpError::internal_error(
+                                "the Frama-C transport is poisoned and no file list is cached; \
+                                 pass files explicitly to reload_project to recover",
+                                Some(json!({
+                                    "kind": "TransportPoisoned",
+                                    "retryable": true,
+                                    "suggestion": {
+                                        "tool": "reload_project",
+                                        "args_example": { "files": ["/path/to/source.c"] }
+                                    }
+                                })),
+                            ));
+                        }
+                        files
+                    }
                     Some(c) => {
                         let v = c
                             .get("kernel.ast.getFiles", json!(null))

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1774,6 +1774,10 @@ pub struct MainFramaCState {
     /// respawning immediately: the call that fails should report the user's
     /// actual error, and a syntax error the caller is about to fix does not
     /// deserve a spawn nobody waits for.
+    ///
+    /// The transport's own poison flag feeds the same decision: a frame
+    /// write that died part-way means this client can no longer carry a
+    /// request either, whatever this field says.
     pub poisoned: bool,
 }
 
@@ -3023,7 +3027,13 @@ impl FramaCMcpServer {
         let needs_respawn = match main_lock.as_ref() {
             None => true,
             Some(s) => {
-                s.poisoned || s.with_rte != new_rte || s.project_options != new_project_options
+                // The last disjunct is the transport's own flag: a write
+                // that died part-way poisons the stream without touching
+                // any of the session fields above.
+                s.poisoned
+                    || s.with_rte != new_rte
+                    || s.project_options != new_project_options
+                    || client_lock.as_ref().is_some_and(|c| c.is_poisoned())
             }
         };
 

--- a/tests/test-transport-poison-recovery.rs
+++ b/tests/test-transport-poison-recovery.rs
@@ -1,0 +1,216 @@
+//! Regression tests for session recovery after the transport is poisoned.
+//!
+//! A frame write that fails part-way poisons the transport: the socket may
+//! already hold a prefix of the frame, so nothing may follow it. The
+//! respawn decision used to look only at the session fields, so a reload
+//! with explicit files failed in place on the first call and only the
+//! second respawned, and a reload without files failed forever because it
+//! asked the dead transport for the current file list before ever reaching
+//! that decision.
+//!
+//! The failure is staged for real: spawn the main instance, SIGKILL it,
+//! and let the next request turn EPIPE into the poisoned state. There are
+//! no sleeps: the socket answering ECONNREFUSED is the kernel's proof that
+//! the process is gone, and everything after that is immediate.
+//!
+//! In-process rather than over stdio, because the assertions need the main
+//! instance's pid, which main_frama_c_state exposes and the wire does not.
+//! A separate target from tests/unit, so the redness check can run this
+//! against the unfixed sources: the unit target references the new
+//! accessors and stops compiling there, while this file uses only the API
+//! that already existed and so fails by red test, not by red build.
+
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rmcp::handler::server::wrapper::Parameters;
+use serde_json::json;
+use tokio::sync::RwLock;
+
+use frama_c_mcp::error::FramaCError;
+use frama_c_mcp::mcp::server::FramaCMcpServer;
+use frama_c_mcp::mcp::types::ReloadProjectParams;
+use frama_c_mcp::state::SessionState;
+
+/// The smallest fixture with a named function the reload response lists.
+fn fixture_file() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/test_abs.c");
+    assert!(path.exists(), "fixture missing: {}", path.display());
+    path.display().to_string()
+}
+
+fn reload_params(files: Option<Vec<String>>) -> Parameters<ReloadProjectParams> {
+    Parameters(ReloadProjectParams {
+        files,
+        include_paths: None,
+        defines: None,
+        force_includes: None,
+        machdep: None,
+        detail: None,
+        compilation_database: None,
+        rte: None,
+    })
+}
+
+/// A server holding one live main instance with the fixture loaded.
+async fn server_with_project() -> FramaCMcpServer {
+    let state = Arc::new(RwLock::new(SessionState::default()));
+    let server = FramaCMcpServer::new_lazy(state, "frama-c".to_string(), 4);
+    let loaded = server
+        .reload_project(reload_params(Some(vec![fixture_file()])))
+        .await
+        .expect("the initial load spawns a healthy instance");
+    assert!(
+        !loaded.is_error.unwrap_or(false),
+        "the initial load reported a tool error"
+    );
+    server
+}
+
+async fn current_main_pid(server: &FramaCMcpServer) -> u32 {
+    server
+        .main_frama_c_state()
+        .lock()
+        .await
+        .as_ref()
+        .expect("main state")
+        .pid
+}
+
+/// SIGKILL the main Frama-C and wait until the kernel has torn it down,
+/// returning the pid that is gone.
+///
+/// The wait is the socket refusing a connect, not a sleep. The path
+/// outlives its listener (MainFramaCState::drop unlinks it and nothing has
+/// dropped here), but while the process lives a connect succeeds off the
+/// backlog, and once exit has closed every descriptor the path answers
+/// ECONNREFUSED. That refusal is the proof the transport's peer is gone,
+/// so the write below cannot be buffered: it fails with EPIPE at once.
+/// kill(pid, 0) cannot stand in here; nothing reaps the child until the
+/// respawn, so the pid still answers as a zombie.
+async fn kill_main_frama_c(server: &FramaCMcpServer) -> u32 {
+    let (pid, socket_path) = {
+        let state = server.main_frama_c_state();
+        let guard = state.lock().await;
+        let main = guard.as_ref().expect("main state after the initial load");
+        (main.pid, main.socket_path.clone())
+    };
+    let killed = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+    assert_eq!(
+        killed,
+        0,
+        "SIGKILL {pid}: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Err(error) = std::os::unix::net::UnixStream::connect(&socket_path) {
+            if error.kind() == ErrorKind::ConnectionRefused {
+                return pid;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "frama-c {pid} still answers its socket 10s after SIGKILL"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Turn the dead peer into the poisoned state, and prove the state took:
+/// the next call fails fast with the poison reason. Without this proof the
+/// recovery assertions below could be running against a healthy transport
+/// and mean nothing.
+async fn poison_transport(server: &FramaCMcpServer) {
+    let client = server
+        .require_client()
+        .await
+        .expect("client after the initial load");
+
+    let error = client
+        .get("kernel.ast.getFiles", json!(null))
+        .await
+        .expect_err("a write whose peer is gone");
+    match error {
+        FramaCError::Io(_) => {}
+        other => panic!("expected an io error, got {other:?}"),
+    }
+
+    let started = Instant::now();
+    let error = client
+        .get("kernel.ast.getFiles", json!(null))
+        .await
+        .expect_err("a poisoned transport answered a request");
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "a poisoned call waited on the socket: {:?}",
+        started.elapsed()
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("transport poisoned by an incomplete frame write"),
+        "the transport was not poisoned: {error}"
+    );
+}
+
+/// The first reload with files after the poison respawns, rather than
+/// failing in place with BrokenPipe and leaving the respawn to a second
+/// call.
+#[tokio::test]
+async fn an_explicit_reload_respawns_a_poisoned_transport() {
+    let server = server_with_project().await;
+    let dead_pid = kill_main_frama_c(&server).await;
+    poison_transport(&server).await;
+
+    let recovered = server
+        .reload_project(reload_params(Some(vec![fixture_file()])))
+        .await
+        .expect("a single explicit reload must recover the session");
+    assert!(
+        !recovered.is_error.unwrap_or(false),
+        "the recovery reload reported a tool error"
+    );
+    assert_ne!(
+        current_main_pid(&server).await,
+        dead_pid,
+        "recovery reloaded the dead process in place instead of respawning"
+    );
+}
+
+/// A reload without files reads the cached file list instead of asking the
+/// dead transport for one, and recovers through the same respawn.
+#[tokio::test]
+async fn a_no_arg_reload_falls_back_to_the_cached_file_list() {
+    let server = server_with_project().await;
+    let dead_pid = kill_main_frama_c(&server).await;
+    poison_transport(&server).await;
+
+    let recovered = server
+        .reload_project(reload_params(None))
+        .await
+        .expect("a no-arg reload must recover through the cached file list");
+    assert!(
+        !recovered.is_error.unwrap_or(false),
+        "the recovery reload reported a tool error"
+    );
+    assert_ne!(
+        current_main_pid(&server).await,
+        dead_pid,
+        "recovery reloaded the dead process in place instead of respawning"
+    );
+
+    // The respawned instance reloaded the cached list, so the fixture's
+    // function is back in the response.
+    let result = serde_json::to_value(&recovered).expect("serialize the result");
+    let text = result["content"][0]["text"]
+        .as_str()
+        .expect("the reload response carries its payload as text");
+    assert!(
+        text.contains("abs_val"),
+        "the cached file was not reloaded: {text}"
+    );
+}

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -38,3 +38,5 @@ mod types;
 mod frama_c_client;
 #[path = "unit/frama-c-codec.rs"]
 mod frama_c_codec;
+#[path = "unit/frama-c-transport.rs"]
+mod frama_c_transport;

--- a/tests/unit/frama-c-transport.rs
+++ b/tests/unit/frama-c-transport.rs
@@ -1,0 +1,78 @@
+use std::io::ErrorKind;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use frama_c_mcp::error::FramaCError;
+use frama_c_mcp::frama_c::transport::Transport;
+
+/// A write that dies part-way poisons the transport, and every later frame
+/// in either direction fails fast with the reason rather than waiting on
+/// the dead peer.
+///
+/// The peer is closed rather than wedged, because the close is
+/// deterministic: on Linux the next write on an AF_UNIX stream whose peer
+/// is gone answers EPIPE at once, where a stalled write would need the
+/// write timeout and a wall-clock budget. This is the transport half of
+/// poison recovery; the session half is in
+/// tests/test-transport-poison-recovery.rs.
+#[tokio::test]
+async fn a_failed_write_poisons_every_later_frame() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket = dir.path().join("peer-gone.sock");
+    let listener = tokio::net::UnixListener::bind(&socket).expect("bind");
+
+    let mut transport = Transport::connect(socket.to_str().expect("utf8 path"))
+        .await
+        .expect("connect to the listener");
+    let (peer, _) = listener.accept().await.expect("accept");
+
+    // close(2) is synchronous: once the peer drops, this stream has no
+    // other end and the kernel refuses the next write rather than
+    // buffering it.
+    drop(peer);
+
+    // The failing write reports the kernel's error, not the poison
+    // message: poison() returns the error the caller should see, and the
+    // fixed text below is for the calls after it.
+    let error = transport
+        .send_frame("{}")
+        .await
+        .expect_err("a write whose peer is gone");
+    match error {
+        FramaCError::Io(error) => {
+            assert_eq!(error.kind(), ErrorKind::BrokenPipe, "{error}");
+        }
+        other => panic!("expected an io error, got {other:?}"),
+    }
+
+    assert!(
+        transport.poison_flag().load(Ordering::Relaxed),
+        "the failed write did not set the flag every later call checks"
+    );
+
+    // Both directions answer at once with the reason, and neither waits:
+    // recv_frame is handed a budget it must not spend.
+    let started = Instant::now();
+    let send = transport
+        .send_frame("{}")
+        .await
+        .expect_err("a poisoned transport accepted a frame");
+    let recv = transport
+        .recv_frame(Duration::from_secs(60))
+        .await
+        .expect_err("a poisoned transport waited for a frame");
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "poisoned calls waited on the socket: {:?}",
+        started.elapsed()
+    );
+    for error in [send, recv] {
+        match error {
+            FramaCError::Io(error) => assert_eq!(
+                error.to_string(),
+                "transport poisoned by an incomplete frame write"
+            ),
+            other => panic!("expected an io error, got {other:?}"),
+        }
+    }
+}

--- a/tests/unit/frama-c-transport.rs
+++ b/tests/unit/frama-c-transport.rs
@@ -76,3 +76,92 @@ async fn a_failed_write_poisons_every_later_frame() {
         }
     }
 }
+
+/// A peer that dies while a frame is being waited for poisons the
+/// transport exactly like a failed write does: after EOF the stream has
+/// no live end, so the flag both session recovery paths gate on must be
+/// set on this path too. This is the common crash shape: a server that
+/// aborts or is OOM-killed mid-computation is observed by the in-flight
+/// read, not by a later write.
+#[tokio::test]
+async fn a_peer_death_mid_read_poisons_every_later_frame() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket = dir.path().join("peer-dies-mid-read.sock");
+    let listener = tokio::net::UnixListener::bind(&socket).expect("bind");
+
+    let mut transport = Transport::connect(socket.to_str().expect("utf8 path"))
+        .await
+        .expect("connect to the listener");
+    let (peer, _) = listener.accept().await.expect("accept");
+
+    // Die while the transport is blocked in read: close(2) makes the
+    // pending read answer EOF at once, deterministically.
+    drop(peer);
+
+    let error = transport
+        .recv_frame(Duration::from_secs(60))
+        .await
+        .expect_err("a read whose peer is gone");
+    match error {
+        FramaCError::Io(error) => {
+            assert_eq!(error.kind(), ErrorKind::UnexpectedEof, "{error}");
+        }
+        other => panic!("expected an io error, got {other:?}"),
+    }
+
+    assert!(
+        transport.poison_flag().load(Ordering::Relaxed),
+        "the read-side death did not set the flag recovery gates on"
+    );
+
+    // Later frames in both directions fail fast with the reason.
+    let started = Instant::now();
+    let send = transport
+        .send_frame("{}")
+        .await
+        .expect_err("a poisoned transport accepted a frame");
+    let recv = transport
+        .recv_frame(Duration::from_secs(60))
+        .await
+        .expect_err("a poisoned transport waited for a frame");
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "poisoned calls waited on the socket: {:?}",
+        started.elapsed()
+    );
+    for error in [send, recv] {
+        match error {
+            FramaCError::Io(error) => assert_eq!(
+                error.to_string(),
+                "transport poisoned by an incomplete frame write"
+            ),
+            other => panic!("expected an io error, got {other:?}"),
+        }
+    }
+}
+
+/// A read that merely times out is routine (the poll loop does this
+/// constantly on healthy servers) and must not poison the transport.
+#[tokio::test]
+async fn a_read_timeout_does_not_poison() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket = dir.path().join("slow-peer.sock");
+    let listener = tokio::net::UnixListener::bind(&socket).expect("bind");
+
+    let mut transport = Transport::connect(socket.to_str().expect("utf8 path"))
+        .await
+        .expect("connect to the listener");
+    let (_peer, _) = listener.accept().await.expect("accept");
+
+    // The peer stays open but silent: the read spends its budget and
+    // reports no frame, which is not an error and not a death.
+    let frame = transport
+        .recv_frame(Duration::from_millis(50))
+        .await
+        .expect("a timeout is not an error");
+    assert!(frame.is_none(), "a silent peer sent a frame");
+    assert!(
+        !transport.poison_flag().load(Ordering::Relaxed),
+        "a routine read timeout poisoned the transport"
+    );
+}


### PR DESCRIPTION
Depends on #10 (this branch contains its commits until that lands; rebased onto main after #11 merged, and will rebase again once #10 lands).

## Problem

#10 made an incomplete frame write poison the transport, so later calls fail
fast instead of corrupting the protocol. But the session cannot recover
cleanly from that state:

- `ensure_main_spawned` decides in-place vs respawn from `MainFramaCState`
  alone and never inspects the transport. The first `reload_project` with
  explicit files still attempts an in-place reload on the dead transport,
  fails with BrokenPipe, and only then marks the session poisoned — recovery
  takes two calls.
- A no-arg `reload_project` never reaches `ensure_main_spawned` at all: its
  file resolution calls `kernel.ast.getFiles` on the dead transport first
  (`src/mcp/project.rs`), so the most natural retry fails forever.
- `check` with `files=None` hits the same wall through its internal
  `reload_project` call.
- Every other tool fails fast with a `retryable: false` error that names no
  remedy, even though a respawn would fix it.
- Until the last commit, the hole was wider: a server that dies
  mid-computation is observed by the in-flight READ (EOF), and
  `recv_frame` did not set the poison flag there, so the common crash
  shape deferred recovery by yet another call.

## Reproduction

Regression tests in `tests/test-transport-poison-recovery.rs` run a real
Frama-C 33.0, SIGKILL the main instance, and let one `getFiles` turn the
resulting EPIPE into a poisoned transport (deterministic — no timeouts, no
sleeps). Against the parent commit with only `src/` reverted, both tests
fail with the bug's exact signature:

- `a single explicit reload must recover the session:
  I/O error: transport poisoned by an incomplete frame write`
- same failure for the no-arg reload

The read-side half is pinned the same way: with `src/` reverted,
`a_peer_death_mid_read_poisons_every_later_frame` fails because the EOF
arm never set the flag.

On this branch everything passes: one explicit `reload_project` respawns
(the pid changes), a no-arg reload recovers through the cached file list,
and a peer death observed mid-read poisons the transport immediately.

## Fix

- `Transport.poisoned` becomes an `Arc<AtomicBool>` shared with the owning
  `FramaCClient`, so `is_poisoned()` is a lock-free load that never touches
  the request mutex.
- `ensure_main_spawned`'s respawn decision gains that flag as its last
  disjunct: a poisoned transport now respawns on the first reload instead
  of failing in place to mark the session poisoned.
- The no-arg `reload_project` gates on `is_poisoned()` and resolves files
  from `MainFramaCState.files` — the last successfully loaded list — instead
  of asking the dead transport. An empty cache returns an error that names
  the remedy (`kind: TransportPoisoned`, `retryable: true`, suggests passing
  `files` explicitly). Healthy-transport behavior is unchanged.
- `recv_frame`'s EOF and read-error arms poison the transport too,
  mirroring `send_frame`: after EOF the peer is gone for good, and a read
  error leaves the stream state unknowable. The read-timeout arm
  deliberately does NOT poison — the poll loop times out routinely on
  healthy servers.

Deliberately not in this PR: sandbox clients still have no respawn path
(delete + recreate is their recovery), and capping the poll loop's POLL/Kill
writes at `min(remaining, WRITE_TIMEOUT)` is left for later — it only
shortens error latency in a session that is already being torn down.

## Testing

- New: `tests/unit/frama-c-transport.rs` (poison mechanics via peer-close:
  write-side, read-side, and a timeout-must-not-poison guard; all run in
  <1 s) and `tests/test-transport-poison-recovery.rs` (2 session-level
  regression tests, ~6 s)
- Full suite on Frama-C 33.0 / why3 1.8.2 / Alt-Ergo 2.6.3 / Z3 4.13.3:
  539 tests pass (534 baseline + 5 new)
- `cargo clippy --all-targets` clean
