### PR TITLE
Shrink agent-facing payloads and keep their keys resolvable

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,12 @@ conclusion.
 `verify_program_step` returns one `next_action` plus the unverified `frontier`
 and any `blocked_functions`, under a hard `payload_budget` cap; when the payload
 would exceed it, lists are truncated and the dropped count is reported rather
-than silently omitted.
+than silently omitted. `next_action.args` is never truncated, because it is a
+call to make rather than a list to read. When truncation cannot bring the
+payload under the cap, `next_action.tool` is `null` and `blockers` names why,
+and in the last resort the whole body is replaced by
+`status: "payload_truncated"`; a `null` tool means stop, since repeating the
+call returns the same answer.
 
 ## Verification workflows
 

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -88,6 +88,33 @@ comparing against. Only runs from this session can be named, and an unknown
 hash is an error rather than an empty diff, so a reload or a restart means
 starting from a fresh baseline instead of silently reporting no change.
 
+Record the verdict with `store_function_conclusion` rather than in a file of
+your own. A `verified` status needs a `proof_receipt` as evidence, and the
+server checks the receipt's bytes against the hash it wrote, so echoing the
+object back through your own context is both large and fragile: one function's
+receipt runs to kilobytes, most of it a goal array, and a single altered field
+is rejected without saying which. Pass `proof_receipt_sha256` instead. The
+server resolves the hash against the receipt this process produced, so the
+same coherence check runs against the same bytes and nothing has to be
+transcribed. The same rule as `since` applies: only a run from this session can
+be named, and an unknown hash is an error rather than a shrug.
+
+A goal that failed carries `failure_classification`. Most of it is that goal's
+own: its status, its evidence, and a `suggested_next_tool` whose reason names
+the file and line. The part that is a function of the category rather than of
+the goal, the longer explanation and any runtime-check suggestion, is sent once
+per `category:goal_kind` pair and rides a single goal in the list under
+`advice`. Every classified goal names its pair in `advice_key`, so a goal
+holding no `advice` block is not missing anything: its advice is on the sibling
+that carries the same key.
+
+The reason this matters to a caller rather than only to the server is size.
+Measured on one function whose goals were all unproved, repeating the block per
+goal came to 106 KB across 21 goals against 1.7 KB of the fields worth triaging
+from, which is enough to overflow a tool-result budget before anything is read.
+If you are scanning a long goal list, read `advice_key` to group, then read one
+`advice` per group.
+
 `rte: true` at load is the cheap way to get runtime-error obligations for the
 whole program, but it is not required. `run_wp` generates them for its targets
 when the project was loaded without it, and reports which under
@@ -310,6 +337,55 @@ discharges, but only when the call named a `function`: authorship is answered
 per function, so a whole-project goal list leaves every goal undetermined.
 
 Common failure branch: if the server reports no project loaded, restart from `reload_project`. If a sandbox is missing, recreate it with `create_sandbox`. If a property key or goal no longer exists after reload, refresh with `get_wp_goals` and use the new marker.
+
+### A few goals stuck in a function that already has contracts
+
+The bulk-timeout branch below is the other shape: no contracts, everything
+open. This one is a function that is annotated, mostly proved, and holding a
+handful of goals that will not close. The mistake it invites is editing the
+invariant on suspicion, re-running, and reading a number that barely moves.
+Each guess costs a full proof run, and the number moving is not evidence the
+guess was right.
+
+Read the obligation before changing anything:
+
+```text
+get_wp_goals {function, status: "unproved"}
+```
+
+Every goal it returns carries a `predicate`, which is what turns `mem_access_7`
+into `\valid(bucket_ids + j)`. Work from that field, not from the goal name:
+the trailing number counts siblings generated from one statement, so several
+open checks against one line are told apart by their predicates or not at all,
+and a name alone cannot say whether the write at index `j` or the read at `j-1`
+is the open one.
+
+`context {want: ["rte_obligations"], function}` is a second call worth making
+for a different reason: it drafts the `requires` each check would need, which no
+goal carries. It is not where the predicate lives, and an earlier version of
+this section said otherwise.
+
+Then decide from the predicate rather than from the count:
+
+- The predicate names a bound the caller guarantees and the function does not
+  state. Add the `requires`. `rte_obligations` has already drafted it.
+- The predicate names a bound the loop maintains. Add the invariant that says
+  so, and expect to need the one about contents, not just indices: an insertion
+  loop whose position search depends on the prefix being sorted needs the
+  sortedness stated, because no invariant over indices implies it.
+- The predicate is about a callee's frame. `contract_context` shows whether the
+  callee's `assigns` is what is missing, and no annotation in this function
+  will close it.
+
+Retry before rewriting. `retry_unproved` distinguishes a goal that needs a
+longer budget from one that does not move at whatever budget, and only the
+second is worth new annotation. A goal that is unchanged at six times the
+timeout is not going to yield to a seventh.
+
+Try the strengthening in a sandbox, not in the file. `create_sandbox
+{function}` holds its own copy, so a wrong invariant costs a respawn rather
+than an edit to revert, and the sandbox's goals can be diffed against the main
+project's. Copying the source tree by hand gets none of that.
 
 ### Unproved is not the same as unspecified
 

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -353,17 +353,26 @@ Read the obligation before changing anything:
 get_wp_goals {function, status: "unproved"}
 ```
 
-Every goal it returns carries a `predicate`, which is what turns `mem_access_7`
-into `\valid(bucket_ids + j)`. Work from that field, not from the goal name:
-the trailing number counts siblings generated from one statement, so several
-open checks against one line are told apart by their predicates or not at all,
-and a name alone cannot say whether the write at index `j` or the read at `j-1`
-is the open one.
+Nearly every goal it returns carries a `predicate`, which is what turns
+`mem_access_7` into `\valid(bucket_ids + j)`. Work from that field, not from the
+goal name: the trailing number counts siblings generated from one statement, so
+several open checks against one line are told apart by their predicates or not
+at all, and a name alone cannot say whether the write at index `j` or the read
+at `j-1` is the open one.
 
-`context {want: ["rte_obligations"], function}` is a second call worth making
-for a different reason: it drafts the `requires` each check would need, which no
-goal carries. It is not where the predicate lives, and an earlier version of
-this section said otherwise.
+Not quite every goal, and the exception matters because it is silent. The field
+is copied from the property row the goal discharges, so a goal that matched no
+row, or matched one carrying no predicate, simply has no `predicate` key.
+Measured on this repository's own fixtures, 2 of 79 goals on
+`test_comprehensive.c` and 2 of 21 on `tutorial/linked-n.c`. An earlier version
+of this section claimed the universal, which is the same mistake one level in
+from the one it was written to correct.
+
+`context {want: ["rte_obligations"], function}` is a second call worth making,
+for two reasons: it drafts the `requires` each check would need, which no goal
+carries, and it is where to look for the goals in that remainder. It is not
+where the predicate normally lives, and an even earlier version of this section
+said it was.
 
 Then decide from the predicate rather than from the count:
 

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -100,7 +100,7 @@ transcribed. The same rule as `since` applies: only a run from this session can
 be named, and an unknown hash is an error rather than a shrug.
 
 A goal that failed carries `failure_classification`. Most of it is that goal's
-own: its status, its evidence, and a `suggested_next_tool` whose reason names
+own: its status, its evidence, and a `next_action` whose reason names
 the file and line. The part that is a function of the category rather than of
 the goal, the longer explanation and any runtime-check suggestion, is sent once
 per `category:goal_kind` pair and rides a single goal in the list under

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -269,7 +269,7 @@ Resume after an interruption by calling `verify_program_step`, then `list {kind:
 
 If `verify_program_step` returns more ready functions, stay locked and repeat from `create_sandbox` through the next `verify_program_step` before unlocking with `verify_program_step {lock_project: false}`. The completed set must contain only functions whose verified structured annotations have already been merged into the main project.
 
-Stopping condition: every defined function has a stored conclusion, `verify_program_step` returns no remaining work, and the final `run_wp` over the main project has no non-valid goals.
+Stopping condition: every defined function has a stored conclusion, `verify_program_step` returns no remaining work, and the final `run_wp` over the main project has no non-valid goals. "No remaining work" arrives as `next_action.tool: null`, which is the stop signal. The same null tool also means the response could not be held to its byte budget, so read `blockers` before concluding you are done: `[]` with `next_action.status: "done"` is the finished run, while `oversized_function_name` or `payload_budget` means the answer did not fit and calling again returns the same thing.
 
 Common failure branch: if no function is ready, inspect the `verification_order` and `scc_groups` returned by `verify_program_step` plus current `list {kind: "conclusions"}` output. If `reload_project` or `run_wp` is rejected while locked, finish sandbox work first or call `verify_program_step {lock_project: false}` only for the final main-project gate.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@ hands back subtly wrong C is the failure mode with the highest cost.
 
 ### 4. Bottom-up full program orchestration
 
-`verify_program_step` computes the callee-before-caller verification order, persists orchestration state, and can lock `reload_project` plus main-instance `run_wp` during batch work. It answers with one `next_action` rather than a batch, plus the unverified `frontier` and any `blocked_functions`, all under a hard `payload_budget` cap that truncates lists and reports the dropped count instead of omitting them silently. Ready functions are verified through the public sandbox tools: `create_sandbox`, `inject_all_annotations {dry_run: true}`, `inject_all_annotations`, `run_wp`, and `get_wp_goals`.
+`verify_program_step` computes the callee-before-caller verification order, persists orchestration state, and can lock `reload_project` plus main-instance `run_wp` during batch work. It answers with one `next_action` rather than a batch, plus the unverified `frontier` and any `blocked_functions`, all under a hard `payload_budget` cap that truncates lists and reports the dropped count instead of omitting them silently. When truncation is not enough it drops the action itself, and in the last resort replaces the body with `status: "payload_truncated"`; both cases arrive as `next_action.tool: null`. Ready functions are verified through the public sandbox tools: `create_sandbox`, `inject_all_annotations {dry_run: true}`, `inject_all_annotations`, `run_wp`, and `get_wp_goals`.
 
 ### 5. Fail-closed accounting
 

--- a/src/frama-c/codec.rs
+++ b/src/frama-c/codec.rs
@@ -45,6 +45,22 @@ pub fn encode_frame(payload: &str) -> Vec<u8> {
     buf
 }
 
+/// The largest frame this client will accept from the server.
+///
+/// A W frame declares its length in 15 hex digits, so the wire format allows
+/// almost 2^60 bytes, and recv_frame keeps reading until the declared payload
+/// arrives. Nothing bounded that: a Frama-C that wedged mid-frame, or wrote a
+/// corrupt header, grew this process's read buffer without limit and with no
+/// diagnostic, which reads as a hang rather than as the protocol error it is.
+///
+/// 256 MB rather than something tighter, because a legitimate frame here can
+/// be large: fetchFunctions over a whole kernel tree and printDeclaration on a
+/// big AST both run to tens of megabytes, and a cap that clips a real payload
+/// would be a worse bug than the one it prevents. Every other output path in
+/// this tree is capped too, at 256 KB for the e-acsl and why3 readers, which
+/// are reading tool output rather than the AST.
+pub const MAX_FRAME_PAYLOAD_BYTES: usize = 256 * 1024 * 1024;
+
 /// Try to decode one complete frame from a byte buffer.
 ///
 /// Returns `Ok(Some((payload, consumed)))` on success,
@@ -78,6 +94,16 @@ pub fn decode_frame(buf: &[u8]) -> Result<Option<(String, usize)>, FramaCError> 
     let payload_len = usize::from_str_radix(hex_str, 16).map_err(|e| {
         FramaCError::InvalidFrame(format!("invalid hex in frame header '{hex_str}': {e}"))
     })?;
+
+    // Refused here rather than after buffering, which is the whole point: the
+    // caller reads until the declared length arrives, so a length it will never
+    // honour has to be an error before the first read and not after the last.
+    if payload_len > MAX_FRAME_PAYLOAD_BYTES {
+        return Err(FramaCError::InvalidFrame(format!(
+            "frame declares {payload_len} bytes, over the {MAX_FRAME_PAYLOAD_BYTES} \
+             byte limit; the server is out of sync or the header is corrupt"
+        )));
+    }
 
     let total = header_len + payload_len;
     if buf.len() < total {

--- a/src/frama-c/transport.rs
+++ b/src/frama-c/transport.rs
@@ -71,9 +71,21 @@ impl Transport {
             return Err(poisoned_transport());
         }
         loop {
-            if let Some((payload, consumed)) = codec::decode_frame(&self.read_buf)? {
-                self.read_buf.advance(consumed);
-                return Ok(Some(payload));
+            // A decode failure is as final as an EOF and has to poison for the
+            // same reason. The bytes that would not decode stay in read_buf,
+            // and nothing here resynchronizes, so every later call re-reads the
+            // same header and returns the same error while is_poisoned goes on
+            // answering "healthy" and reload_project therefore never respawns.
+            // That turns a desynchronized stream, which is exactly what an
+            // over-long declared length means, into a session that reports a
+            // protocol error forever instead of getting a new process.
+            match codec::decode_frame(&self.read_buf) {
+                Ok(Some((payload, consumed))) => {
+                    self.read_buf.advance(consumed);
+                    return Ok(Some(payload));
+                }
+                Ok(None) => {}
+                Err(e) => return Err(self.poison(e).await),
             }
             let mut tmp = [0u8; 4096];
             match tokio::time::timeout(timeout, self.stream.read(&mut tmp)).await {

--- a/src/mcp/acsl.rs
+++ b/src/mcp/acsl.rs
@@ -310,26 +310,29 @@ pub fn loop_annots_to_acsl(
         }
     }
 
-    // loop variant: Option<{acsl, behavior?}>
-    if let Some(var) = annot.get("variant") {
-        // Skip if explicitly null or missing acsl
-        if !var.is_null() {
-            let body = var.get("acsl").and_then(|x| x.as_str()).unwrap_or("");
-            if !body.trim().is_empty() {
-                let behavior = var.get("behavior").and_then(|x| x.as_str());
-                let path = format!("proposed_loop_annots[{}].variant", i);
-                match wrap_loop_clause("loop variant", body, behavior, behaviors, &path) {
-                    Ok(acsl_text) => result.push(Ok((
-                        acsl_text,
-                        "annot".to_string(),
-                        path,
-                        stmt_id,
-                        format!("{} variant", loop_label),
-                        Some(format!("{}_variant", base_label)),
-                    ))),
-                    Err(msg) => result.push(Err((path, msg))),
-                }
-            }
+    // loop variant: Option<{acsl, behavior?}> Explicitly null, missing, or
+    // blank acsl all mean the same thing here: no variant was proposed. Asked
+    // as one question so the wrapping below is not three branches deep.
+    let variant_body = annot
+        .get("variant")
+        .filter(|var| !var.is_null())
+        .and_then(|var| var.get("acsl"))
+        .and_then(|x| x.as_str())
+        .filter(|body| !body.trim().is_empty());
+    if let Some(body) = variant_body {
+        let var = &annot["variant"];
+        let behavior = var.get("behavior").and_then(|x| x.as_str());
+        let path = format!("proposed_loop_annots[{}].variant", i);
+        match wrap_loop_clause("loop variant", body, behavior, behaviors, &path) {
+            Ok(acsl_text) => result.push(Ok((
+                acsl_text,
+                "annot".to_string(),
+                path,
+                stmt_id,
+                format!("{} variant", loop_label),
+                Some(format!("{}_variant", base_label)),
+            ))),
+            Err(msg) => result.push(Err((path, msg))),
         }
     }
 

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -1607,11 +1607,11 @@ pub fn ast_diagnostic_gaps(
     // which is what lets the zero-count branch below skip a category instead of
     // having to hedge it, and it is what keeps two checks of one session
     // reporting the same codes: an entry that appeared only on the second would
-    // move proof_receipt.sha256, since the receipt digests incomplete.
-    // A record that says why it is empty is a finding rather than silence.
-    // Reading it as a clean parse would let check answer "proved" on the one
-    // shape where nothing established that the analyzed program is the
-    // compiled one, which is the claim these codes exist to make.
+    // move proof_receipt.sha256, since the receipt digests incomplete. A record
+    // that says why it is empty is a finding rather than silence. Reading it as
+    // a clean parse would let check answer "proved" on the one shape where
+    // nothing established that the analyzed program is the compiled one, which
+    // is the claim these codes exist to make.
     if let Some(reason) = diagnostics["unavailable"].as_str() {
         incomplete.push(json!({
             "code": incomplete_code::AST_PARSE_DIAGNOSTICS_UNAVAILABLE,
@@ -1642,6 +1642,7 @@ pub fn ast_diagnostic_gaps(
             }));
             continue;
         }
+
         // A classified category left the loop above, so the only thing that
         // keeps one out of the aggregate here is a row saying why its silence
         // is deliberate.
@@ -4220,22 +4221,102 @@ impl FramaCMcpServer {
 
         // Add `goal_kind` and (if any) `hash_label` to each goal, so callers
         // can distinguish spec, source assert, and RTE failures.
-        let augmented: Vec<serde_json::Value> = selected
+        let mut advice_seen: BTreeMap<String, (String, serde_json::Value)> = BTreeMap::new();
+        let mut augmented: Vec<serde_json::Value> = selected
             .into_iter()
             .map(|mut g| {
                 add_identity_fields(&mut g);
                 enrich_goal_with_property_status(&mut g, &properties_by_marker);
                 finish_goal(&mut g, &goals_by_marker, stable_scope.as_deref());
-                let failure_classification = goal_needs_failure_classification(&g)
-                    .then(|| classify_wp_failure_from_goal(&g, function));
-                if let Some(obj) = g.as_object_mut() {
-                    if let Some(classification) = failure_classification {
-                        obj.insert("failure_classification".to_string(), classification);
+
+                // The goal keeps what is its own. The advice, which is a
+                // function of category and goal kind rather than of the goal,
+                // rides on the first goal of each pair and the rest name it by
+                // key. Attaching the whole classification per goal is what made
+                // a legitimately-stuck function unreadable: 21 goals, 147 KB,
+                // of which the duplicated advice was 106 KB, against 1.7 KB of
+                // triage fields and two distinct categories underneath.
+                //
+                // An earlier attempt capped how many goals carried the block,
+                // which still duplicated up to the cap and dropped advice past
+                // it. A second appended the advice as one extra array element,
+                // which is worse: every element of this array is a goal, and
+                // three stdio tests walk it expecting that. Carrying it on a
+                // real goal keeps the contract and still emits each advice
+                // once.
+                if goal_needs_failure_classification(&g) {
+                    let classification = classify_wp_failure_from_goal(&g, function);
+                    let (mut per_goal, key, advice) = split_goal_classification(&classification);
+                    match g.get("stable_goal_id").and_then(|value| value.as_str()) {
+                        Some(id) => {
+                            let id = id.to_string();
+                            advice_seen
+                                .entry(key)
+                                .and_modify(|(carrier, _)| {
+                                    // Smallest stable id wins, not first
+                                    // encountered. Two identical runs must
+                                    // produce one receipt, and "first" makes
+                                    // the payload depend on an order this
+                                    // function does not fix:
+                                    // two_identical_runs_produce_one_receipt
+                                    // caught exactly that.
+                                    if id < *carrier {
+                                        *carrier = id.clone();
+                                    }
+                                })
+                                .or_insert_with(|| (id, advice));
+                        }
+                        None => {
+                            // finish_goal gives every goal an id, so this is
+                            // unreachable today. It is written out anyway
+                            // because the second pass finds the carrier by id:
+                            // a goal without one could win the election and
+                            // then never be found again, and the advice for its
+                            // whole key would vanish with no diagnostic.
+                            // Duplication is the thing this split exists to
+                            // reduce, and it is still the better failure.
+                            if let Some(obj) = per_goal.as_object_mut() {
+                                obj.insert("advice".to_string(), advice);
+                            }
+                        }
+                    }
+                    if let Some(obj) = g.as_object_mut() {
+                        obj.insert("failure_classification".to_string(), per_goal);
                     }
                 }
                 g
             })
             .collect();
+
+        // Attached in a second pass, to the goal each key elected above. It
+        // cannot be folded into the pass above: which goal carries a key is not
+        // known until every goal has been classified.
+        for goal in augmented.iter_mut() {
+            // Borrowed only for as long as it takes to decide, so the insert
+            // below can take the goal mutably.
+            let advice = {
+                let Some(id) = goal.get("stable_goal_id").and_then(|value| value.as_str()) else {
+                    continue;
+                };
+                let Some(key) = goal
+                    .get("failure_classification")
+                    .and_then(|c| c.get("advice_key"))
+                    .and_then(|value| value.as_str())
+                else {
+                    continue;
+                };
+                match advice_seen.get(key) {
+                    Some((carrier, advice)) if carrier.as_str() == id => advice.clone(),
+                    _ => continue,
+                }
+            };
+            if let Some(obj) = goal
+                .get_mut("failure_classification")
+                .and_then(|c| c.as_object_mut())
+            {
+                obj.insert("advice".to_string(), advice);
+            }
+        }
 
         Ok(json!(augmented))
     }

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -27,55 +27,170 @@ const VERIFY_PROGRAM_STEP_READY_PREVIEW_ITEMS: usize = 16;
 /// ones, cannot dominate the response.
 const CHECK_SUMMARY_PREVIEW_ITEMS: usize = 5;
 
+/// Hold the response to the advertised byte cap, shedding the cheapest thing
+/// first: preview rows, then the blocked list inside next_action, then the
+/// action itself, and only then the whole body.
+///
+/// next_action.args is never shed. It is a call for the caller to make, and a
+/// shortened argument would quietly change what that call asks for.
 pub fn finish_verify_program_step_response(mut response: serde_json::Value) -> serde_json::Value {
-    let mut bytes = verify_program_step_payload_bytes(&response);
     if let Some(obj) = response.as_object_mut() {
         obj.insert(
             "payload_budget".into(),
             json!({
                 "cap_bytes": VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES,
-                "bytes": bytes,
+                "bytes": 0,
                 "omitted_fields": ["order", "verification_order", "scc_groups", "conclusions", "project_state"],
             }),
         );
     }
-    bytes = verify_program_step_payload_bytes(&response);
-    if let Some(obj) = response.as_object_mut().and_then(|obj| obj.get_mut("payload_budget")).and_then(|value| value.as_object_mut()) {
-        obj.insert("bytes".into(), json!(bytes));
-    }
-    if bytes > VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES {
+    let mut bytes = record_verify_program_step_payload_bytes(&mut response);
+
+    // Keep one row of each preview first, which is enough to show the caller
+    // what shape the omitted rows had. One retained row can itself be larger
+    // than the budget, for example a generated function name or a cyclic SCC,
+    // so the second pass keeps none.
+    for keep in [1, 0] {
+        if bytes <= VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES {
+            break;
+        }
+        let mut shed = false;
         if let Some(obj) = response.as_object_mut() {
-            let already_omitted = obj
-                .get("ready_functions_omitted")
-                .and_then(|value| value.as_u64())
-                .unwrap_or(0) as usize;
-            if let Some(ready) = obj.get_mut("ready_functions").and_then(|value| value.as_array_mut()) {
-                let total = ready.len() + already_omitted;
-                ready.truncate(1);
-                obj.insert("ready_functions_omitted".into(), json!(total.saturating_sub(1)));
-            }
-            let frontier_already_omitted = obj
-                .get("frontier_omitted")
-                .and_then(|value| value.as_u64())
-                .unwrap_or(0) as usize;
-            if let Some(frontier) = obj.get_mut("frontier").and_then(|value| value.as_array_mut()) {
-                let total = frontier.len() + frontier_already_omitted;
-                frontier.truncate(1);
-                obj.insert("frontier_omitted".into(), json!(total.saturating_sub(1)));
-            }
+            shed |= omit_preview_rows(obj, "ready_functions", "ready_functions_omitted", keep);
+            shed |= omit_preview_rows(obj, "frontier", "frontier_omitted", keep);
         }
-        bytes = verify_program_step_payload_bytes(&response);
-        if let Some(obj) = response.as_object_mut().and_then(|obj| obj.get_mut("payload_budget")).and_then(|value| value.as_object_mut()) {
-            obj.insert("bytes".into(), json!(bytes));
+        if shed {
+            bytes = record_verify_program_step_payload_bytes(&mut response);
         }
+    }
+
+    // The blocked list rides inside next_action, so the passes above cannot
+    // reach it. It arrives already previewed, so reaching here means even the
+    // preview does not fit and no row of it can be kept.
+    if bytes > VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES {
+        let shed = response
+            .get_mut("next_action")
+            .and_then(|value| value.as_object_mut())
+            .is_some_and(|action| {
+                omit_preview_rows(action, "blocked_functions", "blocked_functions_omitted", 0)
+            });
+        if shed {
+            bytes = record_verify_program_step_payload_bytes(&mut response);
+        }
+    }
+
+    // The ready function's name also sits in next_action.args, which is not
+    // shed. Drop the whole action instead, and only when that name is what put
+    // the response over: the gate is the measurement, so the reason below is
+    // true whenever it is printed.
+    if bytes > VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES {
+        let name_bytes = response
+            .pointer("/next_action/args/function")
+            .and_then(|value| value.as_str())
+            .map(str::len)
+            .unwrap_or(0);
+        if name_bytes > 0 && bytes - name_bytes <= VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES {
+            if let Some(obj) = response.as_object_mut() {
+                obj.insert("next_action".into(), json!({
+                    "tool": null,
+                    "args": {},
+                    "reason": "The ready function's name does not fit the response budget, so no call naming it can be sent; read the frontier with list.",
+                    "blockers": ["oversized_function_name"],
+                    "confidence": "high",
+                }));
+            }
+            bytes = record_verify_program_step_payload_bytes(&mut response);
+        }
+    }
+
+    // Two fields are still bounded only by the project: the in_progress names
+    // echoed in args, which the passes above deliberately do not touch, and a
+    // persist error carrying a path. Neither is reachable at this size in
+    // practice, and this keeps the cap true rather than assuming so.
+    if bytes > VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES {
+        response = json!({
+            "status": "payload_truncated",
+            "next_action": {
+                "tool": null,
+                "args": {},
+                "reason": "The response did not fit the payload budget with every omittable field already dropped; repeating the call returns this same answer.",
+                "blockers": ["payload_budget"],
+                "confidence": "high",
+            },
+            "payload_budget": {
+                "cap_bytes": VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES,
+                "bytes": 0,
+                "omitted_fields": ["response"],
+            },
+        });
+        record_verify_program_step_payload_bytes(&mut response);
     }
     response
 }
 
+/// Shrink an array field to keep rows, and add the dropped ones to the count
+/// named beside it. The count is cumulative: an earlier pass may already have
+/// previewed the array, and those rows were never here to drop.
+///
+/// Answers whether any row went, so a caller measuring the result can skip the
+/// measurement when nothing changed.
+fn omit_preview_rows(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    field: &str,
+    omitted: &str,
+    keep: usize,
+) -> bool {
+    let already_omitted = obj
+        .get(omitted)
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0) as usize;
+    let Some(items) = obj.get_mut(field).and_then(|value| value.as_array_mut()) else {
+        return false;
+    };
+    let before = items.len();
+    let total = before + already_omitted;
+    items.truncate(keep);
+
+    // Charge the rows that actually went, not an assumed one: truncate keeps
+    // nothing when the array was already empty.
+    let retained = items.len();
+    obj.insert(omitted.into(), json!(total.saturating_sub(retained)));
+    retained < before
+}
+
+/// The size of what is about to be sent. A payload that cannot be serialized
+/// is reported as too large rather than as empty, so it trips the budget guard
+/// instead of sailing past every check.
 fn verify_program_step_payload_bytes(response: &serde_json::Value) -> usize {
     serde_json::to_string_pretty(response)
         .map(|text| text.len())
-        .unwrap_or(0)
+        .unwrap_or(usize::MAX)
+}
+
+/// Record the serialized size. Writing the number can change its digit count,
+/// so measure again until the recorded value is the value being sent.
+///
+/// This terminates. Once payload_budget.bytes exists, the length is
+/// constant + digits(recorded), which is non-decreasing in recorded, so the
+/// iteration is monotone; it is bounded, since a usize has at most 20 digits;
+/// and a bounded monotone integer sequence is eventually constant.
+fn record_verify_program_step_payload_bytes(response: &mut serde_json::Value) -> usize {
+    let mut recorded = 0;
+    loop {
+        let bytes = verify_program_step_payload_bytes(response);
+        if bytes == recorded {
+            return bytes;
+        }
+        recorded = bytes;
+        if let Some(obj) = response
+            .pointer_mut("/payload_budget")
+            .and_then(|value| value.as_object_mut())
+        {
+            obj.insert("bytes".into(), json!(recorded));
+        } else {
+            return bytes;
+        }
+    }
 }
 
 async fn exec_eva_compute(client: &FramaCClient) -> Result<Vec<serde_json::Value>, FramaCError> {
@@ -4821,12 +4936,15 @@ impl FramaCMcpServer {
                 .collect::<Vec<_>>();
 
             // Stored conclusions are the only record of per-function progress.
-            // BTreeSet keeps both lists sorted and deduplicated once the
-            // caller's own in_progress names merge in below, so neither needs a
-            // later sort.
+            // BTreeSet keeps all three lists sorted and deduplicated once the
+            // caller's own in_progress names merge in below, so none needs a
+            // later sort. Order is not cosmetic here: conclusions arrive from a
+            // HashMap, and the blocked list is previewed rather than sent
+            // whole, so an unordered one would show a different sample of the
+            // same state on every call.
             let mut done = std::collections::BTreeSet::new();
             let mut in_progress = std::collections::BTreeSet::new();
-            let mut blocked_functions = Vec::new();
+            let mut blocked_functions = std::collections::BTreeSet::new();
             for conclusion in &conclusions {
                 match conclusion.status {
                     crate::state::VerificationStatus::Verified => {
@@ -4838,7 +4956,7 @@ impl FramaCMcpServer {
                     crate::state::VerificationStatus::Failed
                     | crate::state::VerificationStatus::Unsound
                     | crate::state::VerificationStatus::BlockedOnCallee => {
-                        blocked_functions.push(conclusion.function.clone());
+                        blocked_functions.insert(conclusion.function.clone());
                     }
                 }
             }
@@ -4939,7 +5057,7 @@ impl FramaCMcpServer {
             "eva_completed": eva_completed,
             "wp_completed": wp_completed,
         });
-        let next_action = if all_done {
+        let mut next_action = if all_done {
             json!({
                 "status": "done",
                 "tool": null,
@@ -4978,6 +5096,17 @@ impl FramaCMcpServer {
                 "confidence": "medium",
             })
         };
+        // The blocked list is the one unbounded thing an action carries, and
+        // the same rule that previews the two lists beside it applies here.
+        // Every other branch has no such field and this leaves it untouched.
+        if let Some(action) = next_action.as_object_mut() {
+            omit_preview_rows(
+                action,
+                "blocked_functions",
+                "blocked_functions_omitted",
+                VERIFY_PROGRAM_STEP_READY_PREVIEW_ITEMS,
+            );
+        }
 
         let response = finish_verify_program_step_response(json!({
             "project_locked": project_locked,

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -1233,6 +1233,47 @@ pub fn incomplete_guidance(incomplete: &[serde_json::Value]) -> serde_json::Valu
 /// Returns the goals this pass judged, keyed by WP's obligation id, because
 /// the proofread findings below can only be attributed to a goal that was
 /// judged here.
+/// The gap a goal WP proved can still leave, or None when it leaves none.
+///
+/// Reaching this at all means the property verdict disagreed with the goal,
+/// since a property that consolidated to valid was skipped before the call.
+/// Dead code is one way; resting on an unestablished hypothesis is the other,
+/// and a goal in that second arm used to match neither test and go unreported
+/// with the verdict reading proved over it.
+fn proved_goal_gap(goal: &serde_json::Value, status: &str) -> Option<serde_json::Value> {
+    let field = |name: &str| goal.get(name).cloned().unwrap_or_else(|| json!(null));
+    if property_is_dead(goal) {
+        return Some(json!({
+            "code": incomplete_code::PROPERTY_DEAD,
+            "reason": "WP proved this goal, but its property sits in code EVA proved unreachable.",
+            "stable_goal_id": field("stable_goal_id"),
+            "frama_c_goal_name": field("frama_c_goal_name"),
+            "goal_kind": field("goal_kind"),
+            "normalized_status": status,
+            "property_status": field("normalized_property_status"),
+        }));
+    }
+    if goal_is_valid_under_hypotheses(goal) {
+        return Some(json!({
+            "code": incomplete_code::VALID_UNDER_HYP,
+            "reason": "WP proved this goal, but Frama-C consolidated its property as valid only under hypotheses that are not themselves established.",
+            "stable_goal_id": field("stable_goal_id"),
+            "frama_c_goal_name": field("frama_c_goal_name"),
+            "goal_kind": field("goal_kind"),
+            "normalized_status": status,
+            "property_status": field("normalized_property_status"),
+
+            // Which hypotheses, when the goal carries them.
+            // enrich_goal_with_property_status resolves "deps" against the
+            // property table, and naming them is the difference between this
+            // finding and the guess the unproved-assumption finding has to
+            // make.
+            "hypotheses": field("hypotheses"),
+        }));
+    }
+    None
+}
+
 fn wp_goal_gaps<'a>(
     incomplete: &mut Vec<serde_json::Value>,
     eva_alarms: &'a serde_json::Value,
@@ -1310,34 +1351,7 @@ fn wp_goal_gaps<'a>(
             // arm used to match neither test and go unreported, with the
             // verdict reading proved over it.
             if is_proved(status) {
-                if property_is_dead(goal) {
-                    incomplete.push(json!({
-                        "code": incomplete_code::PROPERTY_DEAD,
-                        "reason": "WP proved this goal, but its property sits in code EVA proved unreachable.",
-                        "stable_goal_id": goal.get("stable_goal_id").cloned().unwrap_or_else(|| json!(null)),
-                        "frama_c_goal_name": goal.get("frama_c_goal_name").cloned().unwrap_or_else(|| json!(null)),
-                        "goal_kind": goal.get("goal_kind").cloned().unwrap_or_else(|| json!(null)),
-                        "normalized_status": status,
-                        "property_status": goal.get("normalized_property_status").cloned().unwrap_or_else(|| json!(null)),
-                    }));
-                } else if goal_is_valid_under_hypotheses(goal) {
-                    incomplete.push(json!({
-                        "code": incomplete_code::VALID_UNDER_HYP,
-                        "reason": "WP proved this goal, but Frama-C consolidated its property as valid only under hypotheses that are not themselves established.",
-                        "stable_goal_id": goal.get("stable_goal_id").cloned().unwrap_or_else(|| json!(null)),
-                        "frama_c_goal_name": goal.get("frama_c_goal_name").cloned().unwrap_or_else(|| json!(null)),
-                        "goal_kind": goal.get("goal_kind").cloned().unwrap_or_else(|| json!(null)),
-                        "normalized_status": status,
-                        "property_status": goal.get("normalized_property_status").cloned().unwrap_or_else(|| json!(null)),
-
-                        // Which hypotheses, when the goal carries them.
-                        // enrich_goal_with_property_status resolves "deps"
-                        // against the property table, and naming them is the
-                        // difference between this finding and the guess the
-                        // unproved-assumption finding has to make.
-                        "hypotheses": goal.get("hypotheses").cloned().unwrap_or_else(|| json!(null)),
-                    }));
-                }
+                incomplete.extend(proved_goal_gap(goal, status));
                 continue;
             }
             incomplete.push(json!({
@@ -1473,6 +1487,21 @@ type DigestGroups = std::collections::HashMap<String, Vec<(String, AstInputs)>>;
 /// Free-standing so the decision can be tested without a Frama-C instance: the
 /// case that matters most is the one no integration test can stage, a run where
 /// every variant proved and no digest was ever established.
+/// Take "label", or the first "label#n" nobody has taken, and record it.
+///
+/// Looped, not suffixed once: a caller who passes "a" twice and also passes
+/// "a#1" would otherwise get two variants called "a#1", and duplicate_ast
+/// names a label, so it would point at whichever of them landed first.
+fn claim_label(taken: &mut std::collections::HashSet<String>, label: String, from: usize) -> String {
+    if taken.insert(label.clone()) {
+        return label;
+    }
+    (from..)
+        .map(|suffix| format!("{label}#{suffix}"))
+        .find(|candidate| taken.insert(candidate.clone()))
+        .unwrap_or(label)
+}
+
 pub fn check_variants_summary(results: Vec<serde_json::Value>) -> serde_json::Value {
     let digest_of = |entry: &serde_json::Value| {
         entry
@@ -3083,17 +3112,7 @@ impl FramaCMcpServer {
             // passes "a#1" would otherwise get two variants called "a#1", and
             // duplicate_ast names a label, so it would point at whichever of
             // them landed first.
-            if !labels_seen.insert(label.clone()) {
-                let base = label.clone();
-                let mut suffix = index;
-                loop {
-                    label = format!("{base}#{suffix}");
-                    if labels_seen.insert(label.clone()) {
-                        break;
-                    }
-                    suffix += 1;
-                }
-            }
+            label = claim_label(&mut labels_seen, label, index);
 
             // params starts as base, so Option::or is the override: the
             // variant's value when it set one, the base's otherwise. One

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -1986,11 +1986,52 @@ fn first_alarm_next_call(alarms: &serde_json::Value) -> Option<serde_json::Value
     })
 }
 
+/// One goal's classification, with the advice its key names folded back in.
+///
+/// get_wp_goals sends each advice once, on the first classified goal of its
+/// key, because repeating it per goal is what made a stuck function
+/// unreadable. That is right for an array a caller reads whole and wrong the
+/// moment a single classification is lifted out of it: quoted on its own, a
+/// non-carrier's classification is status plumbing and an advice_key pointing
+/// at a sibling the caller was never handed. Anything embedding one goal has
+/// to resolve the key first, which is what this does.
+pub fn classification_with_advice(
+    goal: &serde_json::Value,
+    goals: &[serde_json::Value],
+) -> serde_json::Value {
+    let mut classification = goal
+        .get("failure_classification")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    if classification.get("advice").is_some() {
+        return classification;
+    }
+    let Some(key) = classification
+        .get("advice_key")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+    else {
+        return classification;
+    };
+    let advice = goals.iter().find_map(|sibling| {
+        let sibling = sibling.get("failure_classification")?;
+        if sibling.get("advice_key").and_then(|value| value.as_str()) != Some(key.as_str()) {
+            return None;
+        }
+        sibling.get("advice").cloned()
+    });
+    if let (Some(advice), Some(object)) = (advice, classification.as_object_mut()) {
+        object.insert("advice".to_string(), advice);
+    }
+    classification
+}
+
 fn first_wp_goal_next_call(
     goals: &serde_json::Value,
     function: Option<&str>,
 ) -> Option<serde_json::Value> {
-    goals.as_array()?.iter().find_map(|goal| {
+    let goals = goals.as_array()?;
+    goals.iter().find_map(|goal| {
         let normalized_status = goal
             .get("normalized_status")
             .and_then(|value| value.as_str())
@@ -2005,19 +2046,20 @@ fn first_wp_goal_next_call(
         if normalized_status == Some("valid") || raw_status.as_deref() == Some("valid") {
             return None;
         }
+        let classification = classification_with_advice(goal, goals);
         if let Some(function) = function {
             Some(json!({
                 "tool": "get_wp_goals",
                 "args": {"want": ["vc"], "function": function},
                 "reason": "WP has a non-valid goal; inspect VC details and the attached failure_classification before changing the annotation.",
-                "classification": goal.get("failure_classification").cloned().unwrap_or(serde_json::Value::Null),
+                "classification": classification,
             }))
         } else {
             Some(json!({
                 "tool": "get_wp_goals",
                 "args": {},
                 "reason": "WP has a non-valid goal; inspect its failure_classification before changing the annotation.",
-                "classification": goal.get("failure_classification").cloned().unwrap_or(serde_json::Value::Null),
+                "classification": classification,
             }))
         }
     })
@@ -2238,8 +2280,15 @@ fn enrich_vcs_with_goals(
             }
         } else {
             let prover_result = wp_prover_result(vc);
+
+            // The same shape the goals above carry. A VC that matched no goal
+            // used to get the unsplit classification, so one reply could hand a
+            // caller two different layouts under one field name: siblings with
+            // an advice_key naming a shared block, and this one with the same
+            // content spread across proofread_report, runtime_check_suggestion
+            // and semantic_verdict and no key at all.
             let failure_classification = goal_needs_failure_classification(vc)
-                .then(|| classify_wp_failure_from_goal(vc, Some(function)));
+                .then(|| goal_classification_with_own_advice(vc, Some(function)));
             if let Some(obj) = vc.as_object_mut() {
                 obj.entry("prover_result".to_string())
                     .or_insert(prover_result);
@@ -4240,8 +4289,8 @@ impl FramaCMcpServer {
 
         // Add `goal_kind` and (if any) `hash_label` to each goal, so callers
         // can distinguish spec, source assert, and RTE failures.
-        let mut advice_seen: BTreeMap<String, (String, serde_json::Value)> = BTreeMap::new();
-        let mut augmented: Vec<serde_json::Value> = selected
+        let mut advice_carried: BTreeSet<String> = BTreeSet::new();
+        let augmented: Vec<serde_json::Value> = selected
             .into_iter()
             .map(|mut g| {
                 add_identity_fields(&mut g);
@@ -4263,40 +4312,32 @@ impl FramaCMcpServer {
                 // three stdio tests walk it expecting that. Carrying it on a
                 // real goal keeps the contract and still emits each advice
                 // once.
+                //
+                // The carrier is the first classified goal of its key, in the
+                // order this array is about to be emitted in. That is what
+                // makes the key resolvable in a truncated view, and it is the
+                // whole reason the election is positional: check summarizes
+                // this array with summarize_entries, which keeps the first few
+                // entries passing goal_needs_failure_classification, the same
+                // predicate that decides classification here. So the carrier of
+                // a key is scanned before every other goal of that key and is
+                // kept whenever any of them is. Electing by smallest
+                // stable_goal_id instead, which an earlier version did, picks a
+                // digest uncorrelated with position, and a shown goal's
+                // advice_key then routinely named a carrier that truncation had
+                // dropped, leaving that advice in no part of the reply.
                 if goal_needs_failure_classification(&g) {
                     let classification = classify_wp_failure_from_goal(&g, function);
                     let (mut per_goal, key, advice) = split_goal_classification(&classification);
-                    match g.get("stable_goal_id").and_then(|value| value.as_str()) {
-                        Some(id) => {
-                            let id = id.to_string();
-                            advice_seen
-                                .entry(key)
-                                .and_modify(|(carrier, _)| {
-                                    // Smallest stable id wins, not first
-                                    // encountered. Two identical runs must
-                                    // produce one receipt, and "first" makes
-                                    // the payload depend on an order this
-                                    // function does not fix:
-                                    // two_identical_runs_produce_one_receipt
-                                    // caught exactly that.
-                                    if id < *carrier {
-                                        *carrier = id.clone();
-                                    }
-                                })
-                                .or_insert_with(|| (id, advice));
-                        }
-                        None => {
-                            // finish_goal gives every goal an id, so this is
-                            // unreachable today. It is written out anyway
-                            // because the second pass finds the carrier by id:
-                            // a goal without one could win the election and
-                            // then never be found again, and the advice for its
-                            // whole key would vanish with no diagnostic.
-                            // Duplication is the thing this split exists to
-                            // reduce, and it is still the better failure.
-                            if let Some(obj) = per_goal.as_object_mut() {
-                                obj.insert("advice".to_string(), advice);
-                            }
+
+                    // insert answers whether this key has been seen, so first
+                    // wins and nothing later can attach a second copy. Goals
+                    // with no stable_goal_id need no special case any more: the
+                    // carrier is a position rather than a name, so there is
+                    // nothing for a later pass to fail to look up.
+                    if advice_carried.insert(key) {
+                        if let Some(obj) = per_goal.as_object_mut() {
+                            obj.insert("advice".to_string(), advice);
                         }
                     }
                     if let Some(obj) = g.as_object_mut() {
@@ -4306,36 +4347,6 @@ impl FramaCMcpServer {
                 g
             })
             .collect();
-
-        // Attached in a second pass, to the goal each key elected above. It
-        // cannot be folded into the pass above: which goal carries a key is not
-        // known until every goal has been classified.
-        for goal in augmented.iter_mut() {
-            // Borrowed only for as long as it takes to decide, so the insert
-            // below can take the goal mutably.
-            let advice = {
-                let Some(id) = goal.get("stable_goal_id").and_then(|value| value.as_str()) else {
-                    continue;
-                };
-                let Some(key) = goal
-                    .get("failure_classification")
-                    .and_then(|c| c.get("advice_key"))
-                    .and_then(|value| value.as_str())
-                else {
-                    continue;
-                };
-                match advice_seen.get(key) {
-                    Some((carrier, advice)) if carrier.as_str() == id => advice.clone(),
-                    _ => continue,
-                }
-            };
-            if let Some(obj) = goal
-                .get_mut("failure_classification")
-                .and_then(|c| c.as_object_mut())
-            {
-                obj.insert("advice".to_string(), advice);
-            }
-        }
 
         Ok(json!(augmented))
     }
@@ -5132,11 +5143,18 @@ impl FramaCMcpServer {
         let goals_by_marker = property_status_map(&goals);
         for goal in &mut goals {
             finish_goal(goal, &goals_by_marker, Some(&resolved.function));
-            let failure_classification = goal_needs_failure_classification(goal)
-                .then(|| classify_wp_failure_from_goal(goal, Some(&resolved.function)));
-            if let Some(obj) = goal.as_object_mut() {
-                if let Some(classification) = failure_classification {
-                    obj.insert("failure_classification".to_string(), classification);
+
+            // The same split the goal list uses, so failure_classification
+            // means one thing across this tool rather than two. What differs is
+            // that nothing is deduplicated here: this path answers an explicit
+            // want ["vc"] for a handful of goals read one at a time, so every
+            // goal carries its own advice and none of them has to resolve a key
+            // against a sibling.
+            if goal_needs_failure_classification(goal) {
+                let per_goal =
+                    goal_classification_with_own_advice(goal, Some(&resolved.function));
+                if let Some(object) = goal.as_object_mut() {
+                    object.insert("failure_classification".to_string(), per_goal);
                 }
             }
         }

--- a/src/mcp/annotations.rs
+++ b/src/mcp/annotations.rs
@@ -403,18 +403,18 @@ pub fn relabel_origins(value: &mut serde_json::Value, origin: &HashMap<String, u
                     // caller writes.
                     "successful" => continue,
                     "derived_from" | "proposed_path" => {
-                        let relabelled =
-                            child.as_str().and_then(|path| relabel_path(path, origin));
-                        if let Some((path, index)) = relabelled {
+                        if let Some((path, index)) =
+                            child.as_str().and_then(|path| relabel_path(path, origin))
+                        {
                             *child = json!(path);
                             relabelled_index = Some(index);
                             continue;
                         }
                     }
                     "frama_c_error" | "message" => {
-                        let relabelled =
-                            child.as_str().and_then(|text| relabel_message(text, origin));
-                        if let Some(text) = relabelled {
+                        if let Some(text) =
+                            child.as_str().and_then(|text| relabel_message(text, origin))
+                        {
                             *child = json!(text);
                             continue;
                         }
@@ -561,26 +561,28 @@ fn build_injection_plan(
 
     // proposed_loop_annots: each loop expanded via loop_annots_to_acsl()
     if let Some(loop_annots) = inputs.loop_annots {
-        for (i, v) in loop_annots.iter().enumerate() {
-            for outcome in loop_annots_to_acsl(v, i, behaviors) {
-                match outcome {
-                    Ok((acsl_text, kind, derived_from, stmt_id, purpose, user_label)) => {
-                        plan.push(InjectionPlanEntry {
-                            acsl_text,
-                            kind,
-                            derived_from,
-                            stmt_id,
-                            purpose,
-                            user_label,
-                        });
-                    }
-                    Err((path, msg)) => early_failures.push(InjectionFailure {
-                        failure_type: classify_failure(&msg),
-                        proposed_path: path,
-                        acsl_text: String::new(),
-                        frama_c_error: msg,
-                    }),
+        let expanded = loop_annots
+            .iter()
+            .enumerate()
+            .flat_map(|(i, v)| loop_annots_to_acsl(v, i, behaviors));
+        for outcome in expanded {
+            match outcome {
+                Ok((acsl_text, kind, derived_from, stmt_id, purpose, user_label)) => {
+                    plan.push(InjectionPlanEntry {
+                        acsl_text,
+                        kind,
+                        derived_from,
+                        stmt_id,
+                        purpose,
+                        user_label,
+                    });
                 }
+                Err((path, msg)) => early_failures.push(InjectionFailure {
+                    failure_type: classify_failure(&msg),
+                    proposed_path: path,
+                    acsl_text: String::new(),
+                    frama_c_error: msg,
+                }),
             }
         }
     }

--- a/src/mcp/conclusions.rs
+++ b/src/mcp/conclusions.rs
@@ -5,7 +5,11 @@ impl FramaCMcpServer {
     #[tool(
         description = "Store or update the verification conclusion for a function. \
         Supports incremental updates: fields set to null preserve previous values. \
-        Stores only status, notes, committed specs, WP summary, proof receipt, and direct callees."
+        Stores only status, notes, committed specs, WP summary, proof receipt, and direct callees. \
+        Evidence for a verified status arrives as proof_receipt, the object run_wp returned, or \
+        more usefully as proof_receipt_sha256, the digest from it: a receipt is accepted only if \
+        its bytes hash to what this server wrote, so echoing one back by hand is both large and \
+        fragile, while the digest resolves to the same bytes here. Pass one or the other."
     )]
     async fn store_function_conclusion(
         &self,
@@ -37,6 +41,38 @@ impl FramaCMcpServer {
             .transpose()
             .map_err(|e| McpError::invalid_params(format!("invalid wp_summary: {e}"), None))?;
 
+        // A receipt may arrive as itself or, in proof_receipt_sha256, as the
+        // digest of one this session wrote. The second is what makes the tool
+        // usable from an MCP client: acceptance recomputes the hash over the
+        // receipt's serialized bytes, so evidence has to be byte-exact, and a
+        // caller's only way to supply it is to echo roughly 8 KB through its
+        // own context. Resolving the digest here checks the same bytes, because
+        // they are the ones this process produced; what it removes is the
+        // transcription, not the check.
+        let proof_receipt = match (params.proof_receipt, params.proof_receipt_sha256) {
+            (Some(receipt), None) => Some(receipt),
+            (None, Some(sha256)) => {
+                let Some(receipt) = self.state.read().await.receipt_body(&sha256).cloned() else {
+                    return Err(McpError::invalid_params(
+                        format!(
+                            "no receipt with sha256 {sha256} was produced by this session; \
+                             pass proof_receipt itself, or re-run run_wp and use the sha256 \
+                             it returns"
+                        ),
+                        None,
+                    ));
+                };
+                Some(receipt)
+            }
+            (Some(_), Some(_)) => {
+                return Err(McpError::invalid_params(
+                    "pass proof_receipt or proof_receipt_sha256, not both",
+                    None,
+                ))
+            }
+            (None, None) => None,
+        };
+
         let func_name = params.function;
         // The name becomes a directory under .frama-c-mcp/.
         require_safe_path_segment(&func_name, "function")?;
@@ -50,7 +86,7 @@ impl FramaCMcpServer {
             wp_summary,
             notes: params.notes,
             callees: params.callees,
-            proof_receipt: params.proof_receipt,
+            proof_receipt,
         };
 
         let mut state = self.state.write().await;

--- a/src/mcp/contracts.rs
+++ b/src/mcp/contracts.rs
@@ -445,18 +445,17 @@ fn result_values_determined(texts: &[String]) -> std::collections::BTreeSet<i64>
             let rhs = text[after..].trim_start();
             let equality_on_the_right =
                 rhs.strip_prefix("==").is_some_and(|rest| !rest.starts_with('>'));
-            if equality_on_the_right {
-                let off = after + (text[after..].len() - rhs.len()) + 2;
-                if let Some(v) = int_literal_after(text, off) {
-                    out.insert(v);
-                }
-            }
-            if text[..at].trim_end().ends_with("==") {
-                let lhs = text[..at].trim_end();
-                if let Some(v) = int_literal_before(text, lhs.len() - 2) {
-                    out.insert(v);
-                }
-            }
+            let on_the_right = equality_on_the_right
+                .then(|| after + (text[after..].len() - rhs.len()) + 2)
+                .and_then(|off| int_literal_after(text, off));
+            out.extend(on_the_right);
+
+            let lhs = text[..at].trim_end();
+            let on_the_left = lhs
+                .ends_with("==")
+                .then(|| int_literal_before(text, lhs.len() - 2))
+                .flatten();
+            out.extend(on_the_left);
             from = after;
         }
     }

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -65,6 +65,7 @@ fn log_location(source: &str, cwd: &Path) -> serde_json::Value {
     if source.is_empty() {
         return json!({"unresolved": true});
     }
+
     // Frama-C prints "path", "path:line" or "path:line:column", so the numbers
     // come off the end one at a time and what is left is the path. A trailing
     // field that is not a number means the whole string is the path: a path can

--- a/src/mcp/receipt.rs
+++ b/src/mcp/receipt.rs
@@ -762,15 +762,14 @@ impl FramaCMcpServer {
         }));
 
         // Remembered here rather than at each call site, so every receipt a
-        // caller is handed is one they can later pass as `since`, or name by
-        // hash where a whole receipt is wanted.
-        if let (Some(sha256), Some(receipt_goals)) =
-            (receipt["sha256"].as_str(), receipt["goals"].as_array())
-        {
+        // caller is handed is one they can later pass as "since", or name by
+        // hash where a whole receipt is wanted. The goals travel inside the
+        // body, so there is nothing to store beside it.
+        if let Some(sha256) = receipt["sha256"].as_str().map(str::to_string) {
             self.state
                 .write()
                 .await
-                .remember_receipt(sha256, receipt_goals, receipt.clone());
+                .remember_receipt(&sha256, receipt.clone());
         }
         receipt
     }

--- a/src/mcp/receipt.rs
+++ b/src/mcp/receipt.rs
@@ -762,14 +762,15 @@ impl FramaCMcpServer {
         }));
 
         // Remembered here rather than at each call site, so every receipt a
-        // caller is handed is one they can later pass as `since`.
+        // caller is handed is one they can later pass as `since`, or name by
+        // hash where a whole receipt is wanted.
         if let (Some(sha256), Some(receipt_goals)) =
             (receipt["sha256"].as_str(), receipt["goals"].as_array())
         {
             self.state
                 .write()
                 .await
-                .remember_receipt_goals(sha256, receipt_goals);
+                .remember_receipt(sha256, receipt_goals, receipt.clone());
         }
         receipt
     }

--- a/src/mcp/sandbox.rs
+++ b/src/mcp/sandbox.rs
@@ -50,7 +50,12 @@ impl FramaCMcpServer {
     }
 
     #[tool(description = "Create a sandbox Frama-C instance for one function and its dependencies. \
-        Pass experiment_id for a stable sandbox name; omitted IDs are generated and collisions are rejected.")]
+        Pass experiment_id for a stable sandbox name; omitted IDs are generated and collisions are rejected. \
+        This is how an annotation is tried without touching the real source: the sandbox holds its own \
+        copy of the function and its dependencies, so a loop invariant that makes WP diverge costs a \
+        respawn rather than the session, and a strengthening that does not work leaves no edit to revert. \
+        Copying the source tree by hand does the same thing worse: the copy is not addressable by name, \
+        nothing reloads it, and the goals it produces cannot be diffed against the main project.")]
     pub async fn create_sandbox(
         &self,
         Parameters(params): Parameters<CreateSandboxParams>,

--- a/src/mcp/selfcheck.rs
+++ b/src/mcp/selfcheck.rs
@@ -603,6 +603,19 @@ pub fn min_frama_c_version() -> String {
     format!("{}.{}", MIN_FRAMA_C_VERSION.0, MIN_FRAMA_C_VERSION.1)
 }
 
+/// The digit run at the front of an iterator, consumed from it.
+///
+/// Peeked rather than collected, so the first non-digit is left for the caller
+/// to see: the minor number ends at whatever follows it and that character is
+/// still part of the banner.
+fn take_digits(chars: &mut std::iter::Peekable<impl Iterator<Item = char>>) -> String {
+    let mut run = String::new();
+    while chars.peek().is_some_and(char::is_ascii_digit) {
+        run.push(chars.next().unwrap_or_default());
+    }
+    run
+}
+
 /// Major and minor version out of a "frama-c -version" banner, or None when it
 /// holds no version-shaped number outside parentheses.
 ///
@@ -646,10 +659,7 @@ pub fn frama_c_version(banner: &str) -> Option<(u32, u32)> {
         if !digits.is_empty() {
             let value = digits.parse::<u32>().ok();
             if ch == '.' {
-                let mut minor = String::new();
-                while chars.peek().is_some_and(char::is_ascii_digit) {
-                    minor.push(chars.next().unwrap_or_default());
-                }
+                let minor = take_digits(&mut chars);
                 return value.map(|major| (major, minor.parse::<u32>().unwrap_or(0)));
             }
             undotted = undotted.or(value);

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1586,10 +1586,8 @@ fn collect_json_string_fields_impl(
     match value {
         serde_json::Value::Object(map) => {
             for (key, value) in map {
-                if keys.contains(&key.as_str()) {
-                    if let Some(text) = value.as_str() {
-                        out.push(text.to_string());
-                    }
+                if let Some(text) = value.as_str().filter(|_| keys.contains(&key.as_str())) {
+                    out.push(text.to_string());
                 }
                 collect_json_string_fields_impl(value, keys, out);
             }
@@ -1677,6 +1675,50 @@ impl WpModelSupport {
     }
 }
 
+/// Every single-quoted run on one line of help text, in order.
+///
+/// Frama-C writes the model selectors quoted, several to a line, and pulling
+/// them out is a different question from deciding what each one is. Kept apart
+/// so the caller reads as find-then-classify rather than as a string walk with
+/// the classification buried four levels inside it. An unterminated quote ends
+/// the line rather than consuming the rest of it.
+fn quoted_selectors(line: &str) -> Vec<&str> {
+    let mut found = Vec::new();
+    let mut rest = line;
+    while let Some(start) = rest.find('\'') {
+        rest = &rest[start + 1..];
+        let Some(end) = rest.find('\'') else {
+            break;
+        };
+        found.push(&rest[..end]);
+        rest = &rest[end + 1..];
+    }
+    found
+}
+
+/// File one quoted selector under bases or modifiers.
+///
+/// A modifier selector is written with a leading "+" and may name several at
+/// once, as "+raw/+ref"; anything else is a base.
+fn record_selector(selector: &str, bases: &mut Vec<String>, modifiers: &mut Vec<String>) {
+    match selector.strip_prefix('+') {
+        Some(names) => {
+            for name in names.split('/') {
+                push_new(modifiers, name.trim_start_matches('+'));
+            }
+        }
+        None => push_new(bases, selector),
+    }
+}
+
+/// Append a name unless it is empty or already known. Order is the order the
+/// help text lists them in, which is the order they are offered back.
+fn push_new(known: &mut Vec<String>, name: &str) {
+    if !name.is_empty() && !known.iter().any(|seen| seen == name) {
+        known.push(name.to_string());
+    }
+}
+
 pub fn parse_wp_model_support(help: &str) -> WpModelSupport {
     let mut bases = Vec::new();
     let mut modifiers = Vec::new();
@@ -1693,24 +1735,8 @@ pub fn parse_wp_model_support(help: &str) -> WpModelSupport {
             continue;
         }
 
-        let mut rest = line;
-        while let Some(start) = rest.find('\'') {
-            rest = &rest[start + 1..];
-            let Some(end) = rest.find('\'') else {
-                break;
-            };
-            let selector = &rest[..end];
-            if selector.starts_with('+') {
-                for modifier in selector.split('/') {
-                    let modifier = modifier.trim_start_matches('+');
-                    if !modifier.is_empty() && !modifiers.iter().any(|known| known == modifier) {
-                        modifiers.push(modifier.to_string());
-                    }
-                }
-            } else if !selector.is_empty() && !bases.iter().any(|known| known == selector) {
-                bases.push(selector.to_string());
-            }
-            rest = &rest[end + 1..];
+        for selector in quoted_selectors(line) {
+            record_selector(selector, &mut bases, &mut modifiers);
         }
     }
 
@@ -1864,6 +1890,7 @@ fn spawn_frama_c(
     }
     cmd.stdout(Stdio::from(stdout_log))
         .stderr(Stdio::from(stderr_log))
+
         // Its own process group, for the same reason the sandbox spawn takes
         // one: Frama-C starts why3server and the provers as its own children,
         // and kill_on_drop SIGKILLs only Frama-C itself. Without a group there
@@ -3153,14 +3180,19 @@ impl FramaCMcpServer {
                 // process twice is harmless.
                 kill_sandbox(experiment_id, state.sandbox_pid, Some(state.sandbox_pid));
 
-                if let Err(e) = child.start_kill() {
-                    // ESRCH = process is dead; other errors will only warn
-                    if e.kind() != std::io::ErrorKind::InvalidInput {
-                        tracing::warn!(
-                            experiment_id, pid = state.sandbox_pid,
-                            "cleanup_sandbox: start_kill failed: {}", e
-                        );
-                    }
+                // InvalidInput is tokio's ESRCH here, meaning the process is
+                // already dead, which is the outcome being asked for. Anything
+                // else warns.
+                if let Err(e) = child
+                    .start_kill()
+                    .err()
+                    .filter(|e| e.kind() != std::io::ErrorKind::InvalidInput)
+                    .map_or(Ok(()), Err)
+                {
+                    tracing::warn!(
+                        experiment_id, pid = state.sandbox_pid,
+                        "cleanup_sandbox: start_kill failed: {}", e
+                    );
                 }
                 if let Err(e) = child.wait().await {
                     tracing::warn!(
@@ -3353,13 +3385,14 @@ impl FramaCMcpServer {
                     // parse_record_survives read those bytes before the
                     // reparse, so a write that landed in between built an AST
                     // the boot-parse record does not describe. Reading them
-                    // again is what closes that window: unchanged and the record
-                    // still answers for what Frama-C is holding, changed and it
-                    // answers for nothing, so it is replaced by the absence
-                    // rather than left to be read as a parse that dropped what
-                    // the previous bytes dropped. The process is poisoned with
-                    // it, since the next call cannot recover a record for an AST
-                    // whose boot parse never happened; only a new process can.
+                    // again is what closes that window: unchanged and the
+                    // record still answers for what Frama-C is holding, changed
+                    // and it answers for nothing, so it is replaced by the
+                    // absence rather than left to be read as a parse that
+                    // dropped what the previous bytes dropped. The process is
+                    // poisoned with it, since the next call cannot recover a
+                    // record for an AST whose boot parse never happened; only a
+                    // new process can.
                     //
                     // Before the lock, like the read that started this call.
                     let reparsed =
@@ -3367,15 +3400,17 @@ impl FramaCMcpServer {
                             .await;
 
                     let mut main_lock = self.main_frama_c_state.lock().await;
+                    if let Some(s) =
+                        main_lock.as_mut().filter(|s| reparsed.0 != s.ast_parse_source_digest)
+                    {
+                        s.ast_reload_diagnostics = Some(project::parse_log_unavailable(
+                            "the sources changed while Frama-C was rebuilding the AST, so no \
+                             parse record describes it"
+                                .to_string(),
+                        ));
+                        s.poisoned = true;
+                    }
                     if let Some(s) = main_lock.as_mut() {
-                        if reparsed.0 != s.ast_parse_source_digest {
-                            s.ast_reload_diagnostics = Some(project::parse_log_unavailable(
-                                "the sources changed while Frama-C was rebuilding the AST, so no \
-                                 parse record describes it"
-                                    .to_string(),
-                            ));
-                            s.poisoned = true;
-                        }
                         s.files = new_files;
                     }
                     self.state.write().await.project_loaded = true;
@@ -3469,6 +3504,7 @@ impl FramaCMcpServer {
             Err(reason) => {
                 let _ = child.start_kill();
                 let _ = child.wait().await;
+
                 // After the tail is read, which is the last thing that wants
                 // them.
                 let tail = startup_failure_tail(&stdout_log_path, &stderr_log_path, 20);
@@ -4220,10 +4256,9 @@ pub mod sandbox;
 pub fn collect_loop_sids(node: &serde_json::Value, out: &mut Vec<i64>) {
     match node {
         serde_json::Value::Object(map) => {
-            if map.get("kind").and_then(|k| k.as_str()) == Some("loop") {
-                if let Some(sid) = map.get("sid").and_then(|s| s.as_i64()) {
-                    out.push(sid);
-                }
+            let is_loop = map.get("kind").and_then(|k| k.as_str()) == Some("loop");
+            if let Some(sid) = map.get("sid").and_then(|s| s.as_i64()).filter(|_| is_loop) {
+                out.push(sid);
             }
 
             // `if` node: recurse cond → then_body → else_body in explicit
@@ -4231,15 +4266,14 @@ pub fn collect_loop_sids(node: &serde_json::Value, out: &mut Vec<i64>) {
             // iteration (arrays preserve order; non-if objects have no
             // order-sensitive children).
             if map.contains_key("then_body") && map.contains_key("else_body") {
-                for k in ["cond", "then_body", "else_body"] {
-                    if let Some(v) = map.get(k) {
-                        collect_loop_sids(v, out);
-                    }
-                }
-                for (k, v) in map {
-                    if !matches!(k.as_str(), "cond" | "then_body" | "else_body") {
-                        collect_loop_sids(v, out);
-                    }
+                const ORDERED: [&str; 3] = ["cond", "then_body", "else_body"];
+                let ordered = ORDERED.iter().filter_map(|k| map.get(*k));
+                let rest = map
+                    .iter()
+                    .filter(|(k, _)| !ORDERED.contains(&k.as_str()))
+                    .map(|(_, v)| v);
+                for child in ordered.chain(rest) {
+                    collect_loop_sids(child, out);
                 }
             } else {
                 for (_, v) in map {

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -810,7 +810,7 @@ pub struct StoreFunctionConclusionParams {
     pub proof_receipt: Option<serde_json::Value>,
     /// sha256 of a receipt this session produced, in place of the object.
     ///
-    /// A separate field rather than a string in `proof_receipt`, because that
+    /// A separate field rather than a string in "proof_receipt", because that
     /// one is coerced: a string there is parsed as JSON so a client that
     /// stringifies objects still works, and a bare 64-hex digest is not valid
     /// JSON, so it never reaches the handler. Discovered by an end-to-end test

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -808,6 +808,14 @@ pub struct StoreFunctionConclusionParams {
     /// Proof receipt returned by run_wp or check.
     #[serde(default, deserialize_with = "deserialize_value_or_string")]
     pub proof_receipt: Option<serde_json::Value>,
+    /// sha256 of a receipt this session produced, in place of the object.
+    ///
+    /// A separate field rather than a string in `proof_receipt`, because that
+    /// one is coerced: a string there is parsed as JSON so a client that
+    /// stringifies objects still works, and a bare 64-hex digest is not valid
+    /// JSON, so it never reaches the handler. Discovered by an end-to-end test
+    /// after a unit test on the state alone had passed.
+    pub proof_receipt_sha256: Option<String>,
 
     // S1_info_gather outputs
     /// Callee names list

--- a/src/mcp/wpclass.rs
+++ b/src/mcp/wpclass.rs
@@ -846,6 +846,25 @@ pub fn split_goal_classification(
     (per_goal, key, advice)
 }
 
+/// One goal's classification with its own advice attached rather than shared.
+///
+/// The goal-list path hoists each advice onto the first goal of its key,
+/// because a caller reads that array whole and can follow advice_key to a
+/// sibling. A goal handed over on its own has no sibling to follow the key to,
+/// so it carries the block itself. Both single-goal paths call this, so the two
+/// cannot drift into answering with different shapes.
+pub fn goal_classification_with_own_advice(
+    goal: &serde_json::Value,
+    function: Option<&str>,
+) -> serde_json::Value {
+    let (mut per_goal, _key, advice) =
+        split_goal_classification(&classify_wp_failure_from_goal(goal, function));
+    if let Some(object) = per_goal.as_object_mut() {
+        object.insert("advice".to_string(), advice);
+    }
+    per_goal
+}
+
 fn proofread_why_problem(category: &str, goal_kind: &str) -> &'static str {
     match category {
         "rte" => {

--- a/src/mcp/wpclass.rs
+++ b/src/mcp/wpclass.rs
@@ -389,7 +389,11 @@ pub fn classify_wp_failure_from_goal(
         "normalized_status": normalized_status,
         "goal_kind": goal_kind,
         "evidence": evidence,
-        "suggested_next_tool": next_action,
+
+        // One name, not two. This carried the same object under both for a
+        // while, which cost over 6 KB across a 16-goal reply for nothing: the
+        // values were byte-identical, so a caller reading either got the same
+        // answer and every caller paid for both.
         "next_action": next_action,
         "wp_timeout_triage": timeout_triage,
         "proofread_report": report,
@@ -767,17 +771,17 @@ fn proofread_finding_from_wp_failure(
 /// with every other goal of its kind.
 ///
 /// Two different duplications live in a classification and only one of them is
-/// across goals. Within a single goal, `runtime_check_suggestion` appears three
-/// times: standalone, nested inside `next_action`, and again inside
-/// `semantic_verdict`. Across goals, the rendered `proofread_report` and the
+/// across goals. Within a single goal, "runtime_check_suggestion" appears
+/// three times: standalone, nested inside "next_action", and again inside
+/// "semantic_verdict". Across goals, the rendered "proofread_report" and the
 /// E-ACSL advice are byte-identical for everything sharing a category and goal
 /// kind. Measured on one function whose goals were legitimately all unproved,
 /// the two together came to 106 KB across 21 goals, against 1.7 KB of the
 /// fields a caller triages from.
 ///
 /// What stays on the goal is what varies with it or what a caller reads per
-/// goal: the verdict fields, its own evidence, `suggested_next_tool` (whose
-/// reason carries this goal's file and line) and `wp_timeout_triage`. The
+/// goal: the verdict fields, its own evidence, "next_action" (whose reason
+/// carries this goal's file and line) and "wp_timeout_triage". The
 /// stdio suite asserts the last two per goal, which is the contract and not an
 /// accident.
 pub fn split_goal_classification(
@@ -806,7 +810,7 @@ pub fn split_goal_classification(
     // The nested copy inside next_action goes; the standalone one is hoisted.
     // Dropping it here is what makes the per-goal half small, and it is the
     // same object either way.
-    let mut next_action = get("suggested_next_tool");
+    let mut next_action = get("next_action");
     if let Some(obj) = next_action.as_object_mut() {
         obj.remove("runtime_check_suggestion");
     }
@@ -819,7 +823,6 @@ pub fn split_goal_classification(
         "normalized_status": get("normalized_status"),
         "goal_kind": get("goal_kind"),
         "evidence": get("evidence"),
-        "suggested_next_tool": next_action.clone(),
         "next_action": next_action,
         "wp_timeout_triage": get("wp_timeout_triage"),
         "advice_key": key.clone(),

--- a/src/mcp/wpclass.rs
+++ b/src/mcp/wpclass.rs
@@ -95,7 +95,7 @@ fn classify_failure_reason(
                 // invites: retried at six times the budget it does not move,
                 // and the next thing tried is an invariant guessed from the
                 // goal name.
-                "Set retry_unproved to tell a slow goal from an unprovable one: it re-runs at double the budget and reports which flip. If none flip, more time is not the fix. This one is a runtime-error check, so read the goal's own predicate rather than its name: the name's trailing number counts siblings from one statement and names none of them, while the predicate says which access is open. context {want: [\"rte_obligations\"]} adds the drafted requires, which no goal carries."
+                "Set retry_unproved to tell a slow goal from an unprovable one: it re-runs at double the budget and reports which flip. If none flip, more time is not the fix. This one is a runtime-error check, so read the goal's own predicate rather than its name: the name's trailing number counts siblings from one statement and names none of them, while the predicate says which access is open. context {want: [\"rte_obligations\"]} adds the drafted requires, which no goal carries, and is the fallback when this goal carries no predicate either."
             } else {
                 "Set retry_unproved to tell a slow goal from an unprovable one: it re-runs at double the budget and reports which flip. If none flip, more time is not the fix -- read the VC and supply the missing fact."
             },
@@ -158,13 +158,14 @@ fn classify_failure_reason(
              guarantee or the code must establish: the requires that rules the value out, an \
              assert that carries the fact to this point, or a loop invariant that keeps the index \
              in range. Strengthening the postcondition will not close it. \
-             Read the goal's own predicate to choose which: every goal this returns carries \
-             one, so the open access reads as \\valid(p + i) directly. Do not work from the \
+             Read the goal's own predicate to choose which: the goal usually carries one, \
+             and the open access then reads as \\valid(p + i) directly. Do not work from the \
              goal name, which cannot distinguish siblings: the trailing number in mem_access_7 \
              counts checks generated from one statement and names none of them. Guessing an \
              invariant from the name costs a proof run per guess and does not converge. \
-             context {want: [\"rte_obligations\"]} is worth a call for something else: it \
-             drafts the requires, which the goal does not carry.",
+             context {want: [\"rte_obligations\"]} covers both gaps: it drafts the requires, \
+             which no goal carries, and it is the fallback for the goals whose property row \
+             supplied no predicate to copy.",
         )
     } else if ["unsupported", "unbound", "unknown predicate", "unknown logic"]
         .iter()
@@ -845,8 +846,9 @@ pub fn split_goal_classification(
 fn proofread_why_problem(category: &str, goal_kind: &str) -> &'static str {
     match category {
         "rte" => {
-            "The runtime-error obligation is still open; the goal's own predicate \
-                  names which check it is."
+            "The runtime-error obligation is still open. When the goal carries a \
+             predicate, that names which check it is; when it carries none, \
+             context {want: [\"rte_obligations\"]} is where to look."
         }
         "timeout" => "The prover timed out before proving this obligation.",
         "internal_error" => "Frama-C or WP reported an internal failure for this obligation.",

--- a/src/mcp/wpclass.rs
+++ b/src/mcp/wpclass.rs
@@ -85,7 +85,20 @@ fn classify_failure_reason(
             // set is what tells them apart, and run_wp does exactly that when
             // retry_unproved is set. Reach for a bigger budget only if that
             // diff is non-empty; otherwise the budget is not what is missing.
-            "Set retry_unproved to tell a slow goal from an unprovable one: it re-runs at double the budget and reports which flip. If none flip, more time is not the fix -- read the VC and supply the missing fact.",
+            if goal_kind.starts_with("rte_") {
+                // The same advice, ending somewhere concrete. "Read the VC" is
+                // the right instruction and the wrong altitude for a
+                // runtime-error check: the VC is a sequent, while
+                // rte_obligations hands back the one predicate that is open and
+                // a drafted requires for it. Without this the branch reads as
+                // "raise the budget", which is the loop a stuck RTE goal
+                // invites: retried at six times the budget it does not move,
+                // and the next thing tried is an invariant guessed from the
+                // goal name.
+                "Set retry_unproved to tell a slow goal from an unprovable one: it re-runs at double the budget and reports which flip. If none flip, more time is not the fix. This one is a runtime-error check, so read the goal's own predicate rather than its name: the name's trailing number counts siblings from one statement and names none of them, while the predicate says which access is open. context {want: [\"rte_obligations\"]} adds the drafted requires, which no goal carries."
+            } else {
+                "Set retry_unproved to tell a slow goal from an unprovable one: it re-runs at double the budget and reports which flip. If none flip, more time is not the fix -- read the VC and supply the missing fact."
+            },
         )
     } else if text.contains("prover")
         && (text.contains("not found")
@@ -144,7 +157,14 @@ fn classify_failure_reason(
             "The obligation is a runtime-error check, so the fix is a fact the caller must \
              guarantee or the code must establish: the requires that rules the value out, an \
              assert that carries the fact to this point, or a loop invariant that keeps the index \
-             in range. Strengthening the postcondition will not close it.",
+             in range. Strengthening the postcondition will not close it. \
+             Read the goal's own predicate to choose which: every goal this returns carries \
+             one, so the open access reads as \\valid(p + i) directly. Do not work from the \
+             goal name, which cannot distinguish siblings: the trailing number in mem_access_7 \
+             counts checks generated from one statement and names none of them. Guessing an \
+             invariant from the name costs a proof run per guess and does not converge. \
+             context {want: [\"rte_obligations\"]} is worth a call for something else: it \
+             drafts the requires, which the goal does not carry.",
         )
     } else if ["unsupported", "unbound", "unknown predicate", "unknown logic"]
         .iter()
@@ -742,9 +762,92 @@ fn proofread_finding_from_wp_failure(
     })
 }
 
+/// The classification's per-goal half, and the key naming the half it shares
+/// with every other goal of its kind.
+///
+/// Two different duplications live in a classification and only one of them is
+/// across goals. Within a single goal, `runtime_check_suggestion` appears three
+/// times: standalone, nested inside `next_action`, and again inside
+/// `semantic_verdict`. Across goals, the rendered `proofread_report` and the
+/// E-ACSL advice are byte-identical for everything sharing a category and goal
+/// kind. Measured on one function whose goals were legitimately all unproved,
+/// the two together came to 106 KB across 21 goals, against 1.7 KB of the
+/// fields a caller triages from.
+///
+/// What stays on the goal is what varies with it or what a caller reads per
+/// goal: the verdict fields, its own evidence, `suggested_next_tool` (whose
+/// reason carries this goal's file and line) and `wp_timeout_triage`. The
+/// stdio suite asserts the last two per goal, which is the contract and not an
+/// accident.
+pub fn split_goal_classification(
+    classification: &serde_json::Value,
+) -> (serde_json::Value, String, serde_json::Value) {
+    let get = |key: &str| {
+        classification
+            .get(key)
+            .cloned()
+            .unwrap_or(serde_json::Value::Null)
+    };
+    let category = classification
+        .get("category")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    let goal_kind = classification
+        .get("goal_kind")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+
+    // Keyed on both, because the advice differs on each: a timed-out rte
+    // obligation and a timed-out postcondition share a category and are told
+    // different things.
+    let key = format!("{category}:{goal_kind}");
+
+    // The nested copy inside next_action goes; the standalone one is hoisted.
+    // Dropping it here is what makes the per-goal half small, and it is the
+    // same object either way.
+    let mut next_action = get("suggested_next_tool");
+    if let Some(obj) = next_action.as_object_mut() {
+        obj.remove("runtime_check_suggestion");
+    }
+
+    let per_goal = json!({
+        "category": get("category"),
+        "failure_kind": get("failure_kind"),
+        "confidence": get("confidence"),
+        "status": get("status"),
+        "normalized_status": get("normalized_status"),
+        "goal_kind": get("goal_kind"),
+        "evidence": get("evidence"),
+        "suggested_next_tool": next_action.clone(),
+        "next_action": next_action,
+        "wp_timeout_triage": get("wp_timeout_triage"),
+        "advice_key": key.clone(),
+    });
+
+    let advice = json!({
+        "category": get("category"),
+        "goal_kind": get("goal_kind"),
+        "why_problem": proofread_why_problem(category, goal_kind),
+        "suggested_fix": classification
+            .get("proofread_report")
+            .and_then(|report| report.get("findings"))
+            .and_then(|findings| findings.get(0))
+            .and_then(|finding| finding.get("suggested_fix"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        "runtime_check_suggestion": get("runtime_check_suggestion"),
+        "semantic_verdict": get("semantic_verdict"),
+    });
+
+    (per_goal, key, advice)
+}
+
 fn proofread_why_problem(category: &str, goal_kind: &str) -> &'static str {
     match category {
-        "rte" => "The runtime-error obligation is still open.",
+        "rte" => {
+            "The runtime-error obligation is still open; the goal's own predicate \
+                  names which check it is."
+        }
         "timeout" => "The prover timed out before proving this obligation.",
         "internal_error" => "Frama-C or WP reported an internal failure for this obligation.",
         "unsupported_predicate" => "The proof uses logic that WP could not handle.",

--- a/src/mcp/wpclass.rs
+++ b/src/mcp/wpclass.rs
@@ -1307,10 +1307,11 @@ pub fn wp_backend_diagnosis(
             // second. The routing decision only asks whether the list is
             // non-empty, which is unaffected; a reader chasing every cast wants
             // the source, not this field.
-            if let Some(line) = message.pointer("/source/line") {
-                if !cast_lines.contains(line) {
-                    cast_lines.push(line.clone());
-                }
+            if let Some(line) = message
+                .pointer("/source/line")
+                .filter(|line| !cast_lines.contains(*line))
+            {
+                cast_lines.push(line.clone());
             }
         }
     }

--- a/src/mcp/wpout.rs
+++ b/src/mcp/wpout.rs
@@ -247,17 +247,16 @@ pub fn parse_wp_print_blocks(output: &str) -> Vec<serde_json::Value> {
             // calls that used to sit inside it could not fire, since as_mut had
             // already proved the Some, but they left the reader deriving that
             // before ruling out a panic.
-            if title_ends_here {
-                if let Some((title_function, title)) = pending_title.take() {
-                    current = Some((title_function, title, Vec::new()));
-                }
+            if let Some((title_function, title)) =
+                pending_title.take_if(|_| title_ends_here)
+            {
+                current = Some((title_function, title, Vec::new()));
             }
             continue;
         }
-        if let Some((_, _, body)) = current.as_mut() {
-            if trimmed == ":" || trimmed.chars().all(|ch| ch == '-') {
-                continue;
-            }
+        // A bare ":" or a rule of dashes is separator rather than body.
+        let separator = trimmed == ":" || trimmed.chars().all(|ch| ch == '-');
+        if let Some((_, _, body)) = current.as_mut().filter(|_| !separator) {
             body.push(line.to_string());
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -229,8 +229,8 @@ pub struct SessionState {
     pub conclusions: HashMap<String, FunctionVerificationState>,
     pub project_state: Option<ProjectVerificationState>,
     /// Receipts this session produced, keyed by their sha256: the goal set for
-    /// `get_wp_goals {since}` to diff against, and the receipt body itself so
-    /// `store_function_conclusion` can be handed the hash instead of the whole
+    /// get_wp_goals {since} to diff against, and the receipt body itself so
+    /// store_function_conclusion can be handed the hash instead of the whole
     /// thing.
     ///
     /// Session-scoped on purpose. The case a diff is for is two consecutive
@@ -245,7 +245,12 @@ pub struct SessionState {
     /// slip is rejected with no way to tell which field moved. Resolving the
     /// hash against what this process wrote keeps the coherence check exactly
     /// as strong, since the bytes being checked are still the server's own.
-    pub seen_receipts: VecDeque<(String, Vec<serde_json::Value>, serde_json::Value)>,
+    ///
+    /// The goals are not stored beside the body: they are already in it, under
+    /// "goals", written by the same call that produced the hash. Keeping a
+    /// second copy meant the array was held twice per entry, up to the
+    /// SEEN_RECEIPT_LIMIT, and left room for the two to disagree.
+    pub seen_receipts: VecDeque<(String, serde_json::Value)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1152,54 +1157,45 @@ impl SessionState {
         self.wp_completed = true;
     }
 
-    /// Remember a receipt's goals so a later run can be diffed against it.
+    /// Remember a receipt, so the hash the caller was handed can later stand in
+    /// for the whole thing and a later run can be diffed against its goals.
     ///
-    /// Keyed by the receipt hash the caller was handed, which is the only
-    /// identifier they have for "the run I just saw".
-    pub fn remember_receipt_goals(&mut self, sha256: &str, goals: &[serde_json::Value]) {
-        self.remember_receipt(sha256, goals, serde_json::Value::Null);
-    }
-
-    /// Remember a receipt's goals and, when the caller has it, the receipt
-    /// body, so the hash can stand in for the whole thing later.
-    pub fn remember_receipt(
-        &mut self,
-        sha256: &str,
-        goals: &[serde_json::Value],
-        receipt: serde_json::Value,
-    ) {
-        if let Some(slot) = self.seen_receipts.iter_mut().find(|(seen, _, _)| seen == sha256) {
-            // A later call may know the body where an earlier one did not.
-            if slot.2.is_null() {
-                slot.2 = receipt;
-            }
+    /// Keyed by that hash, which is the only identifier a caller has for "the
+    /// run I just saw". Recording the same hash twice keeps the first body: two
+    /// receipts hashing alike are byte-identical, so there is nothing to
+    /// choose between them.
+    pub fn remember_receipt(&mut self, sha256: &str, receipt: serde_json::Value) {
+        if self.seen_receipts.iter().any(|(seen, _)| seen == sha256) {
             return;
         }
         if self.seen_receipts.len() >= SEEN_RECEIPT_LIMIT {
             self.seen_receipts.pop_front();
         }
-        self.seen_receipts
-            .push_back((sha256.to_string(), goals.to_vec(), receipt));
+        self.seen_receipts.push_back((sha256.to_string(), receipt));
     }
 
     /// The goals of a remembered receipt, or None when this session never
     /// produced it. None is an error to the caller rather than an empty diff:
     /// "nothing changed" and "I never saw that run" are different answers.
+    ///
+    /// Read out of the stored body rather than from a field beside it, so the
+    /// diff is against the array the hash was computed over and cannot drift
+    /// from it.
     pub fn receipt_goals(&self, sha256: &str) -> Option<&[serde_json::Value]> {
-        self.seen_receipts
-            .iter()
-            .find(|(seen, _, _)| seen == sha256)
-            .map(|(_, goals, _)| goals.as_slice())
+        self.receipt_body(sha256)?
+            .get("goals")?
+            .as_array()
+            .map(Vec::as_slice)
     }
 
     /// The body of a remembered receipt, or None when this session never
-    /// produced it or recorded only its goals. Same rule as receipt_goals:
-    /// an unknown hash is an error, not an empty answer.
+    /// produced it. Same rule as receipt_goals: an unknown hash is an error,
+    /// not an empty answer.
     pub fn receipt_body(&self, sha256: &str) -> Option<&serde_json::Value> {
         self.seen_receipts
             .iter()
-            .find(|(seen, _, _)| seen == sha256)
-            .map(|(_, _, receipt)| receipt)
+            .find(|(seen, _)| seen == sha256)
+            .map(|(_, receipt)| receipt)
             .filter(|receipt| !receipt.is_null())
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -217,13 +217,24 @@ pub struct SessionState {
     // Skill-based verification
     pub conclusions: HashMap<String, FunctionVerificationState>,
     pub project_state: Option<ProjectVerificationState>,
-    /// Goal sets from receipts this session produced, keyed by receipt sha256,
-    /// so `get_wp_goals {since}` can name a run the caller has actually seen.
+    /// Receipts this session produced, keyed by their sha256: the goal set for
+    /// `get_wp_goals {since}` to diff against, and the receipt body itself so
+    /// `store_function_conclusion` can be handed the hash instead of the whole
+    /// thing.
     ///
     /// Session-scoped on purpose. The case a diff is for is two consecutive
     /// `run_wp` calls, and scanning stored conclusions would only find runs
     /// somebody chose to persist, missing exactly that case.
-    pub seen_receipts: VecDeque<(String, Vec<serde_json::Value>)>,
+    ///
+    /// The body is kept because the alternative does not work through an MCP
+    /// client. A receipt's hash is recomputed over its serialized bytes, so
+    /// evidence has to arrive byte-exact, and a caller's only channel is to
+    /// echo it back through its own context: measured on one function, that is
+    /// 8 KB whose bulk is an 82-entry goal array, and a single transcription
+    /// slip is rejected with no way to tell which field moved. Resolving the
+    /// hash against what this process wrote keeps the coherence check exactly
+    /// as strong, since the bytes being checked are still the server's own.
+    pub seen_receipts: VecDeque<(String, Vec<serde_json::Value>, serde_json::Value)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1135,13 +1146,29 @@ impl SessionState {
     /// Keyed by the receipt hash the caller was handed, which is the only
     /// identifier they have for "the run I just saw".
     pub fn remember_receipt_goals(&mut self, sha256: &str, goals: &[serde_json::Value]) {
-        if self.seen_receipts.iter().any(|(seen, _)| seen == sha256) {
+        self.remember_receipt(sha256, goals, serde_json::Value::Null);
+    }
+
+    /// Remember a receipt's goals and, when the caller has it, the receipt
+    /// body, so the hash can stand in for the whole thing later.
+    pub fn remember_receipt(
+        &mut self,
+        sha256: &str,
+        goals: &[serde_json::Value],
+        receipt: serde_json::Value,
+    ) {
+        if let Some(slot) = self.seen_receipts.iter_mut().find(|(seen, _, _)| seen == sha256) {
+            // A later call may know the body where an earlier one did not.
+            if slot.2.is_null() {
+                slot.2 = receipt;
+            }
             return;
         }
         if self.seen_receipts.len() >= SEEN_RECEIPT_LIMIT {
             self.seen_receipts.pop_front();
         }
-        self.seen_receipts.push_back((sha256.to_string(), goals.to_vec()));
+        self.seen_receipts
+            .push_back((sha256.to_string(), goals.to_vec(), receipt));
     }
 
     /// The goals of a remembered receipt, or None when this session never
@@ -1150,7 +1177,18 @@ impl SessionState {
     pub fn receipt_goals(&self, sha256: &str) -> Option<&[serde_json::Value]> {
         self.seen_receipts
             .iter()
-            .find(|(seen, _)| seen == sha256)
-            .map(|(_, goals)| goals.as_slice())
+            .find(|(seen, _, _)| seen == sha256)
+            .map(|(_, goals, _)| goals.as_slice())
+    }
+
+    /// The body of a remembered receipt, or None when this session never
+    /// produced it or recorded only its goals. Same rule as receipt_goals:
+    /// an unknown hash is an error, not an empty answer.
+    pub fn receipt_body(&self, sha256: &str) -> Option<&serde_json::Value> {
+        self.seen_receipts
+            .iter()
+            .find(|(seen, _, _)| seen == sha256)
+            .map(|(_, _, receipt)| receipt)
+            .filter(|receipt| !receipt.is_null())
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -133,19 +133,30 @@ pub fn sha256_hex_of_reader(mut reader: impl std::io::Read) -> std::io::Result<(
             break;
         }
         if !may_be_a_directive {
-            for &byte in &buffer[..read] {
-                may_be_a_directive |= byte == b'#'
-                    || (byte == b':' && previous[1] == b'%')
-                    || (byte == b'=' && previous[1] == b'?' && previous[0] == b'?');
-                if may_be_a_directive {
-                    break;
-                }
-                previous = [previous[1], byte];
-            }
+            may_be_a_directive = starts_a_directive(&buffer[..read], &mut previous);
         }
         hasher.update(&buffer[..read]);
     }
     Ok((hex_digest(hasher.finalize()), may_be_a_directive))
+}
+
+/// Whether this chunk holds the first byte of something the preprocessor acts
+/// on: a directive, a trigraph, or a digraph.
+///
+/// "previous" carries the two bytes before the chunk, because all three
+/// patterns can straddle a read boundary and a scan that restarts at every
+/// chunk would miss exactly the files large enough to need two reads.
+fn starts_a_directive(chunk: &[u8], previous: &mut [u8; 2]) -> bool {
+    for &byte in chunk {
+        if byte == b'#'
+            || (byte == b':' && previous[1] == b'%')
+            || (byte == b'=' && previous[1] == b'?' && previous[0] == b'?')
+        {
+            return true;
+        }
+        *previous = [previous[1], byte];
+    }
+    false
 }
 
 fn hex_digest(digest: impl AsRef<[u8]>) -> String {

--- a/src/topo.rs
+++ b/src/topo.rs
@@ -76,12 +76,14 @@ pub fn compute_topological_order(vertices: &[String], edges: &[(String, String)]
         }
         let mut next_ready: Vec<NodeIndex> = vec![];
         for &g in &ready {
-            for caller in condensed.neighbors_directed(g, Direction::Incoming) {
+            let callers = condensed.neighbors_directed(g, Direction::Incoming);
+            next_ready.extend(callers.filter(|caller| {
+                // Decrementing is the point, not the filter: every caller loses
+                // one outstanding callee here, and the ones that reach zero are
+                // exactly the next level.
                 out_degree[caller.index()] -= 1;
-                if out_degree[caller.index()] == 0 {
-                    next_ready.push(caller);
-                }
-            }
+                out_degree[caller.index()] == 0
+            }));
         }
         ready = next_ready;
         current_level += 1;

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -1806,7 +1806,7 @@ fn assert_wp_goal_shape(goal: &Value) {
     assert!(goal["vacuous"].as_bool().is_some(), "{:?}", goal);
     if goal["failure_classification"].is_object() {
         assert!(goal["failure_classification"]["category"].as_str().is_some(), "{:?}", goal);
-        assert!(goal["failure_classification"]["suggested_next_tool"]["tool"].as_str().is_some(),
+        assert!(goal["failure_classification"]["next_action"]["tool"].as_str().is_some(),
             "{:?}", goal);
         assert!(goal["failure_classification"]["wp_timeout_triage"]["retry_with_higher_prover_timeout"]
             .as_bool().is_some(), "{:?}", goal);
@@ -3412,7 +3412,7 @@ async fn wp_goals_surface_vacuous_call_precondition_status() {
         later_precondition
     );
     assert!(
-        later_precondition["failure_classification"]["suggested_next_tool"]["tool"]
+        later_precondition["failure_classification"]["next_action"]["tool"]
             .as_str()
             .is_some(),
         "classification should suggest a next tool: {:?}",
@@ -4838,7 +4838,7 @@ async fn property_identity_is_preserved_across_analysis_tools() {
         })
         .unwrap_or_else(|| panic!("VC with failure classification missing: {:?}", details));
     assert!(
-        classified_vc["failure_classification"]["suggested_next_tool"]["tool"]
+        classified_vc["failure_classification"]["next_action"]["tool"]
             .as_str()
             .is_some(),
         "{:?}",
@@ -8831,7 +8831,6 @@ async fn a_respawn_reports_the_new_process_parse() {
     let _ = client.cancel().await;
 }
 
-#[tokio::test]
 /// The advice block rides one goal per category, over the wire.
 ///
 /// The split was unit-tested on split_goal_classification alone, which is the
@@ -8841,10 +8840,15 @@ async fn a_respawn_reports_the_new_process_parse() {
 /// payload a client actually receives.
 ///
 /// Writing it found two things a unit test could not. The split does hold end
-/// to end. And it saves less than it looks, because suggested_next_tool.reason
-/// and next_action.reason still carry the same advice text on every goal, and
-/// those stay per-goal on purpose. The second assertion below pins that number
-/// so the gap is a measurement rather than a belief.
+/// to end. And it saves less than it looks, because next_action.reason still
+/// carries the advice text on every goal, and it stays per-goal on purpose: a
+/// caller reading one goal needs the reason in hand. The second assertion below
+/// pins that number so the gap is a measurement rather than a belief.
+///
+/// The figures moved once since they were first recorded, and downward: the
+/// classification used to carry this same object twice, as next_action and as
+/// suggested_next_tool, so every number here counted it twice.
+#[tokio::test]
 async fn advice_is_carried_once_per_category_over_the_wire() {
     // 16 classified goals collapsing to 4 keys when this was written, which is
     // what makes the duplication visible; a fixture with one failure would pass
@@ -8960,18 +8964,12 @@ async fn advice_is_carried_once_per_category_over_the_wire() {
         "the split must cut at least a quarter here: {actual} against {unsplit} unsplit"
     );
 
-    // And the part it does not save. Both reasons restate the advice per goal,
-    // and they are pinned per-goal by an older test, so this is the ceiling on
-    // what the split can do rather than a defect to fix here.
+    // And the part it does not save. next_action.reason restates the advice per
+    // goal, and it is pinned per-goal by an older test, so this is the ceiling
+    // on what the split can do rather than a defect to fix here.
     let reasons: usize = classified
         .iter()
-        .map(|c| {
-            c["suggested_next_tool"]["reason"]
-                .as_str()
-                .unwrap_or("")
-                .len()
-                + c["next_action"]["reason"].as_str().unwrap_or("").len()
-        })
+        .map(|c| c["next_action"]["reason"].as_str().unwrap_or("").len())
         .sum();
     assert!(
         reasons > (unsplit - actual) / 4,
@@ -8982,15 +8980,14 @@ async fn advice_is_carried_once_per_category_over_the_wire() {
     );
     eprintln!(
         "advice split: {} goals, {} keys, {actual} bytes assembled against \
-         {unsplit} unsplit, {reasons} still repeated in the two reasons",
+         {unsplit} unsplit, {reasons} still repeated in next_action.reason",
         classified.len(),
         keys.len()
     );
 
-    // What truncating each reason to its first sentence would save. Reported
+    // What truncating the reason to its first sentence would save. Reported
     // rather than acted on, because the saving was measured and the change was
-    // then rejected on the text: 12888 bytes against 5976, so about 18 percent
-    // of the whole payload, but for several categories the first sentence is a
+    // then rejected on the text: for several categories the first sentence is a
     // diagnosis rather than an action. "Two different faults share this
     // branch." and "The callee's requires is not established at this call."
     // both put the thing to do in the second sentence, so a caller reading one
@@ -8999,11 +8996,8 @@ async fn advice_is_carried_once_per_category_over_the_wire() {
     let first_sentence_bytes: usize = classified
         .iter()
         .map(|c| {
-            let one = |field: &str| {
-                let text = c[field]["reason"].as_str().unwrap_or("");
-                text.find(". ").map_or(text.len(), |end| end + 1)
-            };
-            one("suggested_next_tool") + one("next_action")
+            let text = c["next_action"]["reason"].as_str().unwrap_or("");
+            text.find(". ").map_or(text.len(), |end| end + 1)
         })
         .sum();
     eprintln!(
@@ -9024,6 +9018,29 @@ async fn advice_is_carried_once_per_category_over_the_wire() {
     // an addition that size. Rerun this test to see the current figure in the
     // line above. Raising the ceiling is a legitimate change; doing it without
     // noticing is the one this stops.
+    //
+    // The mix is pinned first, because the average is a function of it and 11
+    // percent is not much room. The categories carry reason strings of very
+    // different lengths, the rte-timeout one running about two and a half times
+    // the generic, and each goal carries its reason twice. So a slower runner
+    // that times out more goals, or a faster one that closes some, moves this
+    // average without anything having been added to the payload, and the
+    // ceiling failure would then name a text growth that did not happen.
+    let mut by_category: std::collections::BTreeMap<&str, usize> =
+        std::collections::BTreeMap::new();
+    for c in &classified {
+        *by_category
+            .entry(c["category"].as_str().unwrap_or("?"))
+            .or_default() += 1;
+    }
+    assert_eq!(
+        by_category.get("timeout").copied().unwrap_or(0),
+        classified.len(),
+        "the ceiling below is calibrated on an all-timeout mix and this run is \
+         {by_category:?}. The prover or the budget moved, so re-measure the \
+         per-goal figure before reading a ceiling failure as added text."
+    );
+
     let per_goal = actual / classified.len();
     assert!(
         per_goal < 2600,

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -4425,6 +4425,112 @@ async fn check_receipts_distinguish_eva_entry_points() {
     let _ = client.cancel().await;
 }
 
+/// The receipt a real run produced, named by its hash, is accepted as evidence.
+///
+/// The unit test for this covers SessionState alone. What it cannot show is the
+/// path a caller actually takes: run_wp, read sha256 off the receipt, hand that
+/// string back. Every other conclusion test here builds a synthetic receipt
+/// with fixture_receipt, so the real run_wp-to-store path had no coverage in
+/// either direction.
+///
+/// The hash exists because the object cannot practically be echoed: acceptance
+/// recomputes the digest over the receipt's serialized bytes, and one
+/// function's receipt is roughly 8 KB whose bulk is a goal array. Resolving the
+/// hash checks the same bytes, since they are the ones this process wrote.
+#[tokio::test]
+async fn a_receipt_hash_from_run_wp_is_accepted_as_evidence() {
+    // A fixture that proves clean, because a verified conclusion is also
+    // checked against its summary: storing one whose goals are not all valid is
+    // refused on that ground before the receipt is ever consulted, which would
+    // leave the path under test unexercised.
+    let c_file = workspace_path("tests/fixtures/abs-int-fixed.c");
+    let client = spawn_mcp_client(c_file.to_str().unwrap()).await;
+
+    let run = call_tool_json(&client, "run_wp", json!({"timeout": 5}))
+        .await
+        .unwrap();
+    let sha = run["proof_receipt"]["sha256"]
+        .as_str()
+        .expect("run_wp returns a receipt with a sha256")
+        .to_string();
+
+    // Derived from the run, not invented: storing a conclusion also checks the
+    // summary against the receipt's goal count, so a made-up total is refused
+    // even when the receipt itself is genuine. That check is the reason this
+    // test reads the goals rather than asserting a convenient number.
+    let goals = run["proof_receipt"]["goals"]
+        .as_array()
+        .expect("a receipt carries its goals");
+    let total = goals.len();
+    let valid = goals.iter().filter(|g| g["status"] == "valid").count();
+
+    let stored = call_tool_json(
+        &client,
+        "store_function_conclusion",
+        json!({
+            "function": "abs_int",
+            "status": "verified",
+            "wp_summary": {
+                "total": total, "valid": valid,
+                "unknown": total - valid, "timeout": 0, "failed": 0
+            },
+            "proof_receipt_sha256": sha,
+        }),
+    )
+    .await;
+    assert!(
+        stored.is_ok(),
+        "a hash this session produced must be accepted: {stored:?}"
+    );
+
+    // And it must read back as the receipt, not as the string it arrived as.
+    let listed = call_tool_json(
+        &client,
+        "list",
+        json!({"kind": "conclusions", "function": "abs_int"}),
+    )
+    .await
+    .unwrap();
+    let text = serde_json::to_string(&listed).unwrap();
+    assert!(
+        text.contains(&sha),
+        "the stored conclusion must carry the receipt the hash named: {text}"
+    );
+    assert!(
+        text.contains("frama-c-mcp.proof-receipt"),
+        "and it must be the receipt object, not the bare hash: {text}"
+    );
+
+    let _ = client.cancel().await;
+}
+
+/// A hash this session never produced is refused, and says so. An unknown run
+/// and an empty one are different answers, the same rule get_wp_goals {since}
+/// already follows.
+#[tokio::test]
+async fn an_unknown_receipt_hash_is_refused() {
+    let c_file = workspace_path("tests/fixtures/abs-int-fixed.c");
+    let client = spawn_mcp_client(c_file.to_str().unwrap()).await;
+
+    let stored = call_tool_json(
+        &client,
+        "store_function_conclusion",
+        json!({
+            "function": "abs_int",
+            "status": "verified",
+            "wp_summary": {"total": 1, "valid": 1, "unknown": 0, "timeout": 0, "failed": 0},
+            "proof_receipt_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+        }),
+    )
+    .await;
+    assert!(
+        stored.is_err(),
+        "an unknown hash must not stand in for evidence: {stored:?}"
+    );
+
+    let _ = client.cancel().await;
+}
+
 #[tokio::test]
 async fn two_identical_runs_produce_one_receipt() {
     // The claim this server rests on is that two runs are comparable exactly

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -8830,3 +8830,195 @@ async fn a_respawn_reports_the_new_process_parse() {
     assert_eq!(category_count(&respawned, "kernel:asm:clobber"), 2, "{respawned}");
     let _ = client.cancel().await;
 }
+
+#[tokio::test]
+/// The advice block rides one goal per category, over the wire.
+///
+/// The split was unit-tested on split_goal_classification alone, which is the
+/// same shape of evidence that let an earlier round of this work ship a
+/// regression: a change reasoned about from the outside, confirmed against a
+/// function rather than against the server. So this measures the assembled
+/// payload a client actually receives.
+///
+/// Writing it found two things a unit test could not. The split does hold end
+/// to end. And it saves less than it looks, because suggested_next_tool.reason
+/// and next_action.reason still carry the same advice text on every goal, and
+/// those stay per-goal on purpose. The second assertion below pins that number
+/// so the gap is a measurement rather than a belief.
+async fn advice_is_carried_once_per_category_over_the_wire() {
+    // 16 classified goals collapsing to 4 keys when this was written, which is
+    // what makes the duplication visible; a fixture with one failure would pass
+    // either way.
+    let c_file = workspace_path("tests/fixtures/bubble_sort.c");
+    let client = spawn_mcp_client(c_file.to_str().unwrap()).await;
+
+    call_tool_json(&client, "run_wp", json!({"timeout": 5}))
+        .await
+        .unwrap();
+
+    // The receipt's goal array is ids and statuses only, by design: it is what
+    // two runs are compared on. The classification the split is about rides
+    // get_wp_goals, so that is what a client sees and what this measures.
+    let listed = call_tool_json(&client, "get_wp_goals", json!({"function": "bubble_sort"}))
+        .await
+        .unwrap();
+    let goals = listed
+        .as_array()
+        .expect("get_wp_goals returns a goal array");
+
+    let classified: Vec<&serde_json::Value> = goals
+        .iter()
+        .filter_map(|g| g.get("failure_classification"))
+        .collect();
+    assert!(
+        classified.len() >= 8,
+        "this fixture is here for its several failures, and it has {}",
+        classified.len()
+    );
+
+    // The fact the rte guidance rests on, pinned where it can be checked. The
+    // advice tells a caller to read the goal's own predicate rather than fetch
+    // it with context {want: ["rte_obligations"]}, and that is only true while
+    // every goal carries one. An earlier round of this work got it backwards,
+    // and nothing end to end would have caught it.
+    let without: Vec<&str> = goals
+        .iter()
+        .filter(|g| g.get("predicate").and_then(|p| p.as_str()).is_none())
+        .filter_map(|g| g["wpo"].as_str())
+        .collect();
+    assert!(
+        without.is_empty(),
+        "the rte advice says to read the goal's predicate, and {} of {} carry \
+         none: {without:?}. Either restore it or change the advice.",
+        without.len(),
+        goals.len()
+    );
+
+    let mut keys = std::collections::BTreeSet::new();
+    let mut carriers = 0usize;
+    for c in &classified {
+        keys.insert(
+            c["advice_key"]
+                .as_str()
+                .unwrap_or_else(|| panic!("every classified goal names its advice: {c}"))
+                .to_string(),
+        );
+        if c.get("advice").is_some() {
+            carriers += 1;
+        }
+    }
+    assert!(
+        keys.len() < classified.len(),
+        "with {} goals collapsing to {} keys there is nothing to demonstrate",
+        classified.len(),
+        keys.len()
+    );
+    assert_eq!(
+        carriers,
+        keys.len(),
+        "one carrier per key, not {carriers} across {} keys",
+        keys.len()
+    );
+
+    // What it saves, against the shape it replaced: the same advice on every
+    // goal. Compared rather than asserted as a byte count, so a fixture or a
+    // wording change moves both sides together.
+    let advice: std::collections::BTreeMap<&str, &serde_json::Value> = classified
+        .iter()
+        .filter(|c| c.get("advice").is_some())
+        .map(|c| (c["advice_key"].as_str().unwrap(), &c["advice"]))
+        .collect();
+    let actual = serde_json::to_string(&classified).unwrap().len();
+
+    // Every goal would carry its key's advice, so the counterfactual is what is
+    // sent now plus one copy for each goal that does not hold one.
+    let unsplit = actual
+        + classified
+            .iter()
+            .filter(|c| c.get("advice").is_none())
+            .map(|c| {
+                let key = c["advice_key"].as_str().unwrap();
+                serde_json::to_string(advice[key]).unwrap().len()
+            })
+            .sum::<usize>();
+    assert!(
+        actual * 4 < unsplit * 3,
+        "the split must cut at least a quarter here: {actual} against {unsplit} unsplit"
+    );
+
+    // And the part it does not save. Both reasons restate the advice per goal,
+    // and they are pinned per-goal by an older test, so this is the ceiling on
+    // what the split can do rather than a defect to fix here.
+    let reasons: usize = classified
+        .iter()
+        .map(|c| {
+            c["suggested_next_tool"]["reason"]
+                .as_str()
+                .unwrap_or("")
+                .len()
+                + c["next_action"]["reason"].as_str().unwrap_or("").len()
+        })
+        .sum();
+    assert!(
+        reasons > (unsplit - actual) / 4,
+        "the per-goal reasons are the remaining duplication, and they are \
+         {reasons} bytes against {} hoisted; if that has changed, \
+         re-read whether the split is still where the payload goes",
+        unsplit - actual
+    );
+    eprintln!(
+        "advice split: {} goals, {} keys, {actual} bytes assembled against \
+         {unsplit} unsplit, {reasons} still repeated in the two reasons",
+        classified.len(),
+        keys.len()
+    );
+
+    // What truncating each reason to its first sentence would save. Reported
+    // rather than acted on, because the saving was measured and the change was
+    // then rejected on the text: 12888 bytes against 5976, so about 18 percent
+    // of the whole payload, but for several categories the first sentence is a
+    // diagnosis rather than an action. "Two different faults share this
+    // branch." and "The callee's requires is not established at this call."
+    // both put the thing to do in the second sentence, so a caller reading one
+    // goal would be left with a finding and no next step. The number is kept so
+    // the next person weighing this starts from it instead of re-measuring.
+    let first_sentence_bytes: usize = classified
+        .iter()
+        .map(|c| {
+            let one = |field: &str| {
+                let text = c[field]["reason"].as_str().unwrap_or("");
+                text.find(". ").map_or(text.len(), |end| end + 1)
+            };
+            one("suggested_next_tool") + one("next_action")
+        })
+        .sum();
+    eprintln!(
+        "reason ceiling: {reasons} bytes now, {first_sentence_bytes} if each \
+         reason stopped at its first sentence"
+    );
+
+    // The budget this whole split exists to defend. A classified goal costs
+    // what it costs; what broke before was guidance text growing inside
+    // failure_classification with nothing measuring it, so the growth reached a
+    // real function as an unreadable reply rather than as a failing test.
+    //
+    // Calibrated against the regression it exists to catch, not just against
+    // today's figure. 37431 bytes over 16 goals is 2340 per goal. The round of
+    // guidance edits that caused this added 641 bytes per goal, which lands at
+    // 2981, so a ceiling of 3000 would have let through the very thing it was
+    // written for. 2600 keeps about 11 percent of headroom and still fails on
+    // an addition that size. Rerun this test to see the current figure in the
+    // line above. Raising the ceiling is a legitimate change; doing it without
+    // noticing is the one this stops.
+    let per_goal = actual / classified.len();
+    assert!(
+        per_goal < 2600,
+        "a classified goal costs {per_goal} bytes, over the 2600 this test \
+         records. Something added text to failure_classification: either hoist \
+         it into the advice block, which is sent once per category, or raise \
+         this ceiling deliberately and say in the commit message what a caller \
+         gets for the extra bytes."
+    );
+
+    let _ = client.cancel().await;
+}

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -9053,3 +9053,92 @@ async fn advice_is_carried_once_per_category_over_the_wire() {
 
     let _ = client.cancel().await;
 }
+
+/// An advice_key a caller is handed has to resolve in the payload it was
+/// handed, not in the array the server happened to build.
+///
+/// This is the failure the split shipped with and no test could see. check
+/// summarizes wp_goals through summarize_entries, which keeps the first few
+/// goals passing goal_needs_failure_classification and reports the rest as a
+/// count. The carrier was elected by smallest stable_goal_id, a digest with no
+/// relation to position, so a shown goal routinely named a carrier that was
+/// among the omitted entries and its advice was in no part of the reply, while
+/// the playbook promised the opposite. Electing the first classified goal of
+/// each key instead makes the two agree by construction: check keeps goals on
+/// the same predicate that classifies them, so the carrier of a key is scanned
+/// before every other goal of that key and survives whenever any of them does.
+///
+/// Both halves are asserted, because they fail apart. The truncated payload is
+/// the election; recommended_next_call is a single classification lifted out
+/// of the array, which loses its advice however the election works.
+#[tokio::test]
+async fn a_truncated_check_still_resolves_every_advice_key() {
+    // Several failing goals over more than one category, and comfortably more
+    // than the five a summarized check shows. bubble_sort.c is the wrong
+    // fixture for this and was tried first: it truncates, but its four
+    // smallest-id carriers all landed inside the shown five, so the test passed
+    // against the very code it was written to fail.
+    let c_file = workspace_path("tests/fixtures/tutorial/linked-n.c");
+    let client = spawn_mcp_client(c_file.to_str().unwrap()).await;
+
+    let checked = call_tool_json(
+        &client,
+        "check",
+        json!({"function": "isolated_loop_1", "want": ["wp"], "wp": {"timeout": 5}}),
+    )
+    .await
+    .unwrap();
+
+    let shown = checked["wp_goals"]["entries"]
+        .as_array()
+        .unwrap_or_else(|| panic!("a summarized check reports goals under entries: {checked}"));
+    assert!(
+        checked["wp_goals"]["omitted"].as_u64().unwrap_or(0) > 0,
+        "this fixture is here because check truncates it, and it did not: {}",
+        checked["wp_goals"]
+    );
+
+    let classified: Vec<&serde_json::Value> = shown
+        .iter()
+        .filter_map(|goal| goal.get("failure_classification"))
+        .collect();
+    assert!(
+        classified.len() >= 2,
+        "nothing to demonstrate with {} classified goals shown",
+        classified.len()
+    );
+
+    // Every key named in the truncated view is carried in the truncated view.
+    let carried: std::collections::BTreeSet<&str> = classified
+        .iter()
+        .filter(|c| c.get("advice").is_some())
+        .filter_map(|c| c["advice_key"].as_str())
+        .collect();
+    let named: std::collections::BTreeSet<&str> = classified
+        .iter()
+        .filter_map(|c| c["advice_key"].as_str())
+        .collect();
+    let dangling: Vec<&&str> = named.difference(&carried).collect();
+    assert!(
+        dangling.is_empty(),
+        "{} of {} shown keys resolve to a carrier check did not send: {dangling:?}. \
+         The advice for those categories is in no part of this reply.",
+        dangling.len(),
+        named.len()
+    );
+
+    // And the one classification check quotes on its own carries its advice,
+    // rather than an advice_key pointing at a goal the caller never received.
+    let quoted = &checked["recommended_next_call"]["classification"];
+    if !quoted.is_null() {
+        assert!(
+            quoted["advice"]["suggested_fix"]
+                .as_str()
+                .is_some_and(|fix| !fix.is_empty()),
+            "the recommended call quotes one goal to explain itself, and it \
+             explains nothing without the advice its key names: {quoted}"
+        );
+    }
+
+    let _ = client.cancel().await;
+}

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -8878,19 +8878,33 @@ async fn advice_is_carried_once_per_category_over_the_wire() {
 
     // The fact the rte guidance rests on, pinned where it can be checked. The
     // advice tells a caller to read the goal's own predicate rather than fetch
-    // it with context {want: ["rte_obligations"]}, and that is only true while
-    // every goal carries one. An earlier round of this work got it backwards,
-    // and nothing end to end would have caught it.
+    // it with context {want: ["rte_obligations"]}, which is only worth saying
+    // while the field is nearly always there. An earlier round of this work got
+    // it backwards, and nothing end to end would have caught it.
+    //
+    // A ratio and not an emptiness check, deliberately. This assertion asserted
+    // "every goal carries one" and passed, on this fixture, while the guidance
+    // it protects said the same thing and was false: predicate is copied from
+    // the property row a goal discharges, so a goal matching no row, or a row
+    // without one, has no such key, and 2 of 79 goals on test_comprehensive.c
+    // do not. An emptiness check here pins bubble_sort.c rather than the claim,
+    // which is the failure mode the guidance itself had.
     let without: Vec<&str> = goals
         .iter()
         .filter(|g| g.get("predicate").and_then(|p| p.as_str()).is_none())
         .filter_map(|g| g["wpo"].as_str())
         .collect();
     assert!(
-        without.is_empty(),
+        without.len() * 4 < goals.len(),
         "the rte advice says to read the goal's predicate, and {} of {} carry \
-         none: {without:?}. Either restore it or change the advice.",
+         none: {without:?}. Below three in four the advice is no longer worth \
+         giving: either restore the field or point at rte_obligations first.",
         without.len(),
+        goals.len()
+    );
+    eprintln!(
+        "predicate coverage: {} of {} goals carry one",
+        goals.len() - without.len(),
         goals.len()
     );
 

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -4578,10 +4578,65 @@ async fn two_identical_runs_produce_one_receipt() {
         first_receipt["reported"]["incomplete"], second_receipt["reported"]["incomplete"],
         "the incomplete digest moved between identical runs"
     );
-    assert_eq!(
-        first_receipt["sha256"], second_receipt["sha256"],
-        "identical runs produced different receipts: {first_receipt:?} vs {second_receipt:?}"
-    );
+
+    // A hash mismatch has two causes and they need different answers. Real
+    // nondeterminism is the bug this test exists for. A prover that reached its
+    // budget in one run and not the other is a loaded host, and reporting that
+    // as nondeterminism sends the reader to look for an ordering bug that is
+    // not there. Both were observed on one machine: three full-suite runs, each
+    // failing a different test, all passing alone.
+    //
+    // So the statuses are compared before the hash, and a difference that
+    // involves a timeout is named as what it is. It still fails, because a
+    // silent pass would hide a real divergence behind the same excuse, but it
+    // fails saying which of the two happened.
+    if first_receipt["sha256"] != second_receipt["sha256"] {
+        let statuses = |receipt: &serde_json::Value| {
+            receipt["goals"]
+                .as_array()
+                .map(|goals| {
+                    goals
+                        .iter()
+                        .map(|goal| {
+                            (
+                                goal["stable_goal_id"].as_str().unwrap_or("").to_string(),
+                                goal["status"].as_str().unwrap_or("").to_string(),
+                            )
+                        })
+                        .collect::<std::collections::BTreeMap<_, _>>()
+                })
+                .unwrap_or_default()
+        };
+        let (before, after) = (statuses(first_receipt), statuses(second_receipt));
+        let moved: Vec<String> = before
+            .iter()
+            .filter(|(id, status)| after.get(*id).is_some_and(|now| now != *status))
+            .map(|(id, status)| format!("{id}: {status} -> {}", after[id]))
+            .collect();
+        assert!(
+            !moved.iter().any(|m| m.contains("timeout")),
+            "a goal changed status between identical runs and the change involves \
+             a timeout, so this is a prover that reached its budget on a loaded \
+             host rather than a nondeterministic server. Re-run it alone before \
+             reading it as an ordering bug. Moved: {moved:?}"
+        );
+        // Statuses moved with no timeout among them. This is the divergence the
+        // test exists for, and it has to say so: falling through to the message
+        // below would send the reader to the receipt's own fields while the
+        // moved list on screen shows WP concluding something different.
+        assert!(
+            moved.is_empty(),
+            "identical runs disagreed about goal statuses and no timeout is \
+             involved, so this is the nondeterministic server rather than a \
+             loaded host. Moved: {moved:?}"
+        );
+        panic!(
+            "identical runs produced different receipts with every goal status \
+             equal, so the difference is in the receipt's own fields rather than \
+             in what WP concluded. \
+             First: {first_receipt:?} Second: {second_receipt:?}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -9041,14 +9041,38 @@ async fn advice_is_carried_once_per_category_over_the_wire() {
          per-goal figure before reading a ceiling failure as added text."
     );
 
+    // Two-sided on purpose, and the lower bound is the part that matters.
+    //
+    // A one-sided ceiling goes slack on its own. This one was set at 2600
+    // against a measured 2340, sized so the 641-bytes-per-goal round that
+    // caused all this would fail it. Then next_action and suggested_next_tool
+    // stopped being sent twice, the figure fell to 1654, and the ceiling did
+    // not follow: 1654 plus that same 641 is 2295, under 2600, so the gate
+    // quietly stopped catching the regression it exists for. Nothing was wrong
+    // with the payload; the gate had drifted away from it.
+    //
+    // So the baseline is recorded and the payload has to stay near it in both
+    // directions. TOLERANCE is under the regression size, which is what makes
+    // the upper bound bite. A legitimate shrink trips the lower bound, and the
+    // fix is to update BASELINE, which drags the ceiling down with it. That is
+    // the step that did not happen last time.
+    const BASELINE: usize = 1654;
+    const TOLERANCE: usize = 400;
     let per_goal = actual / classified.len();
     assert!(
-        per_goal < 2600,
-        "a classified goal costs {per_goal} bytes, over the 2600 this test \
-         records. Something added text to failure_classification: either hoist \
-         it into the advice block, which is sent once per category, or raise \
-         this ceiling deliberately and say in the commit message what a caller \
-         gets for the extra bytes."
+        per_goal < BASELINE + TOLERANCE,
+        "a classified goal costs {per_goal} bytes against a recorded {BASELINE}. \
+         Something added text to failure_classification: either hoist it into \
+         the advice block, which is sent once per category, or raise BASELINE \
+         deliberately and say in the commit message what a caller gets for the \
+         extra bytes."
+    );
+    assert!(
+        per_goal + TOLERANCE > BASELINE,
+        "a classified goal costs {per_goal} bytes against a recorded {BASELINE}, \
+         so the payload shrank and this gate is now looser than it reads. That \
+         is good news and an edit: set BASELINE to {per_goal} so the ceiling \
+         follows it down and keeps catching an addition of {TOLERANCE} bytes."
     );
 
     let _ = client.cancel().await;

--- a/tests/test-process-lifecycle.rs
+++ b/tests/test-process-lifecycle.rs
@@ -690,6 +690,7 @@ fn tool_registry_count_matches_declared_snapshots() {
             "function",
             "notes",
             "proof_receipt",
+            "proof_receipt_sha256",
             "specs",
             "status",
             "wp_summary",

--- a/tests/unit/frama-c-codec.rs
+++ b/tests/unit/frama-c-codec.rs
@@ -40,6 +40,36 @@ fn decode_frame_invalid_prefix() {
     assert!(result.is_err());
 }
 
+/// An oversized declared length is refused before anything is buffered.
+///
+/// A W frame carries 15 hex digits, so the wire format allows almost 2^60
+/// bytes, and recv_frame reads until the declared payload arrives. Without this
+/// the loop had no exit: a wedged or corrupt server grew the read buffer with
+/// no diagnostic, which a caller sees as a hang rather than a protocol error.
+/// The check has to be on the header, since by the time the payload is short
+/// the process has already allocated for it.
+#[test]
+fn decode_frame_refuses_a_length_it_will_never_honour() {
+    // One byte over the cap, declared in a well-formed W header, with no
+    // payload behind it at all: the refusal must come off the header.
+    let header = format!("W{:015x}", MAX_FRAME_PAYLOAD_BYTES + 1);
+    let error = decode_frame(header.as_bytes())
+        .expect_err("a length over the cap is a protocol error, not a short read");
+    let text = error.to_string();
+    assert!(
+        text.contains("over the") && text.contains(&MAX_FRAME_PAYLOAD_BYTES.to_string()),
+        "the error has to name the limit it enforced: {text}"
+    );
+
+    // And the cap is not so tight that a large legitimate frame trips it. A
+    // whole-AST printDeclaration runs to tens of megabytes.
+    let ok = format!("W{:015x}", 64 * 1024 * 1024);
+    assert!(
+        decode_frame(ok.as_bytes()).unwrap().is_none(),
+        "a 64 MB frame is a short read waiting for its payload, not an error"
+    );
+}
+
 // encode_command
 
 #[test]

--- a/tests/unit/repo-guards.rs
+++ b/tests/unit/repo-guards.rs
@@ -437,6 +437,116 @@ fn no_function_in_src_runs_past_the_length_ceiling() {
 /// Deliberately blind to a declaration inside a string or a comment: those do
 /// not reach an opening brace at their own indentation, so they find no closing
 /// line and are skipped by the caller rather than needing to be excluded here.
+/// Three levels of control flow, and this is what counts them.
+///
+/// CLAUDE.md has stated the rule for a long time and said in the same breath
+/// that it could not be checked, because telling a deep branch from a deep
+/// JSON literal needs a parser rather than a column count. That is true of a
+/// column count and false of this: a level is opened only by a line whose
+/// first token is if, for, while, match or loop and which ends in an opening
+/// brace, so the payload assembly the rule deliberately exempts is invisible
+/// to it. Measured when it was written, 508 lines in src sit at indentation
+/// depth six or more and none of them are branches.
+///
+/// Depth is popped by indentation before it is pushed, which is what makes
+/// "} else if cond {" a continuation rather than a fourth level: it closes the
+/// block it is chained to before opening its own.
+///
+/// It under-reports, on purpose, in the two cases worth naming. A construct
+/// written across several lines, with the brace not on the first of them, is
+/// not counted, and neither is a branch inside a closure passed to something.
+/// Both would need the parser the old note was talking about. What is left
+/// still caught seventeen functions the day it was added.
+///
+/// It reads only line comments, so it would over-report in one direction the
+/// paragraph above does not cover: a branch-shaped line ending in a brace,
+/// written inside a block comment or a multi-line string literal, counts as a
+/// real level and could fail a compliant function. Telling those apart needs
+/// the same parser, and src carries no instance of either, its two "/*" both
+/// sitting inside line comments and its files holding no raw strings. Measured
+/// rather than assumed, and worth re-measuring before that changes.
+#[test]
+fn no_function_in_src_nests_control_flow_past_three() {
+    const LEVELS: usize = 3;
+
+    let mut files = Vec::new();
+    source_files(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+        "rs",
+        &mut files,
+    );
+
+    let mut offenders = Vec::new();
+    for path in files {
+        let Ok(text) = std::fs::read_to_string(&path) else { continue };
+        let mut function = "";
+        let mut open: Vec<usize> = Vec::new();
+        let mut worst = 0usize;
+        let mut worst_line = 0usize;
+        let mut report = |function: &str, worst: usize, worst_line: usize| {
+            if worst > LEVELS && !function.is_empty() {
+                offenders.push(format!(
+                    "{}:{worst_line} {function} nests {worst} deep",
+                    path.display()
+                ));
+            }
+        };
+        for (number, line) in text.lines().enumerate() {
+            if let Some(name) = function_name(line) {
+                report(function, worst, worst_line);
+                function = name;
+                open.clear();
+                worst = 0;
+                worst_line = 0;
+                continue;
+            }
+            let trimmed = line.trim_start();
+            if trimmed.is_empty() || trimmed.starts_with("//") {
+                continue;
+            }
+            let indent = line.len() - trimmed.len();
+            while open.last().is_some_and(|&outer| indent <= outer) {
+                open.pop();
+            }
+            if !opens_a_branch(trimmed) || !line.trim_end().ends_with('{') {
+                continue;
+            }
+            open.push(indent);
+            if open.len() > worst {
+                worst = open.len();
+                worst_line = number + 1;
+            }
+        }
+        report(function, worst, worst_line);
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "control flow nested past {LEVELS} levels:\n{}\n\nA fourth live \
+         branch inside three others is a function doing too much. Extract the \
+         inner work, or invert a condition to return early. Raising LEVELS is \
+         not the fix: the number is the rule.",
+        offenders.join("\n")
+    );
+}
+
+/// Whether a line's first token opens a control-flow block.
+///
+/// The leading brace of "} else if" and "} while" is skipped, so a chained
+/// branch is recognised as the construct it is. "else {" alone opens no new
+/// level: it is the other half of an if that was already counted.
+fn opens_a_branch(trimmed: &str) -> bool {
+    let rest = trimmed.strip_prefix('}').unwrap_or(trimmed).trim_start();
+    let rest = rest.strip_prefix("else ").unwrap_or(rest);
+
+    // The trailing space is what keeps "if_" style identifiers out: a keyword
+    // is only a keyword when something follows it, and "loop {" satisfies that
+    // as much as "loop while_ready" does.
+    ["if ", "for ", "while ", "match ", "loop "]
+        .iter()
+        .any(|keyword| rest.starts_with(keyword))
+}
+
 fn function_name(line: &str) -> Option<&str> {
     let rest = line.trim_start();
     let mut rest = rest

--- a/tests/unit/server.rs
+++ b/tests/unit/server.rs
@@ -37,6 +37,14 @@ fn request_matrix_marks_rejected_request_missing() {
     assert_eq!(status["status"], "missing");
 }
 
+/// Every budget test asserts the same two things: the response fits the cap,
+/// and it reports the size it is actually sent at.
+fn assert_step_payload_fits(payload: &serde_json::Value) {
+    let bytes = serde_json::to_string_pretty(payload).unwrap().len();
+    assert!(bytes <= VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES, "{bytes}");
+    assert_eq!(payload["payload_budget"]["bytes"], bytes);
+}
+
 #[test]
 fn verify_program_step_response_budget_records_sent_size() {
     let payload = finish_verify_program_step_response(json!({
@@ -66,13 +74,90 @@ fn verify_program_step_response_budget_records_sent_size() {
         "project_state_persisted": {"stored": true},
         "next_action": {"tool": "create_sandbox", "args": {"function": "f0"}}
     }));
-    let bytes = serde_json::to_string_pretty(&payload).unwrap().len();
-    assert!(bytes <= VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES, "{bytes}");
+    assert_step_payload_fits(&payload);
     assert!(payload["ready_functions"].as_array().unwrap().len() <= 1);
     assert!(payload["ready_functions_omitted"].as_u64().unwrap() >= 999);
     assert!(payload["frontier"].as_array().unwrap().len() <= 1);
     assert!(payload["frontier_omitted"].as_u64().unwrap() >= 999);
     assert_eq!(payload["next_action"]["tool"], "create_sandbox");
+}
+
+#[test]
+fn verify_program_step_response_budget_drops_an_oversized_preview() {
+    let oversized_function = "f".repeat(VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES);
+    let payload = finish_verify_program_step_response(json!({
+        "frontier": [],
+        "frontier_omitted": 0,
+        "ready_functions": [{"function": oversized_function}],
+        "ready_functions_omitted": 0,
+        "next_action": {"tool": "create_sandbox", "args": {"function": oversized_function}},
+    }));
+    assert_step_payload_fits(&payload);
+    // Not the constant-size fallback: this response still carries its fields.
+    assert!(payload.get("status").is_none());
+    assert!(payload["ready_functions"].as_array().unwrap().is_empty());
+    assert_eq!(payload["ready_functions_omitted"], 1);
+    assert_eq!(payload["next_action"]["tool"], serde_json::Value::Null);
+    assert!(payload["next_action"]["args"].get("function").is_none());
+    assert_eq!(payload["next_action"]["blockers"][0], "oversized_function_name");
+}
+
+#[test]
+fn verify_program_step_response_budget_keeps_an_omitted_count_with_no_rows_left() {
+    // The caller can hand over a count with an empty preview. Charging a
+    // retained row here would report one fewer function than went missing.
+    // ready_functions is what puts this over the cap, so the truncation stage
+    // runs and reaches an already empty frontier on its way past.
+    let payload = finish_verify_program_step_response(json!({
+        "frontier": [],
+        "frontier_omitted": 5,
+        "ready_functions": (0..1000).map(|i| json!({"function": format!("f{i}")})).collect::<Vec<_>>(),
+        "ready_functions_omitted": 0,
+        "next_action": {"tool": "create_sandbox", "args": {"function": "f0"}},
+    }));
+    assert_step_payload_fits(&payload);
+    assert!(payload["frontier"].as_array().unwrap().is_empty());
+    assert_eq!(payload["frontier_omitted"], 5);
+}
+
+#[test]
+fn verify_program_step_response_budget_trims_the_blocked_list_in_next_action() {
+    let blocked = (0..2000).map(|i| format!("blocked_function_{i}")).collect::<Vec<_>>();
+    let payload = finish_verify_program_step_response(json!({
+        "frontier": [],
+        "frontier_omitted": 0,
+        "ready_functions": [],
+        "ready_functions_omitted": 0,
+        "next_action": {
+            "tool": "verify_program_step",
+            "args": {},
+            "blockers": ["blocked_functions"],
+            "blocked_functions": blocked,
+        },
+    }));
+    assert_step_payload_fits(&payload);
+    assert!(payload.get("status").is_none());
+    // The action stays callable; only its list is replaced by a count.
+    assert_eq!(payload["next_action"]["tool"], "verify_program_step");
+    assert!(payload["next_action"]["blocked_functions"].as_array().unwrap().is_empty());
+    assert_eq!(payload["next_action"]["blocked_functions_omitted"], 2000);
+}
+
+#[test]
+fn verify_program_step_response_budget_falls_back_when_nothing_else_can_go() {
+    // project_state_persisted is not one of the fields any stage can drop.
+    let payload = finish_verify_program_step_response(json!({
+        "frontier": [],
+        "frontier_omitted": 0,
+        "ready_functions": [],
+        "ready_functions_omitted": 0,
+        "project_state_persisted": {"error": "e".repeat(VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES)},
+        "next_action": {"tool": "verify_program_step", "args": {}},
+    }));
+    assert_step_payload_fits(&payload);
+    assert_eq!(payload["status"], "payload_truncated");
+    // Nothing to call again: repeating the step returns this same answer.
+    assert_eq!(payload["next_action"]["tool"], serde_json::Value::Null);
 }
 
 #[test]

--- a/tests/unit/state.rs
+++ b/tests/unit/state.rs
@@ -432,9 +432,14 @@ fn invalidate_all_preserves_conclusions() {
 #[test]
 fn remembered_receipts_are_bounded_deduped_and_dropped_on_reload() {
     let mut state = SessionState::default();
-    let goals = |id: &str| vec![serde_json::json!({"stable_goal_id": id, "status": "valid"})];
+    let receipt = |id: &str| {
+        serde_json::json!({
+            "schema": "frama-c-mcp.proof-receipt",
+            "goals": [{"stable_goal_id": id, "status": "valid"}],
+        })
+    };
 
-    state.remember_receipt_goals("sha-a", &goals("g1"));
+    state.remember_receipt("sha-a", receipt("g1"));
     assert_eq!(
         state.receipt_goals("sha-a").map(<[_]>::len),
         Some(1),
@@ -442,9 +447,10 @@ fn remembered_receipts_are_bounded_deduped_and_dropped_on_reload() {
     );
     assert_eq!(state.receipt_goals("sha-missing"), None);
 
-    // Re-recording the same hash keeps the first goals rather than appending a
-    // second entry under the same name.
-    state.remember_receipt_goals("sha-a", &goals("different"));
+    // Re-recording the same hash keeps the first body rather than appending a
+    // second entry under the same name. Two receipts hashing alike are
+    // byte-identical anyway, so there is nothing to choose between them.
+    state.remember_receipt("sha-a", receipt("different"));
     assert_eq!(
         state.receipt_goals("sha-a").and_then(|goals| goals
             .first()
@@ -455,7 +461,7 @@ fn remembered_receipts_are_bounded_deduped_and_dropped_on_reload() {
     // Oldest out first once the bound is reached, so a long session cannot grow
     // without limit.
     for i in 0..40 {
-        state.remember_receipt_goals(&format!("sha-{i}"), &goals("g"));
+        state.remember_receipt(&format!("sha-{i}"), receipt("g"));
     }
     assert_eq!(state.receipt_goals("sha-a"), None, "evicted with the oldest");
     assert!(state.receipt_goals("sha-39").is_some(), "newest kept");

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -267,14 +267,14 @@ fn splitting_a_classification_keeps_the_goal_half_small() {
         "the E-ACSL advice is identical everywhere and belongs in the shared half"
     );
     assert!(
-        per_goal["suggested_next_tool"]
+        per_goal["next_action"]
             .get("runtime_check_suggestion")
             .is_none(),
         "and its copy nested inside next_action goes with it"
     );
 
     // What the stdio suite reads per goal stays per goal.
-    assert!(per_goal["suggested_next_tool"]["tool"].as_str().is_some());
+    assert!(per_goal["next_action"]["tool"].as_str().is_some());
     assert!(
         per_goal["wp_timeout_triage"]["retry_with_higher_prover_timeout"]
             .as_bool()
@@ -283,7 +283,7 @@ fn splitting_a_classification_keeps_the_goal_half_small() {
 
     // Measured rather than aspired to: 2015 bytes against 5706 on this goal, so
     // a little over a third. The rest is what the shared half now carries once.
-    // A tighter ratio is not available without moving suggested_next_tool or
+    // A tighter ratio is not available without moving next_action or
     // wp_timeout_triage, and the stdio suite reads both per goal.
     let goal_bytes = serde_json::to_string(&per_goal).unwrap().len();
     let whole_bytes = serde_json::to_string(&classification).unwrap().len();
@@ -1234,8 +1234,8 @@ fn classify_wp_failure_unknown_fallback() {
     assert_eq!(classification["category"], "prover_unknown");
     assert_eq!(classification["failure_kind"], "proof_obligation");
     assert!(!classification["evidence"].as_array().unwrap().is_empty());
-    assert_eq!(classification["suggested_next_tool"]["tool"], "get_wp_goals");
-    assert_eq!(classification["suggested_next_tool"]["args"]["want"], serde_json::json!(["vc"]));
+    assert_eq!(classification["next_action"]["tool"], "get_wp_goals");
+    assert_eq!(classification["next_action"]["args"]["want"], serde_json::json!(["vc"]));
     assert_eq!(classification["semantic_verdict"]["kind"], "specification_too_weak");
     assert!(classification["semantic_verdict"]["plain_language"]
         .as_str()

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -215,6 +215,103 @@ fn remembering_goals_first_then_body_keeps_both() {
     assert_eq!(state.receipt_body("abc123"), Some(&receipt));
 }
 
+/// Advice is a function of category and goal kind, so it belongs once per pair
+/// and not once per goal. This is the property that keeps a legitimately-stuck
+/// function readable: measured before the split, 21 unproved goals carried
+/// 106 KB of duplicated advice between them and shared two categories.
+#[test]
+fn splitting_a_classification_keeps_the_goal_half_small() {
+    let classification = classify_wp_failure_from_goal(
+        &json!({
+            "name": "mem_access",
+            "goal_kind": "rte_mem_access",
+            "normalized_status": "timeout",
+            "source_location": {"file": "src.c", "line": 40, "column": 8}
+        }),
+        Some("collect"),
+    );
+    let (per_goal, key, advice) = split_goal_classification(&classification);
+
+    // The verdict stays on the goal: callers key on it, the stdio suite
+    // included.
+    assert_eq!(per_goal["category"], "timeout");
+    assert_eq!(per_goal["goal_kind"], "rte_mem_access");
+    assert!(per_goal["evidence"].is_array());
+    assert_eq!(per_goal["advice_key"], key);
+
+    // The rendered one-finding report does not: its fields are already on the
+    // goal and the rest is a markdown rendering of them. Nor does the E-ACSL
+    // advice, which appeared three times in one goal before this.
+    assert!(
+        per_goal.get("proofread_report").is_none(),
+        "the per-goal half must not carry the report: {per_goal}"
+    );
+    assert!(
+        per_goal.get("runtime_check_suggestion").is_none(),
+        "the E-ACSL advice is identical everywhere and belongs in the shared half"
+    );
+    assert!(
+        per_goal["suggested_next_tool"]
+            .get("runtime_check_suggestion")
+            .is_none(),
+        "and its copy nested inside next_action goes with it"
+    );
+
+    // What the stdio suite reads per goal stays per goal.
+    assert!(per_goal["suggested_next_tool"]["tool"].as_str().is_some());
+    assert!(
+        per_goal["wp_timeout_triage"]["retry_with_higher_prover_timeout"]
+            .as_bool()
+            .is_some()
+    );
+
+    // Measured rather than aspired to: 2015 bytes against 5706 on this goal, so
+    // a little over a third. The rest is what the shared half now carries once.
+    // A tighter ratio is not available without moving suggested_next_tool or
+    // wp_timeout_triage, and the stdio suite reads both per goal.
+    let goal_bytes = serde_json::to_string(&per_goal).unwrap().len();
+    let whole_bytes = serde_json::to_string(&classification).unwrap().len();
+    assert!(
+        goal_bytes * 2 < whole_bytes,
+        "the per-goal half should be well under half the whole: {goal_bytes} \
+         against {whole_bytes}. A bare goal_bytes < whole_bytes would hold by \
+         construction, since the per-goal half is the whole with keys removed, \
+         so the factor is what makes this an assertion. If it trips, read the \
+         two numbers before changing it: a per-goal half that grew is the \
+         regression this guards, while a shared half that shrank means the \
+         split has stopped paying and the factor is what should move."
+    );
+
+    // The advice keeps what a caller acts on.
+    assert!(advice["suggested_fix"]
+        .as_str()
+        .is_some_and(|s| !s.is_empty()));
+    assert!(advice["why_problem"]
+        .as_str()
+        .is_some_and(|s| !s.is_empty()));
+}
+
+/// Two goals of one category and kind share an advice key, and two of
+/// different kinds do not: a timed-out rte obligation and a timed-out
+/// postcondition are told different things.
+#[test]
+fn advice_key_groups_by_category_and_kind() {
+    let of = |kind: &str| {
+        let c = classify_wp_failure_from_goal(
+            &json!({
+                "name": "g",
+                "goal_kind": kind,
+                "normalized_status": "timeout",
+                "source_location": {"file": "src.c", "line": 1, "column": 1}
+            }),
+            Some("f"),
+        );
+        split_goal_classification(&c).1
+    };
+    assert_eq!(of("rte_mem_access"), of("rte_mem_access"));
+    assert_ne!(of("rte_mem_access"), of("ensures"));
+}
+
 #[test]
 fn proofread_report_sorts_by_severity_then_file_line() {
     let report = proofread_report(vec![
@@ -1840,4 +1937,94 @@ fn ast_digest_separates_runs_that_goal_counts_cannot() {
     let unknown_b = build(serde_json::Value::Null);
     assert!(unknown_a["subject"]["ast_digest"].is_null());
     assert_ne!(unknown_a["sha256"], unknown_b["sha256"]);
+}
+
+/// An open runtime-error check has to name the tool that says which check it
+/// is. The goal name does not: mem_access_7 counts siblings generated from one
+/// statement, so a function holding several open checks on one line is
+/// indistinguishable from the goal list alone, and the next step without this
+/// pointer is to guess an invariant and re-prove, which costs a run per guess
+/// and does not converge.
+#[test]
+fn rte_finding_points_at_the_obligation_reader() {
+    let classification = classify_wp_failure_from_goal(
+        &json!({
+            "name": "mem_access",
+            "goal_kind": "rte_mem_access",
+            "normalized_status": "unknown",
+            "source_location": {"file": "src.c", "line": 40, "column": 8}
+        }),
+        Some("collect"),
+    );
+    let finding = &classification["proofread_report"]["findings"][0];
+    assert_eq!(finding["category"], "rte");
+
+    // The predicate is on the goal already: measured, 21 of 21 goals from
+    // get_wp_goals carried one. Guidance that sends a caller elsewhere to find
+    // it is wrong about its own payload, which is what the first version of
+    // this advice got wrong.
+    let fix = finding["suggested_fix"].as_str().unwrap();
+    assert!(
+        fix.contains("predicate"),
+        "rte guidance must point at the goal's own predicate: {fix}"
+    );
+    assert!(
+        !fix.contains("returns the open predicate"),
+        "rte_obligations must not be described as the way to see the predicate: {fix}"
+    );
+    let why = finding["why_problem"].as_str().unwrap();
+    assert!(
+        why.contains("predicate"),
+        "the short form must say so too, since a caller may render only that: {why}"
+    );
+}
+
+/// A runtime-error check that times out is classified as a timeout, not as an
+/// rte, so it would otherwise get only the generic "retry, then read the VC".
+/// That is the shape most likely to strand a caller: retried at six times the
+/// budget it does not move, and the goal name alone cannot say which access is
+/// open, so the next thing tried is a guessed invariant.
+#[test]
+fn timed_out_rte_goal_still_names_the_obligation_reader() {
+    let classification = classify_wp_failure_from_goal(
+        &json!({
+            "name": "mem_access",
+            "goal_kind": "rte_mem_access",
+            "normalized_status": "timeout",
+            "source_location": {"file": "src.c", "line": 40, "column": 8}
+        }),
+        Some("collect"),
+    );
+    let finding = &classification["proofread_report"]["findings"][0];
+    assert_eq!(finding["category"], "timeout");
+
+    let fix = finding["suggested_fix"].as_str().unwrap();
+    assert!(
+        fix.contains("retry_unproved"),
+        "the retry-first instruction must survive: {fix}"
+    );
+    assert!(
+        fix.contains("predicate"),
+        "a timed-out rte goal must still say where the predicate is: {fix}"
+    );
+}
+
+/// The non-rte timeout keeps the generic wording: there is no obligation
+/// reader for a postcondition, so pointing at one would be wrong.
+#[test]
+fn timed_out_non_rte_goal_keeps_the_generic_advice() {
+    let classification = classify_wp_failure_from_goal(
+        &json!({
+            "name": "post_condition",
+            "goal_kind": "ensures",
+            "normalized_status": "timeout",
+            "source_location": {"file": "src.c", "line": 7, "column": 1}
+        }),
+        Some("f"),
+    );
+    let fix = classification["proofread_report"]["findings"][0]["suggested_fix"]
+        .as_str()
+        .unwrap();
+    assert!(fix.contains("retry_unproved"));
+    assert!(!fix.contains("rte_obligations"));
 }

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -328,6 +328,67 @@ fn advice_key_groups_by_category_and_kind() {
     assert_ne!(of("rte_mem_access"), of("ensures"));
 }
 
+/// A classification quoted on its own has to bring its advice with it.
+///
+/// The split sends each advice once, on the first classified goal of its key,
+/// which is right for an array read whole and wrong for a single goal lifted
+/// out of one. check embeds exactly one: recommended_next_call.classification
+/// is the first non-valid goal, which is the carrier only by luck. Before this
+/// resolved the key, that field was status plumbing with no why_problem, no
+/// suggested_fix and no semantic_verdict, and nothing asserted its contents.
+#[test]
+fn a_quoted_classification_resolves_its_advice_key() {
+    use frama_c_mcp::mcp::server::analysis::classification_with_advice;
+
+    let classify = |kind: &str| {
+        classify_wp_failure_from_goal(
+            &json!({
+                "name": "mem_access",
+                "goal_kind": kind,
+                "normalized_status": "timeout",
+                "source_location": {"file": "src.c", "line": 40, "column": 8}
+            }),
+            Some("collect"),
+        )
+    };
+    let (carrier_half, key, advice) = split_goal_classification(&classify("rte_mem_access"));
+    let (follower_half, follower_key, _) = split_goal_classification(&classify("rte_mem_access"));
+    assert_eq!(key, follower_key, "the fixture needs both goals on one key");
+
+    let mut carrier_half = carrier_half;
+    carrier_half
+        .as_object_mut()
+        .unwrap()
+        .insert("advice".to_string(), advice.clone());
+    let goals = vec![
+        json!({"stable_goal_id": "sg-carrier", "failure_classification": carrier_half}),
+        json!({"stable_goal_id": "sg-follower", "failure_classification": follower_half}),
+    ];
+
+    // The follower is the one check would quote, and it holds no advice.
+    assert!(
+        goals[1]["failure_classification"].get("advice").is_none(),
+        "the fixture is pointless unless the second goal is a follower"
+    );
+    let resolved = classification_with_advice(&goals[1], &goals);
+    assert_eq!(
+        resolved["advice"], advice,
+        "a follower's key must resolve to its carrier's advice: {resolved}"
+    );
+    assert!(resolved["advice"]["suggested_fix"]
+        .as_str()
+        .is_some_and(|fix| !fix.is_empty()));
+
+    // The carrier is returned untouched rather than given a second copy.
+    assert_eq!(classification_with_advice(&goals[0], &goals)["advice"], advice);
+
+    // A key no sibling carries leaves the classification as it was, rather than
+    // inventing an empty advice block.
+    let orphan = json!({"failure_classification": {"advice_key": "timeout:nothing"}});
+    let resolved = classification_with_advice(&orphan, &goals);
+    assert!(resolved.get("advice").is_none(), "{resolved}");
+}
+
 #[test]
 fn proofread_report_sorts_by_severity_then_file_line() {
     let report = proofread_report(vec![

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -180,39 +180,55 @@ fn classify_wp_failure_includes_proofread_report_shape() {
 /// the object cannot practically be echoed back by an MCP client: one
 /// function's receipt is 8 KB whose bulk is the goal array, and a single slip
 /// is rejected with no indication of which field moved. The session therefore
-/// keeps the body next to the goals, and the hash resolves to it.
+/// keeps the body, and the hash resolves to it.
 #[test]
 fn session_remembers_receipt_body_for_lookup_by_hash() {
     use frama_c_mcp::state::SessionState;
 
     let mut state = SessionState::default();
-    let goals = vec![json!({"stable_goal_id": "sg_1", "status": "valid"})];
-    let receipt = json!({"schema": "frama-c-mcp.proof-receipt", "sha256": "abc123"});
+    let receipt = json!({
+        "schema": "frama-c-mcp.proof-receipt",
+        "sha256": "abc123",
+        "goals": [{"stable_goal_id": "sg_1", "status": "valid"}],
+    });
 
-    state.remember_receipt("abc123", &goals, receipt.clone());
+    state.remember_receipt("abc123", receipt.clone());
 
     assert_eq!(state.receipt_body("abc123"), Some(&receipt));
-    assert_eq!(state.receipt_goals("abc123").map(<[_]>::len), Some(1));
     assert!(
         state.receipt_body("never-produced").is_none(),
         "an unknown hash must not resolve: it is an error, not an empty receipt"
     );
 }
 
-/// The goals-only writer stays usable, and a later call that does know the body
-/// fills it in rather than being dropped as a duplicate.
+/// The goals a run is diffed against come out of the stored body rather than a
+/// second copy beside it, so a since diff is against the array the hash was
+/// computed over and the two cannot drift apart.
 #[test]
-fn remembering_goals_first_then_body_keeps_both() {
+fn remembered_goals_are_read_out_of_the_stored_body() {
     use frama_c_mcp::state::SessionState;
 
     let mut state = SessionState::default();
-    let goals = vec![json!({"stable_goal_id": "sg_1", "status": "valid"})];
-    state.remember_receipt_goals("abc123", &goals);
-    assert!(state.receipt_body("abc123").is_none());
+    state.remember_receipt(
+        "abc123",
+        json!({
+            "schema": "frama-c-mcp.proof-receipt",
+            "goals": [{"stable_goal_id": "sg_1", "status": "valid"}],
+        }),
+    );
+    assert_eq!(state.receipt_goals("abc123").map(<[_]>::len), Some(1));
+    assert_eq!(
+        state
+            .receipt_goals("abc123")
+            .and_then(|goals| goals[0]["stable_goal_id"].as_str()),
+        Some("sg_1")
+    );
 
-    let receipt = json!({"schema": "frama-c-mcp.proof-receipt", "sha256": "abc123"});
-    state.remember_receipt("abc123", &goals, receipt.clone());
-    assert_eq!(state.receipt_body("abc123"), Some(&receipt));
+    // A body with no goal array resolves as a body and not as goals, rather
+    // than as an empty diff.
+    state.remember_receipt("def456", json!({"schema": "frama-c-mcp.proof-receipt"}));
+    assert!(state.receipt_body("def456").is_some());
+    assert_eq!(state.receipt_goals("def456"), None);
 }
 
 /// Advice is a function of category and goal kind, so it belongs once per pair

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -176,6 +176,45 @@ fn classify_wp_failure_includes_proofread_report_shape() {
     assert_eq!(finding["clause_or_goal_kind"], "rte_division");
 }
 
+/// A receipt is accepted only when its bytes hash to what the server wrote, so
+/// the object cannot practically be echoed back by an MCP client: one
+/// function's receipt is 8 KB whose bulk is the goal array, and a single slip
+/// is rejected with no indication of which field moved. The session therefore
+/// keeps the body next to the goals, and the hash resolves to it.
+#[test]
+fn session_remembers_receipt_body_for_lookup_by_hash() {
+    use frama_c_mcp::state::SessionState;
+
+    let mut state = SessionState::default();
+    let goals = vec![json!({"stable_goal_id": "sg_1", "status": "valid"})];
+    let receipt = json!({"schema": "frama-c-mcp.proof-receipt", "sha256": "abc123"});
+
+    state.remember_receipt("abc123", &goals, receipt.clone());
+
+    assert_eq!(state.receipt_body("abc123"), Some(&receipt));
+    assert_eq!(state.receipt_goals("abc123").map(<[_]>::len), Some(1));
+    assert!(
+        state.receipt_body("never-produced").is_none(),
+        "an unknown hash must not resolve: it is an error, not an empty receipt"
+    );
+}
+
+/// The goals-only writer stays usable, and a later call that does know the body
+/// fills it in rather than being dropped as a duplicate.
+#[test]
+fn remembering_goals_first_then_body_keeps_both() {
+    use frama_c_mcp::state::SessionState;
+
+    let mut state = SessionState::default();
+    let goals = vec![json!({"stable_goal_id": "sg_1", "status": "valid"})];
+    state.remember_receipt_goals("abc123", &goals);
+    assert!(state.receipt_body("abc123").is_none());
+
+    let receipt = json!({"schema": "frama-c-mcp.proof-receipt", "sha256": "abc123"});
+    state.remember_receipt("abc123", &goals, receipt.clone());
+    assert_eq!(state.receipt_body("abc123"), Some(&receipt));
+}
+
 #[test]
 fn proofread_report_sorts_by_severity_then_file_line() {
     let report = proofread_report(vec![


### PR DESCRIPTION
Eleven commits, each one functional change, on top of `main`.

The through-line is agent-facing payloads: making them smaller, making the
references inside them resolvable, and making the gates that bound them
able to fail.

## Resolvable references

`store_function_conclusion` now accepts a receipt by its
`proof_receipt_sha256` rather than only as an echoed object. The coherence
check is exactly as strong, since the bytes checked are still the ones this
process produced; what goes away is asking a client to transcribe kilobytes
through its own context.

A stuck goal's advice is sent once per category instead of once per goal.
Measured on a function whose goals were all unproved: 21 goals, 147 KB, of
which the repeated advice was 106 KB against 1.7 KB of the fields a caller
actually triages from.

That split shipped with a bug no gate could see. The advice carrier was
elected by smallest `stable_goal_id`, a digest with no relation to array
position, while `check` truncates the same array by keeping the first few
goals needing classification. A shown goal therefore routinely named a
carrier among the omitted entries, so its advice was in no part of the
reply. The carrier is now the first classified goal of its key, which makes
the election and the truncation agree by construction.

## Smaller payloads

A goal's classification carried the same object under both `next_action` and
`suggested_next_tool`, byte-identical, over 6 KB of a 37 KB sixteen-goal
reply. One name survives.

`verify_program_step` held its 16 KiB budget by replacing the whole
`next_action` on any overflow, on the premise that the oversized value was a
function name. It is normally the blocked-function list inside that action,
so the enforcer destroyed the answer to protect a diagnostic list, printed a
false reason, and told the caller to repeat a deterministic call. The list is
previewed where it is built now, arguments are never shed, and the terminal
states answer with a null tool instead of a livelock.

## Gates that can fail

The per-goal payload ceiling was one-sided and had gone slack: the payload
shrank away from it, so it no longer caught the regression it exists for. It
is two-sided against a recorded baseline now, checked in both directions.

`two_identical_runs_produce_one_receipt` had one message for two causes, real
nondeterminism and a loaded host whose prover hit its budget in one run only.
It names which one happened.

The nesting rule in CLAUDE.md was asserted for a long time and measured by
nothing. It is enforced now, and the sixteen functions it found over the
limit are flattened.

The rte guidance claimed every goal carries a `predicate`. It does not: 2 of
79 goals on `test_comprehensive.c`. The guard protecting the claim asserted
emptiness on a fixture where it happened to hold, so it pinned the fixture
rather than the claim. It asserts a ratio and prints coverage.

## Robustness

A `W` frame declares its length in fifteen hex digits and `recv_frame` read
until the declared payload arrived, so a wedged Frama-C grew the read buffer
without bound or diagnostic. There is a 256 MB cap off the header now, and a
decode error poisons the transport, without which every later call returned
the same error while `is_poisoned` answered healthy and no respawn fired.

`seen_receipts` held each goal array twice, beside the body and inside it,
with room to disagree. The goals are read out of the stored body, so a
`since` diff runs against the array the hash was computed over.

## Verification

`scripts/run-gates.sh`: 16/16 on the tip, `rc=0` on every gate. Unit 421,
stdio 107, lifecycle 37, integration 12, reload 10, store 11, poison 2, plus
the tutorial corpus, both fixture scripts, the OCaml plug-in regressions,
clippy, shfmt and the artifact scan.

Every commit was also checked out in isolation and independently builds,
passes clippy and passes the unit suite, with test counts growing
monotonically so no commit borrows a test from a later one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrinks agent-facing payloads and fixes the gates that bound them, so replies are smaller and the references inside them always resolve.

**Bug Fixes**
- `store_function_conclusion` now accepts a receipt by `proof_receipt_sha256`, so callers don't echo kilobytes through their context.
- Stuck-goal advice is sent once per category, with the carrier chosen by position so `advice_key` always resolves in the reply.
- `verify_program_step` no longer sheds `next_action.args` or replaces the whole action with a false reason; it previews the blocked list and returns a null tool when nothing fits.
- A decode error now poisons the transport and oversized frames are refused, so a wedged Frama-C can't grow the read buffer without bound.
- Receipt goals are stored once inside the body, so `since` diffs run against the array the hash was computed over.
- The rte guidance no longer claims every goal carries a `predicate`; `rte_obligations` is named as the fallback, and the guard asserts a coverage ratio instead of pinning a fixture.
- The `two_identical_runs_produce_one_receipt` mismatch now blames a prover budget timeout on a loaded host rather than on nondeterminism.

**Refactors**
- Removed the duplicate `suggested_next_tool` field; `next_action` is the only name.
- Made the per-goal payload ceiling two-sided against a baseline so it can't go slack.
- Enforced the three-level control-flow limit and flattened the sixteen functions that exceeded it.

<sup>Written for commit 57cd0cbd184151ed534dea9bd1145b8943f62dd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/frama-c-mcp/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

