### PR TITLE
Report what the front end dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,10 +427,67 @@ payload contract and the change rule. The full set:
 | `EVA_NOT_REQUESTED` | `want` excluded EVA, so nothing here excludes the alarms it finds |
 | `WP_NOT_REQUESTED` | `want` excluded WP, so nothing here is a proof |
 | `WP_BACKEND_ANOMALY` | Why3 aborted, so the FAILED goals of this run were never judged by a prover |
+| `AST_ASM_CLOBBER` | Frama-C assumed inline assembly has no effects beyond its operands, so the analyzed statement is weaker than the compiled one |
+| `AST_UNKNOWN_ATTRIBUTE` | Frama-C ignored an unknown attribute, so the analyzed declaration differs from the source |
+| `AST_UNCLASSIFIED_WARNING` | Frama-C emitted parse warnings in categories this server has not classified, so their effect on the analyzed program is unknown |
+| `AST_PARSE_DIAGNOSTICS_UNAVAILABLE` | This server has no record of what the front end dropped, so nothing says the analyzed program is the compiled one |
 
 Treat the set as additive: codes are added as gaps are found, and three were
 added in one day. Branch on the ones you handle and surface the rest rather
 than assuming an unknown code is benign.
+
+The four `AST_*` codes are about the parse and not the verdict: they say the
+program that was analyzed is not the program that would be compiled, or that
+nothing checked. The two soundness codes carry `count`, `count_unit` (clobber
+sites, or distinct attribute names, since Frama-C announces an unknown
+attribute once per name for the life of the process), and a capped `locations`
+sample with `locations_omitted`. `AST_UNCLASSIFIED_WARNING` is a single entry
+for every category nobody has classified, carrying a `categories` object that
+maps each category to that same record; it has no `count` of its own. The same
+numbers are on `reload_project` under `ast_reload_health.parse_diagnostics`.
+
+`AST_PARSE_DIAGNOSTICS_UNAVAILABLE` is the fourth and carries no counts at all,
+only a `detail` naming what went missing. It replaces the other three rather
+than joining them, because a record that could not be taken has nothing to say
+about any category.
+
+How long it lasts depends on which failure it names, and the `detail` is what
+says which. Four of them cost the process. Three are properties of its spawn:
+Frama-C had written nothing to its log when the socket appeared, the boot parse
+could not be measured in it (`cannot measure the boot parse in ...`), or the
+sources moved while Frama-C was starting. The fourth is the same race one
+reload later, when the sources move while Frama-C is rebuilding the AST in
+place. None can be recovered by looking again, since the boundary they would
+need was a property of an instant that has passed, so the server marks that
+Frama-C unusable: the next `reload_project` replaces it whether or not the file
+set changed, and the code goes with it.
+
+The one that does not is the spawn log being unreadable when a later call goes
+to read it (`cannot read the Frama-C stdout log at ...`). That one is neither
+cached nor fatal: the same process answers the code for as long as its log
+stays unreadable, and reports counts again as soon as it does not. The two
+unreadable cases are worded apart on purpose, because that wording is the only
+thing telling a caller which of the two it is holding.
+
+None of them carries a completeness caveat, because there is nothing for one to
+say. The record is always the boot parse of the Frama-C process that answered,
+and a boot parse is complete in both directions: Frama-C suppresses a warn-once
+category for the rest of the process, so no later parse could re-announce one,
+and the log is process-wide, so a call running alongside a later parse would
+write into its window. Nothing can be in flight before the socket exists.
+
+Keeping that true costs a respawn. `reload_project` reuses the running Frama-C
+only when the file set is byte-identical to the one that process booted on and
+carries no preprocessor directive; anything else, including a source with an
+`#include`, gets a new process. Reload rebuilds the AST from source either way,
+so what this costs is process lifetime rather than anything you were holding.
+The payoff is that a zero means the front end dropped nothing, that two checks
+in one session report the same codes, and that `proof_receipt.sha256` therefore
+does not move between them.
+
+When the spawn log cannot be read at all, `parse_diagnostics` carries an
+`unavailable` string and no categories, rather than the zeros that would read
+as "nothing was dropped".
 
 `check` also returns `messages[]`, Frama-C's own errors and warnings from the
 run, each with its plugin and source location. A generated `assigns` for an

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -945,6 +945,10 @@ pub mod incomplete_code {
     pub const EVA_NOT_REQUESTED: &str = "EVA_NOT_REQUESTED";
     pub const WP_NOT_REQUESTED: &str = "WP_NOT_REQUESTED";
     pub const WP_BACKEND_ANOMALY: &str = "WP_BACKEND_ANOMALY";
+    pub const AST_ASM_CLOBBER: &str = "AST_ASM_CLOBBER";
+    pub const AST_UNKNOWN_ATTRIBUTE: &str = "AST_UNKNOWN_ATTRIBUTE";
+    pub const AST_UNCLASSIFIED_WARNING: &str = "AST_UNCLASSIFIED_WARNING";
+    pub const AST_PARSE_DIAGNOSTICS_UNAVAILABLE: &str = "AST_PARSE_DIAGNOSTICS_UNAVAILABLE";
 
     // Only the doc comparison reads the list as a list; the emit sites name
     // codes one at a time. It used to be cfg(test) gated, which stopped meaning
@@ -971,6 +975,10 @@ pub mod incomplete_code {
         EVA_NOT_REQUESTED,
         WP_NOT_REQUESTED,
         WP_BACKEND_ANOMALY,
+        AST_ASM_CLOBBER,
+        AST_UNKNOWN_ATTRIBUTE,
+        AST_UNCLASSIFIED_WARNING,
+        AST_PARSE_DIAGNOSTICS_UNAVAILABLE,
     ];
 }
 
@@ -1542,6 +1550,7 @@ pub fn check_incomplete_items(
     wanted: WantedAnalyses,
 ) -> Vec<serde_json::Value> {
     let mut incomplete = Vec::new();
+    ast_diagnostic_gaps(&mut incomplete, reload, AST_WARNING_ALLOWLIST);
     unrequested_analysis_gaps(&mut incomplete, rte, wanted);
     step_failure_gaps(&mut incomplete, reload, eva, eva_alarms, wp, wp_goals, wanted);
     property_row_gaps(&mut incomplete, eva_alarms, wp_goals);
@@ -1550,6 +1559,110 @@ pub fn check_incomplete_items(
     incomplete
 }
 
+/// Warning categories this server has read and declared benign, with the
+/// reason it is willing to say so. Empty on purpose: silence about a category
+/// nobody has looked at would be this server deciding a warning is harmless
+/// without saying so. A row leaves the aggregate below and goes nowhere else.
+pub const AST_WARNING_ALLOWLIST: &[(&str, &str)] = &[];
+
+/// The code and reason a category becomes, for the two the front end drops
+/// soundness with. The spellings come from the module that reads them off the
+/// log, so the classifier and the zero rows cannot disagree about what a
+/// category is called.
+fn ast_soundness_reason(category: &str) -> Option<(&'static str, &'static str)> {
+    match category {
+        project::ASM_CLOBBER => Some((
+            incomplete_code::AST_ASM_CLOBBER,
+            "Frama-C assumed inline assembly has no effects beyond its operands, so the analyzed statement is weaker than the compiled one.",
+        )),
+        project::ATTRS_UNKNOWN => Some((
+            incomplete_code::AST_UNKNOWN_ATTRIBUTE,
+            "Frama-C ignored an unknown attribute, so the analyzed declaration differs from the source.",
+        )),
+        _ => None,
+    }
+}
+
+/// What the parse of the loaded files cost, read off the reload payload.
+///
+/// The two soundness classes get a code each; everything else that nobody has
+/// classified or allowlisted shares one aggregate entry, because a payload
+/// carrying one entry per category is unbounded in the size of the program.
+///
+/// The allowlist is a parameter rather than a read of the const below, so a
+/// test can prove that a row removes its category from the aggregate and
+/// changes nothing else. A guard over an empty const proves neither.
+pub fn ast_diagnostic_gaps(
+    incomplete: &mut Vec<serde_json::Value>,
+    reload: &serde_json::Value,
+    allowlist: &[(&str, &str)],
+) {
+    let diagnostics = &reload["ast_reload_health"]["parse_diagnostics"];
+
+    // No completeness flag on any of this, and that is a property of how the
+    // record is produced rather than an omission. It is always a process's boot
+    // parse, because ensure_main_spawned respawns rather than hand back a
+    // reparse, and a boot parse can neither miss a warn-once category nor pick
+    // up a concurrent call's output. So a zero here is evidence of absence,
+    // which is what lets the zero-count branch below skip a category instead of
+    // having to hedge it, and it is what keeps two checks of one session
+    // reporting the same codes: an entry that appeared only on the second would
+    // move proof_receipt.sha256, since the receipt digests incomplete.
+    // A record that says why it is empty is a finding rather than silence.
+    // Reading it as a clean parse would let check answer "proved" on the one
+    // shape where nothing established that the analyzed program is the
+    // compiled one, which is the claim these codes exist to make.
+    if let Some(reason) = diagnostics["unavailable"].as_str() {
+        incomplete.push(json!({
+            "code": incomplete_code::AST_PARSE_DIAGNOSTICS_UNAVAILABLE,
+            "reason": "This server has no record of what Frama-C's front end dropped while parsing, so nothing here says the analyzed program is the compiled one.",
+            "detail": reason,
+        }));
+        return;
+    }
+
+    let Some(categories) = diagnostics["categories"].as_object() else {
+        return;
+    };
+
+    let mut unclassified = serde_json::Map::new();
+    for (category, record) in categories {
+        if record["count"].as_u64().unwrap_or(0) == 0 {
+            continue;
+        }
+        if let Some((code, reason)) = ast_soundness_reason(category) {
+            incomplete.push(json!({
+                "code": code,
+                "reason": reason,
+                "category": category,
+                "count": record["count"],
+                "count_unit": record["count_unit"],
+                "locations": record["locations"],
+                "locations_omitted": record["locations_omitted"],
+            }));
+            continue;
+        }
+        // A classified category left the loop above, so the only thing that
+        // keeps one out of the aggregate here is a row saying why its silence
+        // is deliberate.
+        if !allowlist.iter().any(|(allowed, _)| allowed == category) {
+            // The whole record, not the bare count. One entry is what keeps the
+            // payload bounded in the number of categories; dropping the unit
+            // and the capped sample inside it would leave a caller a number it
+            // cannot interpret and a warning it cannot find, and buys nothing,
+            // since each sample is already capped.
+            unclassified.insert(category.clone(), record.clone());
+        }
+    }
+
+    if !unclassified.is_empty() {
+        incomplete.push(json!({
+            "code": incomplete_code::AST_UNCLASSIFIED_WARNING,
+            "reason": "Frama-C emitted parse warnings in categories this server has not classified, so their effect on the analyzed program is unknown.",
+            "categories": unclassified,
+        }));
+    }
+}
 
 /// How Frama-C prints the goal name for each PKEnsures clause. All five are
 /// assumed at a call site, so all five belong to the same finding;

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -50,8 +50,261 @@ struct AstReloadHealth {
     payload: serde_json::Value,
 }
 
+const AST_DIAGNOSTIC_SAMPLE: usize = 20;
+
+/// The two categories a dropped soundness assumption arrives under. Public
+/// because analysis.rs classifies them into check codes and has to name the
+/// same strings this module reads off the log.
+pub const ASM_CLOBBER: &str = "kernel:asm:clobber";
+pub const ATTRS_UNKNOWN: &str = "kernel:attrs:unknown";
+const ATTRIBUTE_PREFIX: &str = "Ignoring unknown attribute:";
+const AST_SOUNDNESS_CATEGORIES: [&str; 2] = [ASM_CLOBBER, ATTRS_UNKNOWN];
+
+fn log_location(source: &str, cwd: &Path) -> serde_json::Value {
+    let source = source.trim().trim_end_matches(':').trim();
+    if source.is_empty() {
+        return json!({"unresolved": true});
+    }
+    // Frama-C prints "path", "path:line" or "path:line:column", so the numbers
+    // come off the end one at a time and what is left is the path. A trailing
+    // field that is not a number means the whole string is the path: a path can
+    // carry a colon.
+    let (source, line, column) = match trailing_number(source) {
+        None => (source, None, None),
+        Some((head, last)) => match trailing_number(head) {
+            Some((head, line)) => (head, Some(line), Some(last)),
+            None => (head, Some(last), None),
+        },
+    };
+    let path = Path::new(source);
+    let path = if path.is_absolute() { path.to_path_buf() } else { cwd.join(path) };
+    json!({"file": path, "line": line, "column": column})
+}
+
+/// Summarize Warning records from the log slice that built the current AST.
+/// The server protocol loses boot-time messages, while this file is
+/// append-only.
+///
+/// The window is the process's boot parse, from byte zero to the length
+/// stdout had when the socket appeared, and it is complete for two reasons
+/// that no later window has. Frama-C suppresses a warn-once category for the
+/// life of the process, so a reparse cannot re-emit one. And the log is
+/// process-wide, so a call running alongside a reparse would put its own
+/// warnings in the same range; nothing can be in flight before the socket
+/// exists. ensure_main_spawned is what keeps this true, by respawning rather
+/// than reparsing whenever the record would stop answering for the file set.
+///
+/// Measured on Frama-C 33. A warning is one line or two, and which it is
+/// depends on the path length against the margin rather than on anything this
+/// server chose: "[kernel:attrs:unknown] a.c:1: Warning: Ignoring unknown
+/// attribute: __q__" fits, while the same warning under a longer path breaks
+/// after "Warning:" and indents the text onto the next line. Reading only the
+/// second shape counted zero unknown attributes for every project with short
+/// paths.
+///
+/// The tag is found by tag_bounds rather than by either end of the line,
+/// because a directory name can carry brackets on either side of it.
+pub fn ast_parse_diagnostics(log: &[u8], end: u64, cwd: &Path) -> serde_json::Value {
+    let end = usize::try_from(end).unwrap_or(usize::MAX).min(log.len());
+
+    // Counted in full, sampled up to the cap. A program with ten thousand
+    // clobber sites is ten thousand increments rather than ten thousand JSON
+    // objects and paths that the cap below would throw away: the count is the
+    // soundness claim, and the sample is the evidence a reader can follow.
+    let mut categories: BTreeMap<String, (usize, Vec<serde_json::Value>)> = BTreeMap::new();
+    let mut record = |category: &str, source: &str| {
+        let entry = categories.entry(category.to_string()).or_default();
+        entry.0 += 1;
+        if entry.1.len() < AST_DIAGNOSTIC_SAMPLE {
+            entry.1.push(log_location(source, cwd));
+        }
+    };
+
+    // The attributes are keyed by name because the count is distinct names, so
+    // this map is bounded by the program's attribute vocabulary rather than by
+    // its size. The location stays unparsed until the name is known to be new.
+    let mut attributes: BTreeMap<String, &str> = BTreeMap::new();
+    let mut pending_attribute: Option<&str> = None;
+    let text = String::from_utf8_lossy(&log[..end]);
+    for line in text.lines() {
+        match warning_line_fields(line) {
+            // The name sits on this line when it fits and wraps onto the next
+            // when it does not, and which of the two happens is a function of
+            // the path length and the margin rather than of anything this
+            // server controls. Measured on Frama-C 33: "a.c:1" keeps "__q__" on
+            // the tag line, while the same attribute under "tests/fixtures/..."
+            // wraps.
+            Some((category, source)) if category == ATTRS_UNKNOWN => {
+                match line.split_once(ATTRIBUTE_PREFIX) {
+                    Some((_, name)) => {
+                        attributes.entry(name.trim().to_string()).or_insert(source);
+                        pending_attribute = None;
+                    }
+                    None => pending_attribute = Some(source),
+                }
+            }
+
+            // Any other warning ends the wrap: what follows it belongs to that
+            // warning, so an attribute name arriving later is not this one's.
+            Some((category, source)) => {
+                record(category, source);
+                pending_attribute = None;
+            }
+
+            // Untagged, so a continuation line if it names an attribute. It is
+            // counted even with no pending location, because the count is the
+            // soundness claim and a location this server could not pin is a
+            // worse answer than an unpinned one, not a reason to drop it. An
+            // empty source is what log_location reads as unresolved.
+            None => {
+                if let Some((_, name)) = line.split_once(ATTRIBUTE_PREFIX) {
+                    let source = pending_attribute.take().unwrap_or("");
+                    attributes.entry(name.trim().to_string()).or_insert(source);
+                }
+            }
+        }
+    }
+    for (name, source) in attributes {
+        let entry = categories.entry(ATTRS_UNKNOWN.to_string()).or_default();
+        entry.0 += 1;
+        if entry.1.len() < AST_DIAGNOSTIC_SAMPLE {
+            entry.1.push(json!({"attribute": name, "location": log_location(source, cwd)}));
+        }
+    }
+
+    // Present with a zero count rather than absent, so a caller reads "Frama-C
+    // dropped nothing here" instead of having to guess why a key is missing.
+    for category in AST_SOUNDNESS_CATEGORIES {
+        categories.entry(category.to_string()).or_default();
+    }
+    let categories = categories
+        .into_iter()
+        .map(|(category, (count, locations))| {
+            let count_unit = if category == ATTRS_UNKNOWN {
+                "distinct_attribute_names"
+            } else {
+                "sites"
+            };
+            (
+                category,
+                json!({
+                    "count": count,
+                    "count_unit": count_unit,
+                    "locations_omitted": count - locations.len(),
+                    "locations": locations,
+                }),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
+    json!({"categories": categories})
+}
+
+/// The string without its trailing ":<number>" field, and that number.
+fn trailing_number(source: &str) -> Option<(&str, u64)> {
+    let (head, last) = source.rsplit_once(':')?;
+    Some((head, last.parse().ok()?))
+}
+
+/// The category and the unparsed source location of one warning line, or None
+/// when the line is not one: feedback carries a tag too, as in
+/// "[kernel:pp:compilation-db] using compilation database:", and only a
+/// warning carries the "Warning:" token.
+///
+/// The tag is the first bracketed group at a field boundary before the token,
+/// scanning left to right. Neither end of the line is a safe anchor: a
+/// directory name can carry brackets on either side of the tag.
+///
+/// The location is handed back as the text Frama-C printed rather than as a
+/// parsed one, so a caller that is only going to count this warning never pays
+/// for the path it will not keep.
+fn warning_line_fields(line: &str) -> Option<(&str, &str)> {
+    // The first "Warning:" with a tag before it, not the first one on the line.
+    // A path may carry the token, as in "src/Warning:x/a.c:3:", and stopping
+    // there leaves a head with no tag in it, which dropped the warning
+    // entirely. Earliest rather than latest, because the message that follows
+    // the real marker may quote the token too, and a head that reaches into the
+    // message reads its text as a location.
+    let mut from = 0;
+    let (head, open, close) = loop {
+        let at = from + line[from..].find("Warning:")?;
+        let head = &line[..at];
+        match tag_bounds(head) {
+            Some((open, close)) => break (head, open, close),
+            None => from = at + 1,
+        }
+    };
+
+    // Whichever side of the tag the location was printed on. Both sides are
+    // taken because Frama-C puts it after the tag and nothing promises that.
+    let before = head[..open].trim().trim_end_matches(':').trim();
+    let after = head[close + 1..].trim().trim_end_matches(':').trim();
+    let source = if before.is_empty() { after } else { before };
+    Some((&head[open + 1..close], source))
+}
+
+/// Byte offsets of the "[" and "]" around the first plugin:category tag.
+///
+/// A tag holds a colon and no whitespace, and is a whitespace-separated field
+/// of its own. Both sides of that have to be checked: a path segment carrying
+/// a colon, as in "[team:api]/a.c:3:", is a field boundary on its left when the
+/// path is relative and starts with it, so only the character after the bracket
+/// tells the two apart.
+fn tag_bounds(head: &str) -> Option<(usize, usize)> {
+    let mut from = 0;
+    while let Some(open) = head[from..].find('[') {
+        let open = from + open;
+        let close = open + head[open..].find(']')?;
+        let candidate = &head[open + 1..close];
+        let tail = &head[close + 1..];
+        if (open == 0 || head[..open].ends_with(char::is_whitespace))
+            && (tail.is_empty() || tail.starts_with(char::is_whitespace))
+            && candidate.contains(':')
+            && !candidate.contains(char::is_whitespace)
+        {
+            return Some((open, close));
+        }
+
+        // Past the rejected "[", not past the "]" it was paired with. That
+        // bracket may be the real tag's, as in "src/[dir/a.c:3:
+        // [kernel:asm:clobber]", where the first "[" is unmatched inside the
+        // path and pairs with the tag's own closing bracket. Skipping to it
+        // stepped over the tag and dropped the warning.
+        from = open + 1;
+    }
+    None
+}
+
+/// The boot parse's own bytes, rather than the whole log. Frama-C keeps
+/// writing to this file for the life of the process, so a read of all of it
+/// grows with the proof while the window that gets parsed does not. The read
+/// is still bounded by end inside ast_parse_diagnostics, which answers for a
+/// slice a caller passes rather than for whatever this handed it.
+fn read_parse_window(path: &Path, end: u64) -> std::io::Result<Vec<u8>> {
+    use std::io::Read;
+    let mut window = Vec::new();
+    std::fs::File::open(path)?.take(end).read_to_end(&mut window)?;
+    Ok(window)
+}
+
+/// The parse record when there is none. No categories, because an absent key
+/// is the only honest answer: a zero would say the front end dropped nothing,
+/// which is exactly what has not been established. One constructor, so that
+/// invariant is stated once rather than honored by convention.
+pub fn parse_log_unavailable(reason: String) -> serde_json::Value {
+    json!({"unavailable": reason, "categories": {}})
+}
+
+/// The record for a spawn log this server could not read.
+pub fn unreadable_parse_log(path: &Path, error: &std::io::Error) -> serde_json::Value {
+    parse_log_unavailable(format!(
+        "cannot read the Frama-C stdout log at {}: {error}",
+        path.display()
+    ))
+}
+
 async fn ast_reload_health(
     client: &FramaCClient,
+    parse_diagnostics: serde_json::Value,
 ) -> Result<AstReloadHealth, McpError> {
     let files = reload_health_get(client, "kernel.ast.getFiles", json!(null)).await?;
     let functions = reload_health_fetch_all(
@@ -88,6 +341,7 @@ async fn ast_reload_health(
         "functions_count": functions.len(),
         "globals_count": globals.len(),
         "properties_count": properties.len(),
+        "parse_diagnostics": parse_diagnostics,
     });
     Ok(AstReloadHealth { functions, payload })
 }
@@ -235,7 +489,46 @@ impl FramaCMcpServer {
         // back empty and the sandbox path has no function cache to resolve
         // against.
         let client = self.require_client().await?;
-        let health = ast_reload_health(&client).await?;
+
+        // Read and memoize under one lock. Splitting the two across the
+        // ast_reload_health await let a concurrent reload reset the offsets in
+        // between, after which storing this call's value put the previous file
+        // set's counts back as the answer for the new one. An empty payload if
+        // the process is gone, rather than a panic: the state lock was released
+        // when ensure_main_spawned returned, so the client and the state are no
+        // longer known to agree.
+        let parse_diagnostics = {
+            let mut state = self.main_frama_c_state.lock().await;
+            match state.as_mut() {
+                Some(state) => match state.ast_reload_diagnostics.clone() {
+                    // Including a cached absence. A process that never got a
+                    // boot record cannot grow one, since the boundary it would
+                    // need was a property of an instant that has passed, so
+                    // ensure_main_spawned poisons it instead and the next
+                    // reload answers from a new process.
+                    Some(cached) => cached,
+
+                    // A log this server cannot read is not a parse that dropped
+                    // nothing, and the difference matters: the record below
+                    // carries both soundness categories at zero, which a caller
+                    // is entitled to read as "Frama-C kept everything". So the
+                    // failure answers with no categories at all, and it is not
+                    // cached, since the next call may well read the file.
+                    None => match read_parse_window(&state.stdout_log_path, state.ast_parse_log_end)
+                    {
+                        Ok(log) => {
+                            let fresh =
+                                ast_parse_diagnostics(&log, state.ast_parse_log_end, &state.working_dir);
+                            state.ast_reload_diagnostics = Some(fresh.clone());
+                            fresh
+                        }
+                        Err(error) => unreadable_parse_log(&state.stdout_log_path, &error),
+                    },
+                },
+                None => parse_log_unavailable("the Frama-C process is gone".to_string()),
+            }
+        };
+        let health = ast_reload_health(&client, parse_diagnostics).await?;
         let entries = health.functions;
         {
             let mut state = self.state.write().await;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -29,7 +29,8 @@ pub use crate::mcp::store::*;
 pub use crate::mcp::wpout::*;
 use crate::mcp::types::*;
 use crate::state::{
-    FunctionVerificationState, MarkerLocation, SandboxMetadata, SessionState, StaleMarker,
+    sha256_hex, sha256_hex_of_reader, FunctionVerificationState, MarkerLocation, SandboxMetadata,
+    SessionState, StaleMarker,
 };
 
 pub fn proofread_report_from_wp_goals(
@@ -1724,6 +1725,235 @@ pub fn parse_wp_model_support(help: &str) -> WpModelSupport {
     }
 }
 
+/// Identity of a loaded file set: its paths in order, and the bytes behind
+/// them.
+///
+/// The parse record kept on the state below answers for one AST, so it has to
+/// be dropped exactly when that AST changes and kept otherwise. A path list
+/// alone cannot say that, since editing a file in place changes nothing about
+/// the list. Header-bearing sources are deliberately not eligible to reuse
+/// this digest: the header bytes are outside it.
+pub fn loaded_source_digest(files: &[String], machdep: Option<&str>) -> String {
+    loaded_source_state(files, machdep).0
+}
+
+/// One entry of that identity: the name, when it was last written, and a digest
+/// of the bytes behind it.
+///
+/// The timestamp is there because the digest is taken at an instant and the
+/// question is about an interval. A file edited and put back between two reads
+/// hashes the same both times, and the identity would then say "unchanged"
+/// about bytes Frama-C may have parsed in their edited state. Writing it back
+/// moves the modification time, so the round trip shows up as a change even
+/// though the content does not. It is not a proof: a caller that restores the
+/// timestamp too, or that completes the round trip inside one tick of the
+/// filesystem's resolution, is indistinguishable from one that did nothing, and
+/// no content-based identity can see that.
+///
+/// An unreadable name is its own state and has to differ from every digest and
+/// from itself read: what matters is only that it never matches a name that was
+/// read. Returns the bytes when there were any, so a caller can ask something
+/// else of them without opening the file twice.
+fn hash_named_file(input: &mut Vec<u8>, name: &str) -> bool {
+    input.extend_from_slice(name.as_bytes());
+    let read = std::fs::File::open(name).and_then(|file| {
+        let written = file
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|since_epoch| since_epoch.as_nanos());
+
+        // Streamed rather than read whole. Nothing here wants the bytes, only a
+        // digest and one question about them, and a generated translation unit
+        // is as large as its generator felt like making it.
+        let (digest, has_hash) = sha256_hex_of_reader(file)?;
+        Ok((written, digest, has_hash))
+    });
+    match &read {
+        Ok((written, digest, _)) => {
+            input.extend_from_slice(format!("{written:?}").as_bytes());
+            input.extend_from_slice(digest.as_bytes());
+        }
+        Err(error) => input.extend_from_slice(error.to_string().as_bytes()),
+    }
+    input.push(0);
+    read.map(|(_, _, has_hash)| has_hash).unwrap_or(true)
+}
+
+/// That digest and whether any of the sources reaches outside itself, from one
+/// read each.
+///
+/// The two answers are taken together because they are answers about the same
+/// bytes: read twice, the include scan and the digest can describe two
+/// different versions of a file that was edited in between, and the pair would
+/// then say "no headers, and these are the bytes" about a file that had both.
+fn loaded_source_state(files: &[String], machdep: Option<&str>) -> (String, bool) {
+    let mut input = Vec::new();
+    let mut may_include = false;
+    for file in files {
+        may_include |= hash_named_file(&mut input, file);
+    }
+
+    // The machdep is in the identity rather than in a test of its own, because
+    // Frama-C reads a YAML file there as readily as a builtin name and decides
+    // which it is from the contents. A name hashes as the error from failing to
+    // open it, so a builtin costs nothing and stays stable, while a file that
+    // is edited, or that disappears after being loaded, moves the digest and
+    // sends the next reload down the respawn path. It stays out of the include
+    // scan: "#" opens a comment in YAML, and a comment is not a reason to
+    // respawn.
+    if let Some(machdep) = machdep {
+        let _ = hash_named_file(&mut input, machdep);
+    }
+    (sha256_hex(&input), may_include)
+}
+
+/// True when this file set may depend on bytes that loaded_source_digest does
+/// not include.
+///
+/// Any "#" anywhere in the file, in any of its three spellings, not a directive
+/// this server recognized. Every narrower read was wrong in the same direction.
+/// Matching the word "include" needs the line free of comments first, since
+/// "/**/#include" and "#/**/include" are both legal; requiring "#" to open the
+/// line misses the first of those, because a comment may precede the directive
+/// and may have opened on an earlier line; and reading only the character
+/// misses "%:include" and "??=include", which are the same directive written
+/// with a digraph or a trigraph. A lexer for all that buys nothing here: a
+/// directive is the preprocessor deciding something this server has no way to
+/// compare. So a file whose only "#" is in a format string pays a recount it
+/// did not need, which is the cheaper mistake.
+///
+/// The scan is over bytes rather than text, because the question is about ASCII
+/// punctuation and a source Frama-C compiles is not required to be UTF-8.
+/// Decoding it first made a latin-1 comment an unreadable file, which is the
+/// answer for a file that is not there.
+pub fn files_may_include(files: &[String]) -> bool {
+    loaded_source_state(files, None).1
+}
+
+/// Start Frama-C on its own two logs, or leave neither behind.
+///
+/// The logs are removed on every path that leaves without a MainFramaCState to
+/// own them, since nothing else knows their names: both carry the spawn counter
+/// that made them unique. Drop unlinks the pair for a spawn that succeeded.
+fn spawn_frama_c(
+    command_line: &[String],
+    stdout_log_path: &Path,
+    stderr_log_path: &Path,
+) -> Result<tokio::process::Child, McpError> {
+    use std::process::Stdio;
+    use tokio::process::Command;
+
+    let create = |path: &Path, which: &str| {
+        std::fs::File::create(path)
+            .map_err(|e| McpError::internal_error(format!("create {which} log: {e}"), None))
+    };
+    let stdout_log = create(stdout_log_path, "stdout")?;
+    let stderr_log = match create(stderr_log_path, "stderr") {
+        Ok(log) => log,
+        Err(error) => {
+            let _ = std::fs::remove_file(stdout_log_path);
+            return Err(error);
+        }
+    };
+
+    let mut cmd = Command::new(&command_line[0]);
+    for arg in &command_line[1..] {
+        cmd.arg(arg);
+    }
+    cmd.stdout(Stdio::from(stdout_log))
+        .stderr(Stdio::from(stderr_log))
+        // Its own process group, for the same reason the sandbox spawn takes
+        // one: Frama-C starts why3server and the provers as its own children,
+        // and kill_on_drop SIGKILLs only Frama-C itself. Without a group there
+        // is nothing to signal them through, and a server that goes away
+        // without running Drop leaves the whole tree behind. Measured: seven
+        // frama-c processes reparented to launchd, the oldest at eight and a
+        // half hours, each still holding its socket.
+        //
+        // The child is the leader, so the pgid is its pid and nothing extra
+        // needs persisting.
+        .process_group(0)
+        .kill_on_drop(true);
+
+    cmd.spawn().map_err(|error| {
+        let _ = std::fs::remove_file(stdout_log_path);
+        let _ = std::fs::remove_file(stderr_log_path);
+        McpError::internal_error(format!("spawn frama-c: {error}"), None)
+    })
+}
+
+/// Where this process's boot parse ends in its log, and the record to answer
+/// with instead when there is no boot parse to read.
+///
+/// Some means no record: a boundary this server could not read is not a boot
+/// parse of length zero, and neither is a log with nothing in it yet. Parsing
+/// an empty window answers every category at zero, which a caller reads as "the
+/// front end dropped nothing". Frama-C narrates the parse it just did, so an
+/// empty file here is its output not having landed rather than a quiet run, and
+/// this server does not spawn it with -quiet.
+///
+/// The identity is the third way to have no record. Booted_on was read before
+/// the spawn, so a write that landed while Frama-C was starting built an AST
+/// those bytes do not name; parsed is the same identity read again afterwards,
+/// and the two differing is what says that happened.
+fn boot_parse_window(
+    stdout_log_path: &Path,
+    parsed: &str,
+    booted_on: &str,
+) -> (u64, Option<serde_json::Value>) {
+    let end = std::fs::metadata(stdout_log_path).map(|metadata| metadata.len());
+    let missing = match &end {
+        // Worded apart from the runtime failure in reload_project deliberately.
+        // Both are an unreadable log, and how long the code lasts depends on
+        // which one it was: this one cannot be retried and takes the process
+        // with it, that one is retried on the next call. The detail is what a
+        // reader has to tell them apart by, so the two cannot share a sentence.
+        Err(error) => Some(format!(
+            "cannot measure the boot parse in the Frama-C stdout log at {}: {error}",
+            stdout_log_path.display()
+        )),
+        Ok(0) => Some(
+            "Frama-C had written nothing to its log when the socket appeared, so this server \
+             never saw the boot parse"
+                .to_string(),
+        ),
+        Ok(_) => (parsed != booted_on).then(|| {
+            "the sources changed while Frama-C was starting, so no boot parse describes them"
+                .to_string()
+        }),
+    };
+    (end.unwrap_or(0), missing.map(project::parse_log_unavailable))
+}
+
+/// Whether the parse record on this state still answers for the file set the
+/// caller is asking to load.
+///
+/// It does when the bytes behind the named paths are the ones the boot parse
+/// read, and nothing outside those bytes reached the preprocessor. A file set
+/// that fails either test does not get a reparse and a hedged record; it gets
+/// a new process, whose own boot parse is complete.
+fn parse_record_survives(state: &MainFramaCState, identity: &(String, bool)) -> bool {
+    let (digest, may_include) = identity;
+    !state.project_options.names_bytes_outside_the_file_set()
+        && !may_include
+        && *digest == state.ast_parse_source_digest
+}
+
+/// loaded_source_state on a blocking thread.
+///
+/// Every reload asks this, and it opens and hashes each source, so on the
+/// executor it is a stall proportional to the project rather than to the call.
+/// A join failure answers as a file set that reaches outside itself, under an
+/// empty digest that matches nothing: both send the caller to a new process,
+/// which is the answer that needs no record to be true.
+async fn source_identity(files: Vec<String>, machdep: Option<String>) -> (String, bool) {
+    tokio::task::spawn_blocking(move || loaded_source_state(&files, machdep.as_deref()))
+        .await
+        .unwrap_or_else(|_| (String::new(), true))
+}
+
 /// Main Frama-C process state. None at server startup; the first
 /// reload_project spawns Frama-C, connects the client, and fills this field.
 ///
@@ -1745,6 +1975,18 @@ pub struct MainFramaCState {
     pub command_line: Vec<String>,
     pub stdout_log_path: PathBuf,
     pub stderr_log_path: PathBuf,
+    /// Length of stdout at the moment this process finished booting, which is
+    /// where its parse diagnostics end. The range always starts at zero: the
+    /// boot parse is the only one this server reads, because it is the only
+    /// complete one, and ensure_main_spawned respawns rather than reparse.
+    pub ast_parse_log_end: u64,
+    /// What loaded_source_digest returned for the file set the boot parse
+    /// read. A later reload matching it can stay in this process.
+    pub ast_parse_source_digest: String,
+    /// Parsed once and kept for the life of the process, since the bytes it
+    /// was read from never change and nothing else appends to that range.
+    pub ast_reload_diagnostics: Option<serde_json::Value>,
+    pub working_dir: PathBuf,
     pub startup_stderr_tail: String,
     /// The WP memory model this process last ran proofs under, if any.
     ///
@@ -1782,18 +2024,27 @@ pub struct MainFramaCState {
 }
 
 impl Drop for MainFramaCState {
-    /// Unlink the socket this spawn's Frama-C was listening on.
+    /// Unlink what this spawn owned: the socket its Frama-C listened on, and
+    /// the two logs it wrote.
     ///
-    /// `kill_on_drop` takes the process down but leaves the path behind, and
-    /// nothing else removed it, so a machine running this suite accumulated
-    /// 1,249 stale `.sock` files in `/tmp`.
+    /// `kill_on_drop` takes the process down but leaves the paths behind, and
+    /// nothing else removed them, so a machine running this suite accumulated
+    /// 1,249 stale `.sock` files in `/tmp`. The logs are named per spawn for
+    /// the same reason the socket is, and a session that reloads a changing
+    /// file set now respawns every time, so they accumulate at the same rate.
+    /// Nothing outside this state reads them: the startup tail is copied into
+    /// the state at spawn, and the parse record is read while the process is
+    /// still live.
     ///
     /// This body runs before the fields drop, so the unlink lands while
     /// Frama-C is still alive and `kill_on_drop` SIGKILLs it a moment later.
-    /// That is harmless: unlink removes the name, not the listening socket, and
-    /// paths are unique per spawn, so nothing will ask for that name again.
+    /// That is harmless: unlink removes the name and not the open file or the
+    /// listening socket, and every path here is unique per spawn, so nothing
+    /// will ask for one of these names again.
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.socket_path);
+        let _ = std::fs::remove_file(&self.stdout_log_path);
+        let _ = std::fs::remove_file(&self.stderr_log_path);
     }
 }
 
@@ -1804,6 +2055,25 @@ pub struct ProjectLoadOptions {
     pub force_includes: Vec<String>,
     pub machdep: Option<String>,
     pub compilation_database: Option<String>,
+}
+
+impl ProjectLoadOptions {
+    /// Whether these options pull in bytes that loaded_source_state never
+    /// reads, which is what makes a parse record unusable for a later call.
+    ///
+    /// Beside the struct rather than beside the one predicate that asks,
+    /// because the answer is a property of the fields: a sixth option naming a
+    /// path is a decision to take here, and taking it anywhere else means the
+    /// author of that field never sees the question.
+    ///
+    /// include_paths and defines are not in it. They reach the preprocessor,
+    /// but only a source with a directive can act on them, and such a source is
+    /// already refused. Nor is machdep: it names bytes, but loaded_source_state
+    /// hashes them, so the identity answers for it rather than this predicate
+    /// refusing every project that sets one.
+    fn names_bytes_outside_the_file_set(&self) -> bool {
+        !self.force_includes.is_empty() || self.compilation_database.is_some()
+    }
 }
 
 #[derive(Clone)]
@@ -3034,13 +3304,18 @@ impl FramaCMcpServer {
         new_rte: bool,
         new_project_options: ProjectLoadOptions,
     ) -> Result<(), McpError> {
-        use std::process::Stdio;
-        use tokio::process::Command;
-
         // Held to the end, so the respawn decision and the assignment that acts
         // on it cannot be split by another caller. The two state locks below
         // are dropped across the spawn and cannot do this themselves.
         let _spawning = self.main_spawn_lock.lock().await;
+
+        // Before the locks, because it reads files: the answer depends on the
+        // caller's arguments and on the disk, never on the state, and taking it
+        // here keeps blocking work out of the section that holds three locks.
+        // One read serves both callers below, the reuse decision and the digest
+        // stamped on a new process.
+        let identity =
+            source_identity(new_files.clone(), new_project_options.machdep.clone()).await;
 
         let main_lock = self.main_frama_c_state.lock().await;
         let client_lock = self.client.lock().await;
@@ -3048,13 +3323,24 @@ impl FramaCMcpServer {
         let needs_respawn = match main_lock.as_ref() {
             None => true,
             Some(s) => {
-                // The last disjunct is the transport's own flag: a write that
+                // The third disjunct is the transport's own flag: a write that
                 // died part-way poisons the stream without touching any of the
                 // session fields above.
+                //
+                // The last one is the parse record. Only a process's boot parse
+                // is a complete account of what the front end dropped: a
+                // reparse cannot re-emit a warn-once category, and the log it
+                // writes into is process-wide, so a concurrent call can put its
+                // own warnings in the same window. Rather than report a record
+                // hedged on both counts, a file set this server cannot prove
+                // unchanged gets a new process. Reload rebuilds the AST from
+                // source either way, so this costs process lifetime rather than
+                // anything the caller had.
                 s.poisoned
                     || s.with_rte != new_rte
                     || s.project_options != new_project_options
                     || client_lock.as_ref().is_some_and(|c| c.is_poisoned())
+                    || !parse_record_survives(s, &identity)
             }
         };
 
@@ -3064,8 +3350,32 @@ impl FramaCMcpServer {
             drop(main_lock);
             match reload_files_in_place(&client, &new_files).await {
                 Ok(()) => {
+                    // parse_record_survives read those bytes before the
+                    // reparse, so a write that landed in between built an AST
+                    // the boot-parse record does not describe. Reading them
+                    // again is what closes that window: unchanged and the record
+                    // still answers for what Frama-C is holding, changed and it
+                    // answers for nothing, so it is replaced by the absence
+                    // rather than left to be read as a parse that dropped what
+                    // the previous bytes dropped. The process is poisoned with
+                    // it, since the next call cannot recover a record for an AST
+                    // whose boot parse never happened; only a new process can.
+                    //
+                    // Before the lock, like the read that started this call.
+                    let reparsed =
+                        source_identity(new_files.clone(), new_project_options.machdep.clone())
+                            .await;
+
                     let mut main_lock = self.main_frama_c_state.lock().await;
                     if let Some(s) = main_lock.as_mut() {
+                        if reparsed.0 != s.ast_parse_source_digest {
+                            s.ast_reload_diagnostics = Some(project::parse_log_unavailable(
+                                "the sources changed while Frama-C was rebuilding the AST, so no \
+                                 parse record describes it"
+                                    .to_string(),
+                            ));
+                            s.poisoned = true;
+                        }
                         s.files = new_files;
                     }
                     self.state.write().await.project_loaded = true;
@@ -3099,12 +3409,13 @@ impl FramaCMcpServer {
         // whenever rte or the project options change, and reusing the name let
         // the new Frama-C bind a path the dying one had not released yet. The
         // counter also gives `MainFramaCState::drop` a path no live process
-        // wants.
+        // wants, and keeps the handover's two stdout writers separate.
         static SPAWN_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let spawn_id = SPAWN_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let socket_path = PathBuf::from(format!(
             "/tmp/frama-c-mcp-{}-{}.sock",
             std::process::id(),
-            SPAWN_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            spawn_id
         ));
 
         // Unique per spawn, so this only matters when a pid is reused and the
@@ -3122,13 +3433,18 @@ impl FramaCMcpServer {
             .map(|root| root.join("logs"))
             .and_then(|dir| std::fs::create_dir_all(&dir).map(|()| dir))
             .map_err(|e| McpError::internal_error(format!("create log directory: {e}"), None))?;
-        let log_basename = format!("main-{}", std::process::id());
+        let log_basename = format!("main-{}-{}", std::process::id(), spawn_id);
         let stdout_log_path = log_dir.join(format!("{}.stdout.log", log_basename));
-        let stdout_log = std::fs::File::create(&stdout_log_path)
-            .map_err(|e| McpError::internal_error(format!("create stdout log: {}", e), None))?;
         let stderr_log_path = log_dir.join(format!("{}.stderr.log", log_basename));
-        let stderr_log = std::fs::File::create(&stderr_log_path)
-            .map_err(|e| McpError::internal_error(format!("create stderr log: {}", e), None))?;
+
+        // The identity taken above, which was read before this spawn. Either
+        // way an edit landing between the read and the parse makes the digest
+        // and the AST disagree, but only this order errs safely: the record is
+        // stamped with the bytes as they were no later than the parse read
+        // them, so a reload of the edited file computes a different digest and
+        // respawns. Reading it afterwards stamps the new bytes onto the old
+        // parse, and that reload reuses a record for an AST nobody built.
+        let ast_parse_source_digest = identity.0.clone();
 
         let command_line = self.main_frama_c_command_line(
             &new_files,
@@ -3136,28 +3452,7 @@ impl FramaCMcpServer {
             &new_project_options,
             &socket_path,
         );
-        let mut cmd = Command::new(&command_line[0]);
-        for arg in &command_line[1..] {
-            cmd.arg(arg);
-        }
-        cmd.stdout(Stdio::from(stdout_log))
-            .stderr(Stdio::from(stderr_log))
-
-            // Its own process group, for the same reason the sandbox spawn
-            // takes one: Frama-C starts why3server and the provers as its own
-            // children, and kill_on_drop SIGKILLs only Frama-C itself. Without
-            // a group there is nothing to signal them through, and a server
-            // that goes away without running Drop leaves the whole tree behind.
-            // Measured: seven frama-c processes reparented to launchd, the
-            // oldest at eight and a half hours, each still holding its socket.
-            //
-            // The child is the leader, so the pgid is its pid and nothing extra
-            // needs persisting.
-            .process_group(0)
-            .kill_on_drop(true);
-
-        let mut child = cmd.spawn()
-            .map_err(|e| McpError::internal_error(format!("spawn frama-c: {}", e), None))?;
+        let mut child = spawn_frama_c(&command_line, &stdout_log_path, &stderr_log_path)?;
         let pid = child.id().unwrap_or_default();
 
         // Waiting for the socket and connecting are one step: the file exists
@@ -3174,7 +3469,11 @@ impl FramaCMcpServer {
             Err(reason) => {
                 let _ = child.start_kill();
                 let _ = child.wait().await;
+                // After the tail is read, which is the last thing that wants
+                // them.
                 let tail = startup_failure_tail(&stdout_log_path, &stderr_log_path, 20);
+                let _ = std::fs::remove_file(&stdout_log_path);
+                let _ = std::fs::remove_file(&stderr_log_path);
                 let message = format!("connect to new frama-c: {reason}\noutput:\n{tail}");
 
                 // A spawn that died in the preprocessor names the header it
@@ -3198,9 +3497,28 @@ impl FramaCMcpServer {
         // found the why3server gone. What kill_on_drop cannot promise is the
         // rest of the tree when a prover is mid-proof, since it signals one pid
         // and never the group, so the respawn goes through the path that does.
+        // The whole file at this point is the boot parse: Frama-C parses the
+        // files named on its command line before it creates the socket, and
+        // connect_when_listening returned only once that socket existed.
+        //
+        // Read again now that the parse is over, and before the locks like the
+        // read that started this call: this is the only reader that wants the
+        // state of the sources after Frama-C looked at them rather than before.
+        let parsed =
+            source_identity(new_files.clone(), new_project_options.machdep.clone()).await;
+        let (ast_parse_log_end, ast_reload_diagnostics) =
+            boot_parse_window(&stdout_log_path, &parsed.0, &ast_parse_source_digest);
+
         let mut main_lock = self.main_frama_c_state.lock().await;
         let mut client_lock = self.client.lock().await;
         let replaced = main_lock.take();
+
+        // A spawn with no record cannot grow one: the boundary it would need
+        // was a property of an instant that has passed, and reading the log
+        // later would take in whatever ran after the parse. So the absence is
+        // cached rather than retried, and the process is marked for
+        // replacement, which is the one thing that does produce a boot record.
+        let poisoned = ast_reload_diagnostics.is_some();
         *main_lock = Some(MainFramaCState {
             child,
             socket_path,
@@ -3216,8 +3534,17 @@ impl FramaCMcpServer {
             startup_stderr_tail: startup_failure_tail(&stdout_log_path, &stderr_log_path, 20),
             stdout_log_path,
             stderr_log_path,
+            ast_parse_log_end,
+            ast_parse_source_digest,
+            ast_reload_diagnostics,
+
+            // The child inherits this process's directory, and a location
+            // Frama-C writes relative is relative to that. Captured per spawn
+            // rather than read back later, so a later chdir cannot make an
+            // already-recorded location resolve somewhere else.
+            working_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             wp_model_used: None,
-            poisoned: false,
+            poisoned,
         });
         *client_lock = Some(Arc::new(new_client));
         drop(client_lock);

--- a/src/state.rs
+++ b/src/state.rs
@@ -105,13 +105,57 @@ pub fn proof_receipt_evidence_error(
 /// One home, because there were three: this, a hand-rolled write! loop, and an
 /// eight-way {:02x} format string in wpclass for the first eight bytes.
 pub fn sha256_hex(bytes: &[u8]) -> String {
+    hex_digest(Sha256::digest(bytes))
+}
+
+/// The same spelling for a digest taken a chunk at a time, so a caller that
+/// must not hold a whole file in memory gets bytes identical to sha256_hex.
+///
+/// Also whether the bytes could open a preprocessing directive, answered here
+/// because the alternative is a second pass over a file this one is already
+/// streaming. All three spellings of the "#" that starts one: the character,
+/// the digraph "%:", and the trigraph "??=". A source is free to use any of
+/// them, and the answer is used to decide whether a file reaches past its own
+/// bytes, so missing a spelling is the expensive direction; a false yes only
+/// costs a reparse.
+///
+/// Scanned byte by byte with a two-byte lookbehind rather than by searching
+/// each chunk, because a digraph or trigraph can straddle a chunk boundary and
+/// a per-chunk search cannot see one that does.
+pub fn sha256_hex_of_reader(mut reader: impl std::io::Read) -> std::io::Result<(String, bool)> {
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; 64 * 1024];
+    let mut may_be_a_directive = false;
+    let mut previous = [0u8; 2];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        if !may_be_a_directive {
+            for &byte in &buffer[..read] {
+                may_be_a_directive |= byte == b'#'
+                    || (byte == b':' && previous[1] == b'%')
+                    || (byte == b'=' && previous[1] == b'?' && previous[0] == b'?');
+                if may_be_a_directive {
+                    break;
+                }
+                previous = [previous[1], byte];
+            }
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok((hex_digest(hasher.finalize()), may_be_a_directive))
+}
+
+fn hex_digest(digest: impl AsRef<[u8]>) -> String {
     use std::fmt::Write;
 
     // One buffer, sized up front. The map-and-collect spelling allocates a
     // String per byte, 33 allocations against this one, and wpclass hashes once
     // per WP goal.
     let mut out = String::with_capacity(64);
-    for byte in Sha256::digest(bytes) {
+    for byte in digest.as_ref() {
         // Writing to a String cannot fail; the Result exists for the trait.
         let _ = write!(out, "{byte:02x}");
     }

--- a/tests/fixtures/ast-parse-clean.c
+++ b/tests/fixtures/ast-parse-clean.c
@@ -1,0 +1,3 @@
+/* Nothing for the front end to drop. The control for the two fixtures beside
+   it: both soundness categories must still be reported, at zero. */
+int clean(int x) { return x + 1; }

--- a/tests/fixtures/ast-parse-losses.c
+++ b/tests/fixtures/ast-parse-losses.c
@@ -1,0 +1,8 @@
+/* Two points where the analyzed program stops being the compiled program: an
+   inline-assembly memory clobber whose real effects Frama-C cannot see, and
+   two dropped declarations. Counted as 2 clobber sites and 2 distinct
+   attribute names. */
+int clobber_one(int x) { __asm__ volatile("" ::: "memory"); return x; }
+int clobber_two(int x) { __asm__ volatile("" ::: "memory"); return x; }
+int attribute_one(void) __attribute__((__unknown_frama_first__));
+int attribute_two(void) __attribute__((__unknown_frama_attribute__));

--- a/tests/fixtures/ast-parse-repeat-attribute.c
+++ b/tests/fixtures/ast-parse-repeat-attribute.c
@@ -1,0 +1,5 @@
+/* One unknown attribute name, used twice. Frama-C reports an unknown
+   attribute once per distinct name per process, not once per site, so the
+   count for this file is 1 and not 2. */
+int repeat_one(void) __attribute__((__unknown_frama_repeat__));
+int repeat_two(void) __attribute__((__unknown_frama_repeat__));

--- a/tests/fixtures/ast-parse-unclassified.c
+++ b/tests/fixtures/ast-parse-unclassified.c
@@ -1,0 +1,3 @@
+/* A warning category neither soundness code names, so it lands in the
+   unclassified aggregate: calling a function with no declaration in scope. */
+int implicit_warning(void) { return undeclared_function(); }

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -8391,3 +8391,336 @@ async fn check_variants_reports_configurations_that_analyse_the_same_ast() {
     );
     let _ = client.cancel().await;
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// What the parse itself cost
+//
+// Frama-C's front end drops things, and until these tests it dropped them
+// silently: the diagnostics are written while Frama-C boots, before log
+// monitoring is enabled, so the first reload_project on a file carrying them
+// answered with an empty message array. The counts below are read off the spawn
+// log instead, which is why they survive that.
+//
+// The numbers are not arbitrary and are pinned against Frama-C 33: a memory
+// clobber repeats once per site, while an unknown attribute is announced once
+// per distinct name for the life of the process. A test asserting a count has
+// to say which of the two it is asserting.
+//
+// Both the counts and the category spellings below are Frama-C's, so a kernel
+// that emits a warning differently fails these rather than degrading. That is
+// the intended direction: this server reads soundness off those exact strings,
+// so a spelling that moved is a finding this server would stop reporting, and a
+// green suite would be the wrong answer. CI measures Frama-C 33.0; the 32.1
+// lane compiles the plug-in and runs nothing. FRAMA_C_MEASURED names the
+// version these expectations were taken under, and a failure below reports it.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The Frama-C the counts and category names in this block were measured
+/// under, quoted in each failure so a version drift reads as one instead of as
+/// a broken parse.
+const FRAMA_C_MEASURED: &str = "Frama-C 33.0";
+
+fn ast_fixture(name: &str) -> String {
+    workspace_path(&format!("tests/fixtures/ast-parse-{name}.c"))
+        .to_str()
+        .expect("fixture path is utf-8")
+        .to_string()
+}
+
+async fn reload_diagnostics(
+    client: &rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    files: &[String],
+    rte: bool,
+) -> Value {
+    // Callers pass rte true unless they are after the respawn: check reloads
+    // with rte true, and a mismatch respawns Frama-C. Respawning no longer
+    // changes what the record says, but it does change which process said it,
+    // and a test comparing two of those is not measuring what it reads as.
+    let payload = call_tool_json(client, "reload_project", json!({"files": files, "rte": rte}))
+        .await
+        .unwrap_or_else(|e| panic!("reload_project({files:?}): {e}"));
+    payload["ast_reload_health"]["parse_diagnostics"].clone()
+}
+
+fn category_count(diagnostics: &Value, category: &str) -> u64 {
+    // A missing category is the failure a version drift shows up as, so it says
+    // which Frama-C the name was taken from and what this one reported instead.
+    // Without that the assertion reads as a broken parse.
+    diagnostics["categories"][category]["count"]
+        .as_u64()
+        .unwrap_or_else(|| {
+            panic!(
+                "no count for {category}, which is a {FRAMA_C_MEASURED} category name. \
+                 This Frama-C reported: {diagnostics}"
+            )
+        })
+}
+
+fn ast_incomplete_codes(check: &Value) -> Vec<String> {
+    check["incomplete"]
+        .as_array()
+        .expect("check payload has an incomplete array")
+        .iter()
+        .filter_map(|item| item["code"].as_str())
+        .filter(|code| code.starts_with("AST_"))
+        .map(str::to_string)
+        .collect()
+}
+
+/// The first reload after a spawn counts what the boot parse dropped, and a
+/// second reload of the same files answers with the same numbers.
+///
+/// The second half is the point. A reparse inside a live process cannot
+/// re-emit what a warn-once category already spent, so recounting the log
+/// would report two clobbers and no attributes: two different answers about
+/// one AST, the second of them false.
+#[tokio::test]
+async fn a_reload_counts_what_the_parse_dropped_and_keeps_counting_it() {
+    let losses = ast_fixture("losses");
+    let client = spawn_mcp_client("").await;
+
+    let first = reload_diagnostics(&client, std::slice::from_ref(&losses), true).await;
+    assert_eq!(category_count(&first, "kernel:asm:clobber"), 2, "{first}");
+    assert_eq!(category_count(&first, "kernel:attrs:unknown"), 2, "{first}");
+
+    let second = reload_diagnostics(&client, std::slice::from_ref(&losses), true).await;
+    assert_eq!(second, first, "one AST, two answers");
+
+    // The clobber sample names where, and says how many it did not name.
+    let sample = first["categories"]["kernel:asm:clobber"]["locations"]
+        .as_array()
+        .expect("a location sample");
+    assert_eq!(sample.len(), 2, "{first}");
+    assert!(
+        sample[0]["file"]
+            .as_str()
+            .is_some_and(|file| file.ends_with("ast-parse-losses.c")),
+        "{first}"
+    );
+    assert_eq!(first["categories"]["kernel:asm:clobber"]["locations_omitted"], 0);
+    assert_eq!(
+        first["categories"]["kernel:attrs:unknown"]["count_unit"],
+        "distinct_attribute_names"
+    );
+    let _ = client.cancel().await;
+}
+
+/// One attribute name at two sites is one dropped declaration kind, and the
+/// count says so. Frama-C announces it once per name, and the unit reported
+/// beside the count is what makes the number readable.
+#[tokio::test]
+async fn a_repeated_attribute_name_counts_once() {
+    let client = spawn_mcp_client("").await;
+    let diagnostics = reload_diagnostics(&client, &[ast_fixture("repeat-attribute")], true).await;
+    assert_eq!(
+        category_count(&diagnostics, "kernel:attrs:unknown"),
+        1,
+        "{diagnostics}"
+    );
+    let _ = client.cancel().await;
+}
+
+/// A clean parse reports zero rather than omitting the category. An absent key
+/// is a caller guessing whether the question was asked.
+#[tokio::test]
+async fn a_clean_parse_reports_zero_rather_than_omitting_the_category() {
+    let client = spawn_mcp_client("").await;
+    let diagnostics = reload_diagnostics(&client, &[ast_fixture("clean")], true).await;
+    assert_eq!(category_count(&diagnostics, "kernel:asm:clobber"), 0);
+    assert_eq!(category_count(&diagnostics, "kernel:attrs:unknown"), 0);
+    let _ = client.cancel().await;
+}
+
+/// The two soundness classes reach the verdict, once each, on every check of
+/// the session rather than only the first.
+#[tokio::test]
+async fn check_names_each_ast_loss_on_every_call_not_only_the_first() {
+    let client = spawn_mcp_client(&ast_fixture("losses")).await;
+    let want = json!({"function": "clobber_one", "want": ["eva"]});
+
+    let first = call_tool_json(&client, "check", want.clone())
+        .await
+        .expect("check on the losses fixture");
+    let codes = ast_incomplete_codes(&first);
+    assert_eq!(
+        codes,
+        vec!["AST_ASM_CLOBBER", "AST_UNKNOWN_ATTRIBUTE"],
+        "{:?}",
+        first["incomplete"]
+    );
+
+    let second = call_tool_json(&client, "check", want)
+        .await
+        .expect("a second check in the same session");
+    assert_eq!(ast_incomplete_codes(&second), codes, "{:?}", second["incomplete"]);
+
+    // No hedge on the count. The record is a boot parse, so nothing was
+    // suppressed and nothing else was writing into its window.
+    let clobber = first["incomplete"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["code"] == "AST_ASM_CLOBBER")
+        .unwrap();
+    assert_eq!(clobber["count"], 2);
+    assert!(clobber["counts_are_complete"].is_null(), "{clobber}");
+    let _ = client.cancel().await;
+}
+
+/// A file with nothing dropped carries neither soundness code.
+#[tokio::test]
+async fn check_carries_no_ast_code_for_a_clean_parse() {
+    let client = spawn_mcp_client(&ast_fixture("clean")).await;
+    let payload = call_tool_json(&client, "check", json!({"function": "clean", "want": ["eva"]}))
+        .await
+        .expect("check on the clean fixture");
+    assert!(
+        ast_incomplete_codes(&payload).is_empty(),
+        "{:?}",
+        payload["incomplete"]
+    );
+    let _ = client.cancel().await;
+}
+
+/// A category nobody classified is still reported, in the aggregate, with its
+/// count. Silence here would be this server deciding a warning is benign
+/// without saying so.
+#[tokio::test]
+async fn an_unclassified_parse_warning_reaches_the_aggregate() {
+    let client = spawn_mcp_client(&ast_fixture("unclassified")).await;
+    let payload = call_tool_json(
+        &client,
+        "check",
+        json!({"function": "implicit_warning", "want": ["eva"]}),
+    )
+    .await
+    .expect("check on the unclassified fixture");
+
+    assert_eq!(
+        ast_incomplete_codes(&payload),
+        vec!["AST_UNCLASSIFIED_WARNING"],
+        "{:?}",
+        payload["incomplete"]
+    );
+    let aggregate = payload["incomplete"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["code"] == "AST_UNCLASSIFIED_WARNING")
+        .unwrap();
+
+    // The whole record, not a bare count: one entry keeps the payload bounded
+    // without costing the caller the unit or the site.
+    let record = &aggregate["categories"]["kernel:typing:implicit-function-declaration"];
+    assert_eq!(record["count"], 1, "{aggregate}");
+    assert_eq!(record["count_unit"], "sites", "{aggregate}");
+    assert!(
+        record["locations"][0]["file"]
+            .as_str()
+            .is_some_and(|file| file.ends_with("ast-parse-unclassified.c")),
+        "{aggregate}"
+    );
+    assert_eq!(record["locations_omitted"], 0, "{aggregate}");
+    let _ = client.cancel().await;
+}
+
+/// Editing a file in place is a new AST even though the path list is
+/// unchanged, and the record follows the bytes rather than the paths.
+///
+/// A path list cannot say that an edit happened, so the digest is over the
+/// bytes; a file set that fails it gets a new process rather than a reparse
+/// whose counts would have to be hedged.
+#[tokio::test]
+async fn an_edit_behind_an_unchanged_path_is_a_new_parse() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let source = tmp.path().join("edited.c");
+    std::fs::write(
+        &source,
+        "int one(int x) { __asm__ volatile(\"\" ::: \"memory\"); return x; }\n",
+    )
+    .expect("write fixture");
+    let files = vec![source.to_str().expect("utf-8 path").to_string()];
+
+    let client = spawn_mcp_client("").await;
+    let first = reload_diagnostics(&client, &files, true).await;
+    assert_eq!(category_count(&first, "kernel:asm:clobber"), 1, "{first}");
+
+    std::fs::write(
+        &source,
+        "int one(int x) { __asm__ volatile(\"\" ::: \"memory\"); return x; }\n\
+         int two(int x) { __asm__ volatile(\"\" ::: \"memory\"); return x; }\n",
+    )
+    .expect("rewrite fixture");
+
+    let second = reload_diagnostics(&client, &files, true).await;
+    assert_eq!(category_count(&second, "kernel:asm:clobber"), 2, "{second}");
+    let _ = client.cancel().await;
+}
+
+/// A source that pulls in headers gets a new Frama-C rather than a reparse, so
+/// its counts are the same on every call.
+///
+/// The reparse this replaces could not re-announce a warn-once category, so
+/// the attribute count fell to zero on the second call and the caller was
+/// handed a zero that was evidence of nothing. Reload rebuilds the AST from
+/// source either way, so a respawn costs process lifetime rather than anything
+/// the caller was holding.
+#[tokio::test]
+async fn a_source_with_includes_reports_the_same_counts_on_every_call() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let source = tmp.path().join("included.c");
+    std::fs::write(
+        &source,
+        "#include <stddef.h>\n\
+         int one(int x) { __asm__ volatile(\"\" ::: \"memory\"); return x; }\n\
+         int two(void) __attribute__((__unknown_frama_included__));\n",
+    )
+    .expect("write fixture");
+    let files = vec![source.to_str().expect("utf-8 path").to_string()];
+
+    let client = spawn_mcp_client("").await;
+    let first = reload_diagnostics(&client, &files, true).await;
+    assert_eq!(category_count(&first, "kernel:asm:clobber"), 1, "{first}");
+    assert_eq!(category_count(&first, "kernel:attrs:unknown"), 1, "{first}");
+
+    let second = reload_diagnostics(&client, &files, true).await;
+    assert_eq!(second, first, "one AST, two answers: {second}");
+
+    // And the finding reaches the verdict with no hedge on it.
+    let payload = call_tool_json(&client, "check", json!({"function": "one", "want": ["eva"]}))
+        .await
+        .expect("check after the reload");
+    let clobber = payload["incomplete"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["code"] == "AST_ASM_CLOBBER")
+        .expect("the clobber is a finding");
+    assert_eq!(clobber["count"], 1, "{clobber}");
+    assert!(clobber["counts_are_complete"].is_null(), "{clobber}");
+    let _ = client.cancel().await;
+}
+
+/// Changing the load options respawns, and the record follows the new process.
+///
+/// Worth pinning separately because a respawn takes the other branch of
+/// ensure_main_spawned, and that branch writes the record from its own boot
+/// rather than carrying anything forward.
+#[tokio::test]
+async fn a_respawn_reports_the_new_process_parse() {
+    let losses = ast_fixture("losses");
+    let client = spawn_mcp_client("").await;
+
+    let first = reload_diagnostics(&client, std::slice::from_ref(&losses), true).await;
+    assert_eq!(category_count(&first, "kernel:attrs:unknown"), 2, "{first}");
+
+    // Same files, rte off: a respawn rather than an in-place reload.
+    let respawned = reload_diagnostics(&client, std::slice::from_ref(&losses), false).await;
+    assert_eq!(
+        category_count(&respawned, "kernel:attrs:unknown"),
+        2,
+        "a new process has spent no warn-once category: {respawned}"
+    );
+    assert_eq!(category_count(&respawned, "kernel:asm:clobber"), 2, "{respawned}");
+    let _ = client.cancel().await;
+}

--- a/tests/test-process-lifecycle.rs
+++ b/tests/test-process-lifecycle.rs
@@ -1862,6 +1862,16 @@ fn self_check_reports_capabilities_over_stdio() {
             .any(|item| item["request"] == request));
     }
 }
+/// Which reloads keep the process and which replace it.
+///
+/// The same file set, unchanged on disk, is reloaded in place: the AST is
+/// rebuilt inside the running Frama-C and the pid does not move. A different
+/// file set is not, and that is the parse record rather than the AST. The
+/// record of what the front end dropped is a boot parse, so it answers for the
+/// files that process was started on and for no others; a reparse could not
+/// re-announce a warn-once category, so reusing the process would leave the
+/// counts describing the previous file set. This test used to assert the
+/// opposite, and it is the only place either half is pinned.
 #[test]
 #[cfg(target_os = "linux")]
 fn in_place_reload_preserves_frama_c_pid() {
@@ -1882,8 +1892,10 @@ fn in_place_reload_preserves_frama_c_pid() {
     eprintln!("[test] first reload frama-c PID = {}", frama_pid_1);
     assert!(process_alive(frama_pid_1));
 
-    let args_b = format!(r#"{{"files":["{}"],"rte":false}}"#, test_c_b.display());
-    let r = mcp.call_tool("reload_project", &args_b);
+    // The same files again, untouched: neither fixture carries a preprocessor
+    // directive, so the bytes behind the paths are the whole input and they are
+    // the ones the boot parse read.
+    let r = mcp.call_tool("reload_project", &args_a);
     assert!(r.get("error").is_none(), "second reload failed: {:?}", r);
 
     // The claim is that the reload happened in place, so wait for the child to
@@ -1899,6 +1911,34 @@ fn in_place_reload_preserves_frama_c_pid() {
         frama_pid_1, frama_pid_2
     );
     assert!(process_alive(frama_pid_1), "frama-c should still be alive");
+
+    // A different file set: a new process, because the record on this one
+    // cannot answer for files it never parsed. Waiting for a pid that differs
+    // rather than for any pid at all, since the old process is killed after the
+    // new one connects and both are children for that moment.
+    let args_b = format!(r#"{{"files":["{}"],"rte":false}}"#, test_c_b.display());
+    let r = mcp.call_tool("reload_project", &args_b);
+    assert!(r.get("error").is_none(), "third reload failed: {:?}", r);
+
+    let frama_pid_3 = wait_until_some(
+        || first_child_pid(mcp_pid).filter(|pid| *pid != frama_pid_2),
+        Duration::from_secs(10),
+    )
+    .expect("a new file set should get its own frama-c");
+    eprintln!("[test] third reload frama-c PID = {}", frama_pid_3);
+    assert!(process_alive(frama_pid_3), "the new frama-c should be alive");
+
+    // Replaced, not joined. Waiting rather than asserting outright: the old
+    // process is killed after the new one connects, so for a moment both are
+    // alive, and a test that read the pid table once would be racing that.
+    assert!(
+        wait_until_some(
+            || (!process_alive(frama_pid_2)).then_some(()),
+            Duration::from_secs(10)
+        )
+        .is_some(),
+        "the replaced frama-c should be gone, not leaked alongside the new one"
+    );
 }
 
 /// Dropping a client must not orphan the server's Frama-C.

--- a/tests/test-store-conclusion.rs
+++ b/tests/test-store-conclusion.rs
@@ -144,7 +144,8 @@ fn a_conclusion_from_another_build_loads_as_unverified() {
     // prove the branch exists without proving the fixture reaches it, so a
     // fixture that started failing on its hash would still look right here.
     //
-    // wp_summary above says one goal, which is what makes the counts meaningful.
+    // wp_summary above says one goal, which is what makes the counts
+    // meaningful.
     assert_eq!(
         proof_receipt_evidence_error(&hollow, 1).as_deref(),
         Some("proof_receipt has no goals")

--- a/tests/unit/check-gaps.rs
+++ b/tests/unit/check-gaps.rs
@@ -95,6 +95,139 @@ fn undischarged_rte_alarm_makes_check_incomplete() {
     assert_eq!(flagged, vec![&json!("#p4"), &json!("#p5")]);
 }
 
+fn reload_with_categories(categories: serde_json::Value) -> serde_json::Value {
+    json!({"ast_reload_health": {"parse_diagnostics": {"categories": categories}}})
+}
+
+fn ast_gaps(reload: &serde_json::Value) -> Vec<serde_json::Value> {
+    check_incomplete_items(
+        Some(true),
+        reload,
+        &json!({"ok": true}),
+        &json!([]),
+        &json!({"ok": true}),
+        &json!([]),
+        WantedAnalyses::BOTH,
+    )
+    .into_iter()
+    .filter(|item| {
+        item["code"]
+            .as_str()
+            .is_some_and(|code| code.starts_with("AST_"))
+    })
+    .collect()
+}
+
+fn record(count: u64, unit: &str) -> serde_json::Value {
+    json!({"count": count, "count_unit": unit, "locations": [], "locations_omitted": 0})
+}
+
+/// Each soundness class is its own code, and everything nobody classified
+/// shares one entry: a payload with an entry per category grows with the
+/// program rather than with the finding.
+#[test]
+fn ast_parse_losses_make_check_incomplete() {
+    let reload = reload_with_categories(
+        json!({
+            "kernel:asm:clobber": record(2, "sites"),
+            "kernel:attrs:unknown": record(1, "distinct_attribute_names"),
+            "kernel:typing:implicit-function-declaration": record(1, "sites"),
+            "kernel:annot:unknown": record(3, "sites"),
+        }),
+    );
+    let items = ast_gaps(&reload);
+    let codes: Vec<_> = items.iter().filter_map(|item| item["code"].as_str()).collect();
+    assert_eq!(
+        codes,
+        vec![
+            "AST_ASM_CLOBBER",
+            "AST_UNKNOWN_ATTRIBUTE",
+            "AST_UNCLASSIFIED_WARNING"
+        ],
+        "{items:?}"
+    );
+
+    let aggregate = items.last().unwrap();
+
+    // Each category keeps its whole record, so the one entry is still enough to
+    // read the number and reach the site.
+    assert_eq!(
+        aggregate["categories"],
+        json!({
+            "kernel:annot:unknown": record(3, "sites"),
+            "kernel:typing:implicit-function-declaration": record(1, "sites"),
+        })
+    );
+    assert_eq!(items[0]["count"], 2);
+    assert_eq!(items[1]["count_unit"], "distinct_attribute_names");
+}
+
+/// A category with a zero count is not a finding, so a clean parse carries no
+/// AST code at all.
+#[test]
+fn a_clean_parse_carries_no_ast_code() {
+    let reload = reload_with_categories(
+        json!({
+            "kernel:asm:clobber": record(0, "sites"),
+            "kernel:attrs:unknown": record(0, "distinct_attribute_names"),
+        }),
+    );
+    assert!(ast_gaps(&reload).is_empty());
+}
+
+/// No entry carries a completeness flag, because there is nothing for one to
+/// say: the record is always a boot parse, ensure_main_spawned having
+/// respawned rather than hand back a reparse.
+///
+/// The property that buys is that two checks of one session report the same
+/// codes. An entry that appeared only on the second would move
+/// proof_receipt.sha256, since the receipt digests incomplete, and two runs of
+/// the same thing would stop matching.
+#[test]
+fn ast_codes_do_not_depend_on_when_the_caller_asked() {
+    let categories = json!({
+        "kernel:asm:clobber": record(2, "sites"),
+        "kernel:typing:implicit-function-declaration": record(1, "sites"),
+    });
+    let items = ast_gaps(&reload_with_categories(categories));
+    assert_eq!(items.len(), 2, "{items:?}");
+    for item in &items {
+        assert!(item["counts_are_complete"].is_null(), "{item:?}");
+    }
+
+    // A zero is evidence of absence rather than a category that may have been
+    // suppressed, which is what lets it be silent.
+    let quiet = ast_gaps(&reload_with_categories(json!({
+        "kernel:attrs:unknown": record(0, "distinct_attribute_names"),
+    })));
+    assert!(quiet.is_empty(), "{quiet:?}");
+}
+
+/// The categories 22.1.2 named are not candidates for the aggregate; every
+/// other warning category, including compilation-database ambiguity, is.
+#[test]
+fn compilation_database_warnings_reach_the_unclassified_aggregate() {
+    let reload = reload_with_categories(
+        json!({
+            "kernel:asm:clobber": record(2, "sites"),
+            "kernel:attrs:unknown": record(2, "distinct_attribute_names"),
+            "kernel:pp:compilation-db": record(1, "sites"),
+        }),
+    );
+    let items = ast_gaps(&reload);
+    assert_eq!(
+        items.last().unwrap()["categories"],
+        json!({"kernel:pp:compilation-db": record(1, "sites")})
+    );
+}
+
+/// A missing or malformed parse record is silence, not a finding. An older
+/// reload payload has no parse_diagnostics key at all.
+#[test]
+fn a_reload_without_parse_diagnostics_carries_no_ast_code() {
+    assert!(ast_gaps(&json!({"ast_reload_health": {"checked": true}})).is_empty());
+}
+
 /// An abort is a gap only when it cost a goal its verdict.
 ///
 /// The anomaly text below is verbatim from Frama-C 33 on

--- a/tests/unit/project.rs
+++ b/tests/unit/project.rs
@@ -1,6 +1,8 @@
 use frama_c_mcp::mcp::server::*;
 
 use frama_c_mcp::mcp::server::project::*;
+use serde_json::json;
+use std::path::Path;
 
 fn with_defines(defines: &[&str]) -> ProjectLoadOptions {
     ProjectLoadOptions {
@@ -32,6 +34,323 @@ fn plain_and_valued_defines_are_accepted() {
 fn ordinary_paths_and_headers_are_accepted() {
     assert!(validate_project_options(&with_include_paths(&["include", "../vendor/inc"])).is_ok());
     assert!(validate_project_options(&with_force_includes(&["builtins.h", "sys/types.h"])).is_ok());
+}
+
+/// The log shape is verbatim Frama-C 33: tag and location on one line, text
+/// indented on the next. The feedback line and the untagged "[kernel] Parsing"
+/// line are both in the sample because both are in every real log.
+fn sample_log() -> String {
+    let mut log = String::from("[kernel] Parsing a.c (with preprocessing)\n");
+    log.push_str("[kernel:pp:compilation-db] using compilation database:\n  a.json\n");
+    for line in 1..=21 {
+        log.push_str(&format!(
+            "[kernel:asm:clobber] src/a.c:{line}: Warning: \n  Clobber list contains \"memory\" argument.\n"
+        ));
+    }
+    for (line, name) in [(30, "one"), (31, "one"), (32, "two")] {
+        log.push_str(&format!(
+            "[kernel:attrs:unknown] src/a.c:{line}: Warning: \n  Ignoring unknown attribute: {name}\n"
+        ));
+    }
+    log.push_str("[kernel:typing:implicit-function-declaration] /abs/b.c:40: Warning: \n  Calling undeclared function f. Old style K&R code?\n");
+    log
+}
+
+#[test]
+fn ast_parse_diagnostics_counts_only_warning_tags_and_bounds_samples() {
+    let log = sample_log();
+    let health = ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+    let categories = &health["categories"];
+
+    assert_eq!(categories["kernel:asm:clobber"]["count"], 21);
+    assert_eq!(categories["kernel:asm:clobber"]["count_unit"], "sites");
+    assert_eq!(
+        categories["kernel:asm:clobber"]["locations"].as_array().unwrap().len(),
+        20
+    );
+    assert_eq!(categories["kernel:asm:clobber"]["locations_omitted"], 1);
+
+    // Three warnings, two names. The unit says which of those it reports.
+    assert_eq!(categories[ATTRS_UNKNOWN]["count"], 2);
+    assert_eq!(
+        categories[ATTRS_UNKNOWN]["count_unit"],
+        "distinct_attribute_names"
+    );
+
+    assert_eq!(
+        categories["kernel:typing:implicit-function-declaration"]["count"],
+        1
+    );
+
+    // A tag without the Warning token is feedback, and an untagged line is
+    // neither.
+    assert!(categories.get("kernel:pp:compilation-db").is_none());
+    assert!(categories.get("kernel").is_none());
+}
+
+/// A relative location resolves against the child's working directory and an
+/// absolute one is left alone, because Frama-C prints both and neither form
+/// matches the argument the caller passed.
+#[test]
+fn ast_parse_diagnostics_resolves_locations_against_the_child_directory() {
+    let log = sample_log();
+    let health = ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+    let clobber = &health["categories"]["kernel:asm:clobber"]["locations"][0];
+    assert_eq!(clobber["file"], "/work/src/a.c");
+    assert_eq!(clobber["line"], 1);
+    let implicit =
+        &health["categories"]["kernel:typing:implicit-function-declaration"]["locations"][0];
+    assert_eq!(implicit["file"], "/abs/b.c");
+    assert_eq!(implicit["line"], 40);
+}
+
+/// Both soundness categories are keys even when nothing fired, so a caller
+/// reads a zero rather than a missing key.
+#[test]
+fn ast_parse_diagnostics_reports_zero_for_a_clean_parse() {
+    let log = "[kernel] Parsing clean.c (with preprocessing)\n";
+    let health = ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+    assert_eq!(health["categories"]["kernel:asm:clobber"]["count"], 0);
+    assert_eq!(health["categories"][ATTRS_UNKNOWN]["count"], 0);
+}
+
+/// The offsets select the boot parse out of a log that has since grown. Only
+/// the named window is counted; bytes on either side are another AST's.
+#[test]
+fn ast_parse_diagnostics_counts_only_the_named_window() {
+    let boot = "[kernel:asm:clobber] a.c:1: Warning: \n  Clobber list contains \"memory\" argument.\n";
+    let later = "[kernel:asm:clobber] b.c:9: Warning: \n  Clobber list contains \"memory\" argument.\n";
+    let log = format!("{boot}{later}");
+    let health = ast_parse_diagnostics(log.as_bytes(), boot.len() as u64, Path::new("/work"));
+    assert_eq!(health["categories"]["kernel:asm:clobber"]["count"], 1);
+
+    // Out-of-range offsets clamp rather than panic.
+    let all = ast_parse_diagnostics(log.as_bytes(), u64::MAX, Path::new("/work"));
+    assert_eq!(all["categories"]["kernel:asm:clobber"]["count"], 2);
+    let empty = ast_parse_diagnostics(log.as_bytes(), 0, Path::new("/work"));
+    assert_eq!(empty["categories"]["kernel:asm:clobber"]["count"], 0);
+}
+
+/// A bracket in a directory name is not a category, on either side of the tag.
+///
+/// Both orderings are here because each broke the other anchor: taking the
+/// first bracket on the line read "[v1]" as the category when the path came
+/// first, and taking the last read it as the category when the path came after
+/// the tag, which dropped the warning entirely rather than misfiling it.
+#[test]
+fn ast_parse_diagnostics_ignores_brackets_outside_the_tag() {
+    let clobber = "  Clobber list contains \"memory\" argument.";
+    for (label, line) in [
+        ("path before the tag", "src/[v1]/a.c:3: [kernel:asm:clobber] Warning: "),
+        ("path after the tag", "[kernel:asm:clobber] src/[v1]/a.c:3: Warning: "),
+    ] {
+        let log = format!("{line}\n{clobber}\nsrc/[v1]/b.c:4: Warning: something untagged\n");
+        let health =
+            ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+        assert_eq!(
+            health["categories"]["kernel:asm:clobber"]["count"], 1,
+            "{label}: {health}"
+        );
+        assert_eq!(
+            health["categories"]["kernel:asm:clobber"]["locations"][0]["file"],
+            "/work/src/[v1]/a.c",
+            "{label}"
+        );
+        assert!(health["categories"].get("v1").is_none(), "{label}");
+    }
+}
+
+#[test]
+fn ast_parse_diagnostics_ignores_colon_containing_bracketed_paths() {
+    let log = "src/[team:api]/a.c:3: [kernel:asm:clobber] Warning: \n  Clobber list contains \"memory\" argument.\n";
+    let health =
+        ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+
+    assert_eq!(health["categories"]["kernel:asm:clobber"]["count"], 1);
+    assert_eq!(
+        health["categories"]["kernel:asm:clobber"]["locations"][0]["file"],
+        "/work/src/[team:api]/a.c"
+    );
+    assert!(health["categories"].get("team:api").is_none(), "{health}");
+}
+
+/// A path that carries the "Warning:" token itself. The marker search has to
+/// keep going until it finds one with a tag before it, because stopping at the
+/// first left a head with no tag in it and dropped the warning: the count is
+/// the soundness claim, so losing it is worse than resolving its location to
+/// the directory the path was cut at.
+#[test]
+fn ast_parse_diagnostics_reads_a_line_whose_path_carries_the_marker() {
+    for (label, line) in [
+        ("path before the tag", "src/Warning:x/a.c:3: [kernel:asm:clobber] Warning: "),
+        ("path after the tag", "[kernel:asm:clobber] src/Warning:x/a.c:3: Warning: "),
+    ] {
+        let log = format!("{line}\n  Clobber list contains \"memory\" argument.\n");
+        let health = ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+        assert_eq!(health["categories"][ASM_CLOBBER]["count"], 1, "{label}: {health}");
+    }
+}
+
+/// An unmatched "[" in the path pairs with the tag's own closing bracket, so
+/// the scan has to resume after the bracket it rejected rather than after the
+/// one it borrowed. Resuming past the "]" stepped over the tag and dropped the
+/// warning, which is the failure that hides a soundness finding rather than
+/// misfiling it.
+#[test]
+fn ast_parse_diagnostics_reads_a_tag_after_an_unmatched_bracket() {
+    let log = "src/[dir/a.c:3: [kernel:asm:clobber] Warning: \n  Clobber list contains \"memory\" argument.\n";
+    let health = ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+
+    assert_eq!(health["categories"][ASM_CLOBBER]["count"], 1, "{health}");
+    assert_eq!(
+        health["categories"][ASM_CLOBBER]["locations"][0]["file"],
+        "/work/src/[dir/a.c"
+    );
+}
+
+/// The same segment at the head of a relative path, where the left side is a
+/// field boundary too and only the character after the bracket separates a
+/// path from a tag.
+#[test]
+fn ast_parse_diagnostics_ignores_a_bracketed_path_that_opens_the_line() {
+    let log = "[team:api]/a.c:3: [kernel:asm:clobber] Warning: \n  Clobber list contains \"memory\" argument.\n";
+    let health = ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+
+    assert_eq!(health["categories"]["kernel:asm:clobber"]["count"], 1, "{health}");
+    assert_eq!(
+        health["categories"]["kernel:asm:clobber"]["locations"][0]["file"],
+        "/work/[team:api]/a.c"
+    );
+    assert!(health["categories"].get("team:api").is_none(), "{health}");
+}
+
+/// Frama-C puts the attribute name on the tag line when it fits and wraps it
+/// onto the next when it does not, and which happens is a function of the path
+/// length against the margin.
+///
+/// Measured on Frama-C 33: "a.c:1" keeps "__q__" on the tag line, while the
+/// same attribute reported under a path like this repository's fixtures wraps.
+/// Reading only the wrapped form counted zero attributes for every project
+/// with short paths, and every fixture here has a long one, so nothing caught
+/// it.
+#[test]
+fn ast_parse_diagnostics_reads_an_attribute_name_on_either_line() {
+    let wrapped = "[kernel:attrs:unknown] tests/fixtures/long-enough-to-wrap.c:3: Warning: \n  Ignoring unknown attribute: __wrapped__\n";
+    let inline = "[kernel:attrs:unknown] a.c:1: Warning: Ignoring unknown attribute: __q__\n";
+
+    for (label, log, name, line) in [
+        ("wrapped", wrapped, "__wrapped__", 3),
+        ("same line", inline, "__q__", 1),
+    ] {
+        let health =
+            ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+        let entry = &health["categories"][ATTRS_UNKNOWN]["locations"][0];
+        assert_eq!(health["categories"][ATTRS_UNKNOWN]["count"], 1, "{label}");
+        assert_eq!(entry["attribute"], name, "{label}");
+        assert_eq!(entry["location"]["line"], line, "{label}");
+    }
+
+    // Both spellings in one log are still two names and two counts.
+    let log = format!("{wrapped}{inline}");
+    let health =
+        ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+    assert_eq!(health["categories"][ATTRS_UNKNOWN]["count"], 2, "{health}");
+}
+
+/// A warning between an attribute's tag line and its name ends the wrap.
+///
+/// The name is still counted, because the count is the soundness claim and an
+/// unpinned location is a worse answer than none rather than a reason to drop
+/// the finding. What must not happen is the name inheriting the earlier
+/// warning's location and pointing at the wrong file.
+#[test]
+fn an_interrupted_attribute_keeps_its_count_and_loses_only_its_location() {
+    let log = "[kernel:attrs:unknown] src/a.c:3: Warning: \n               [kernel:asm:clobber] src/b.c:9: Warning: \n               \x20 Clobber list contains \"memory\" argument.\n               \x20 Ignoring unknown attribute: __orphan__\n";
+    let health =
+        ast_parse_diagnostics(log.as_bytes(), log.len() as u64, Path::new("/work"));
+
+    assert_eq!(health["categories"][ATTRS_UNKNOWN]["count"], 1, "{health}");
+    let entry = &health["categories"][ATTRS_UNKNOWN]["locations"][0];
+    assert_eq!(entry["attribute"], "__orphan__", "{health}");
+    assert_eq!(
+        entry["location"], json!({"unresolved": true}),
+        "src/a.c:3 belongs to the clobber's neighbour, not to this name: {health}"
+    );
+    assert_eq!(health["categories"]["kernel:asm:clobber"]["count"], 1, "{health}");
+}
+
+/// A window this server could not read reports no category at all. A zero
+/// would be a claim that the front end dropped nothing, which is the one thing
+/// an unreadable log cannot establish.
+#[test]
+fn an_unreadable_parse_log_is_not_a_clean_parse() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("never-written.stdout.log");
+    let record = unreadable_parse_log(&missing, &std::io::Error::from(std::io::ErrorKind::NotFound));
+
+    assert_eq!(record["categories"], json!({}));
+    assert!(
+        record["unavailable"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("never-written.stdout.log")),
+        "{record}"
+    );
+
+    // And check reads it as a finding rather than as silence. Silence would let
+    // a verdict of "proved" stand on the one shape where nothing established
+    // that the analyzed program is the compiled one.
+    let reload = json!({"ast_reload_health": {"parse_diagnostics": record}});
+    let mut items = Vec::new();
+    analysis::ast_diagnostic_gaps(&mut items, &reload, &[]);
+    assert_eq!(items.len(), 1, "{items:?}");
+    assert_eq!(
+        items[0]["code"],
+        analysis::incomplete_code::AST_PARSE_DIAGNOSTICS_UNAVAILABLE
+    );
+    assert!(
+        items[0]["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("never-written.stdout.log")),
+        "{items:?}"
+    );
+
+    // And it is the whole answer: a record with no categories has nothing to
+    // say about any of them, so no zero row follows it.
+    let clean = json!({"ast_reload_health": {"parse_diagnostics": {"categories": {
+        "kernel:asm:clobber": {"count": 0, "count_unit": "sites"},
+    }}}});
+    let mut items = Vec::new();
+    analysis::ast_diagnostic_gaps(&mut items, &clean, &[]);
+    assert!(items.is_empty(), "{items:?}");
+}
+
+#[test]
+fn header_bearing_sources_do_not_reuse_parse_diagnostics() {
+    let dir = tempfile::tempdir().unwrap();
+    let plain = dir.path().join("plain.c");
+    let included = dir.path().join("included.c");
+    std::fs::write(&plain, "int f(void) { return 0; }\n").unwrap();
+    std::fs::write(&included, "# include \"header.h\"\nint f(void) { return 0; }\n").unwrap();
+
+    // A comment can precede the directive on its own line, so a scan anchored
+    // to the first character of the line reads this as header-free.
+    let commented = dir.path().join("commented.c");
+    std::fs::write(&commented, "/**/#include \"header.h\"\nint f(void) { return 0; }\n").unwrap();
+
+    // The same directive written with the digraph and with the trigraph. Both
+    // are the preprocessor pulling in bytes the digest does not cover, and
+    // neither carries a "#".
+    let digraph = dir.path().join("digraph.c");
+    std::fs::write(&digraph, "%:include \"header.h\"\nint f(void) { return 0; }\n").unwrap();
+    let trigraph = dir.path().join("trigraph.c");
+    std::fs::write(&trigraph, "??=include \"header.h\"\nint f(void) { return 0; }\n").unwrap();
+
+    assert!(!files_may_include(&[plain.display().to_string()]));
+    assert!(files_may_include(&[included.display().to_string()]));
+    assert!(files_may_include(&[commented.display().to_string()]));
+    assert!(files_may_include(&[digraph.display().to_string()]));
+    assert!(files_may_include(&[trigraph.display().to_string()]));
+    assert!(files_may_include(&[dir.path().join("missing.c").display().to_string()]));
 }
 
 // -cpp-extra-args is shell-evaluated by Frama-C, so these fields are shell
@@ -146,4 +465,118 @@ fn custom_machdep_paths_are_accepted() {
 #[test]
 fn an_empty_define_is_rejected() {
     assert!(validate_project_options(&with_defines(&[""])).is_err());
+}
+
+/// What makes a file set ineligible for the cached parse record: anything
+/// whose bytes reach beyond the files the caller named.
+///
+/// The scan is deliberately crude and errs toward declining. An include
+/// spelled inside a comment or a dead conditional costs a recount; an include
+/// missed would let this server claim a count it cannot stand behind.
+#[test]
+fn a_file_set_that_reaches_past_its_own_bytes_declines_the_cached_record() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let write = |name: &str, body: &str| {
+        let path = tmp.path().join(name);
+        std::fs::write(&path, body).expect("write fixture");
+        path.to_str().expect("utf-8 path").to_string()
+    };
+
+    let plain = write("plain.c", "int f(void) { return 0; }\n");
+    assert!(!files_may_include(std::slice::from_ref(&plain)));
+
+    for (name, body) in [
+        ("direct.c", "#include <stdio.h>\nint f(void) { return 0; }\n"),
+        ("local.c", "#include \"own.h\"\nint f(void) { return 0; }\n"),
+        ("indented.c", "  #  include <stdio.h>\nint f(void) { return 0; }\n"),
+    ] {
+        let file = write(name, body);
+        assert!(files_may_include(&[file]), "{name} reaches past its bytes");
+    }
+
+    // One include anywhere in the set is the whole set.
+    let with_include = write("mixed.c", "#include <stdio.h>\n");
+    assert!(files_may_include(&[plain.clone(), with_include]));
+
+    // A file that cannot be read is not a file whose bytes are known.
+    let missing = tmp.path().join("gone.c").to_str().unwrap().to_string();
+    assert!(files_may_include(&[missing]));
+
+    // Any directive, not only an include. "#/**/include" is a legal spelling
+    // and telling it from a define needs the line stripped of comments first,
+    // so the scan does not try: a define costs a recount it did not need, which
+    // is cheaper than a missed include costing a stale claim.
+    for name in ["#define N 1\n", "#/**/include <stdio.h>\n", "#if 0\n#endif\n"] {
+        let file = write("directive.c", name);
+        assert!(files_may_include(&[file]), "{name:?}");
+    }
+}
+
+/// The digest follows the bytes, so it separates an edit from a re-read and
+/// separates two paths that happen to hold the same text.
+#[test]
+fn the_source_digest_moves_with_the_bytes_and_with_the_names() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("a.c");
+    let name = |p: &std::path::Path| p.to_str().expect("utf-8 path").to_string();
+
+    std::fs::write(&path, "int f(void) { return 0; }\n").expect("write");
+    let first = loaded_source_digest(&[name(&path)], None);
+    assert_eq!(first, loaded_source_digest(&[name(&path)], None), "re-read");
+
+    std::fs::write(&path, "int f(void) { return 1; }\n").expect("rewrite");
+    assert_ne!(first, loaded_source_digest(&[name(&path)], None), "edit in place");
+
+    // Same bytes written again is a different state, because an edit and a
+    // restore between two reads hash the same and the identity has to see the
+    // round trip. Conditional on the write actually moving the modification
+    // time, which is the same limit the identity has: a filesystem that stamps
+    // both writes identically cannot distinguish them and neither can this.
+    let written = |p: &std::path::Path| std::fs::metadata(p).unwrap().modified().unwrap();
+    let before = written(&path);
+    let restored = loaded_source_digest(&[name(&path)], None);
+    std::fs::write(&path, "int f(void) { return 1; }\n").expect("rewrite the same bytes");
+    if written(&path) != before {
+        assert_ne!(restored, loaded_source_digest(&[name(&path)], None), "rewritten");
+    }
+
+    // Same bytes under another name is another file set: Frama-C is handed the
+    // path, and the path is what it parses.
+    let twin = tmp.path().join("b.c");
+    std::fs::copy(&path, &twin).expect("copy");
+    assert_ne!(
+        loaded_source_digest(&[name(&path)], None),
+        loaded_source_digest(&[name(&twin)], None)
+    );
+}
+
+/// A machdep is in the identity, because Frama-C reads a YAML file there as
+/// readily as a builtin name, and those bytes are outside the file set.
+///
+/// A builtin name is not a path, so it hashes as the failure to open it, which
+/// is stable and costs a project that names one nothing. A file that is edited,
+/// or that is deleted after the process loaded it, moves the digest, which is
+/// what sends the next reload to a new process instead of reusing a record
+/// taken under a machine model that is no longer on disk.
+#[test]
+fn the_machdep_is_part_of_the_parse_identity() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let source = tmp.path().join("a.c");
+    std::fs::write(&source, "int f(void) { return 0; }\n").expect("write");
+    let files = [source.to_str().expect("utf-8 path").to_string()];
+
+    let builtin = loaded_source_digest(&files, Some("gcc_x86_64"));
+    assert_eq!(builtin, loaded_source_digest(&files, Some("gcc_x86_64")), "re-read");
+    assert_ne!(builtin, loaded_source_digest(&files, None), "no machdep at all");
+
+    let custom = tmp.path().join("custom.yaml");
+    std::fs::write(&custom, "machdep:\n  sizeof_int: 4\n").expect("write machdep");
+    let custom = custom.to_str().expect("utf-8 path").to_string();
+    let loaded = loaded_source_digest(&files, Some(&custom));
+
+    std::fs::write(&custom, "machdep:\n  sizeof_int: 8\n").expect("edit machdep");
+    assert_ne!(loaded, loaded_source_digest(&files, Some(&custom)), "edited");
+
+    std::fs::remove_file(&custom).expect("remove machdep");
+    assert_ne!(loaded, loaded_source_digest(&files, Some(&custom)), "deleted");
 }

--- a/tests/unit/repo-guards.rs
+++ b/tests/unit/repo-guards.rs
@@ -3,7 +3,9 @@ use serde_json::json;
 
 use frama_c_mcp::mcp::server::*;
 use frama_c_mcp::mcp::server::receipt::strip_generated_label;
-use frama_c_mcp::mcp::server::analysis::{incomplete_code, CHECK_SCHEMA};
+use frama_c_mcp::mcp::server::analysis::{
+    ast_diagnostic_gaps, incomplete_code, AST_WARNING_ALLOWLIST, CHECK_SCHEMA,
+};
 use frama_c_mcp::mcp::server::selfcheck;
 
 /// The check payload's frozen vocabulary, in the three places it is written.
@@ -73,6 +75,55 @@ fn incomplete_codes_match_their_documentation() {
         architecture.contains(&format!("| `{CHECK_SCHEMA}` |")),
         "docs/architecture.md has no compatibility-history row for {CHECK_SCHEMA}"
     );
+}
+
+/// A category leaves the unclassified aggregate only through the allowlist,
+/// and a row that says nothing is a mute list rather than an allowlist: this
+/// server would be calling a warning benign without saying why.
+#[test]
+fn ast_warning_allowlist_entries_explain_their_silence() {
+    assert!(
+        AST_WARNING_ALLOWLIST
+            .iter()
+            .all(|(category, reason)| !category.trim().is_empty() && !reason.trim().is_empty()),
+        "{AST_WARNING_ALLOWLIST:?}"
+    );
+
+    // What a row does, proved against a stub rather than against the empty
+    // const above, which would pass either way.
+    let reload = json!({"ast_reload_health": {"parse_diagnostics": {
+        "categories": {
+            "kernel:asm:clobber": {"count": 1, "count_unit": "sites"},
+            "kernel:annot:unknown": {"count": 3, "count_unit": "sites"},
+            "kernel:typing:implicit-function-declaration": {"count": 1, "count_unit": "sites"},
+        },
+    }}});
+
+    let mut silent = Vec::new();
+    ast_diagnostic_gaps(&mut silent, &reload, &[("kernel:annot:unknown", "why")]);
+    let aggregate = silent
+        .iter()
+        .find(|item| item["code"] == incomplete_code::AST_UNCLASSIFIED_WARNING)
+        .expect("the unallowlisted category still reports");
+    assert_eq!(
+        aggregate["categories"],
+        json!({"kernel:typing:implicit-function-declaration":
+            {"count": 1, "count_unit": "sites"}})
+    );
+
+    // And nowhere else: the soundness code beside it is untouched. Found before
+    // it is compared, because two absent entries are also equal and would let a
+    // renamed category pass this as if it had rendered.
+    let mut loud = Vec::new();
+    ast_diagnostic_gaps(&mut loud, &reload, &[]);
+    let clobber = |items: &[serde_json::Value]| {
+        items
+            .iter()
+            .find(|item| item["code"] == incomplete_code::AST_ASM_CLOBBER)
+            .cloned()
+            .expect("kernel:asm:clobber must render as its own code")
+    };
+    assert_eq!(clobber(&silent), clobber(&loud));
 }
 
 /// A generated hash label is stripped from a clause before the receipt keeps
@@ -930,7 +981,9 @@ fn every_published_item_has_a_user() {
             let Some(rest) = line.trim_start().strip_prefix("pub ") else {
                 continue;
             };
-            // "pub async fn" and "pub unsafe fn" carry the keyword a token further in.
+
+            // "pub async fn" and "pub unsafe fn" carry the keyword a token
+            // further in.
             let rest = rest
                 .strip_prefix("async ")
                 .or_else(|| rest.strip_prefix("unsafe "))


### PR DESCRIPTION
Frama-C's front end throws things away and said so only in prose that never reached the caller. An inline-assembly memory clobber is an assumption about a statement whose real effects it cannot see; an unknown attribute is a dropped declaration. Both are points where the analyzed program stops being the compiled program, and both were invisible on the call that matters: files are parsed while Frama-C boots, before log monitoring is enabled, and getLogs before setLogs(true) returns an empty array rather than the backlog, so the first reload_project on a file carrying them answered with no messages at all.

The counts come off the spawn log instead of the message stream, which is the only record that survives that. reload_project reports them under ast_reload_health.parse_diagnostics, per category, with a capped location sample and the omitted count beside it. check turns the two soundness classes into AST_ASM_CLOBBER and AST_UNKNOWN_ATTRIBUTE, and folds every category nobody has classified into one AST_UNCLASSIFIED_WARNING entry keyed by category, because an entry per category grows with the program rather than with the finding. AST_WARNING_ALLOWLIST is the only way a category leaves that aggregate and starts empty: silence about a warning nobody has read would be this server calling it benign without saying so.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports what Frama-C's front end dropped during parsing. Inline-assembly clobbers and unknown attributes were invisible on `reload_project` and `check` because boot-time parse messages predate log monitoring; now both surface these gaps, including when no record establishes that the analyzed program is the compiled one.

- Counts come from the spawn log, the only record that survives boot-time parsing, under `ast_reload_health.parse_diagnostics` per category with capped location samples; unknown attributes count per distinct name.
- `check` maps clobbers and unknown attributes to `AST_ASM_CLOBBER` and `AST_UNKNOWN_ATTRIBUTE`, folds every other warning category into one `AST_UNCLASSIFIED_WARNING` entry, and reports a missing or unreadable record as `AST_PARSE_DIAGNOSTICS_UNAVAILABLE`.
- A changed file set, edited file contents, any `#` in a source, or `force_includes`/compilation database options respawn Frama-C rather than reparse, so the record always describes a complete boot parse.
- An unreadable or absent record reports an `unavailable` reason instead of zeros; unreadable logs are retried on the next call, while missing boot records poison the process since they can never be recovered.
- `AST_WARNING_ALLOWLIST` starts empty; adding a category is the only way it leaves the aggregate.

<sup>Written for commit 1898921887dd2f284e028523bd231b209479cc41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/frama-c-mcp/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

