### PR TITLE
Withhold WP timeout verdict the run didn't measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,13 @@ The server holds one project: `reload_project` or the first `check` loads it,
 and later calls operate on that AST. Sandboxes are separate processes,
 addressed as `experiment_id:function`.
 
-The preprocessor surface is `include_paths`, `defines`, `force_includes`, and
-`machdep`, applied in that order. Each value is written without its compiler
-flag.
+The preprocessor surface is `nostdinc`, `include_paths`, `isystem_paths`,
+`defines`, `force_includes`, and `machdep`, applied in that order. Each value is
+written without its compiler flag. `nostdinc` drops the preprocessor's default
+system directories and `isystem_paths` are searched after `include_paths`; pair
+them to put a modeled libc where the real system headers would otherwise be
+found. Both are part of the load identity a proof receipt is hashed over,
+because they decide which declarations a file is compiled against.
 
 ## Quick start
 
@@ -365,12 +369,16 @@ reparse. A malformed set is refused before anything is replaced; a set that
 parses is registered even if the load that follows it fails.
 
 A profile that is only used to load may carry `sources`, `machdep`,
-`include_paths`, `defines`, `force_includes` and `reproduce`. One you intend to
-prove under additionally needs `functions`, `model`, `provers` and
-`timeout_seconds`, and a run naming it is refused unless all four are there:
-without the proof settings it would fall back to this server's defaults and
-report the target's name over them, and without a function set there is nothing
-for the coverage check to compare against. Emit the JSON from the build system that defines the targets
+`include_paths`, `isystem_paths`, `nostdinc`, `defines`, `force_includes` and
+`reproduce`. One you intend to prove under additionally needs `functions`,
+`model`, `provers`, `timeout_seconds`, `rte` and `nostdinc`, and a run naming it
+is refused unless all six are there: without the proof settings it would fall
+back to this server's defaults and report the target's name over them, without a
+function set there is nothing for the coverage check to compare against, and
+`rte` and `nostdinc` each decide which obligations exist at all, so a run
+missing either discharges a different set than the target's own command does.
+A profile written before those two were required still loads; it is refused only
+where it would have become evidence, and stating them restores it. Emit the JSON from the build system that defines the targets
 rather than writing it by hand, so it cannot drift from the command that
 decides. An unknown key is refused rather than ignored. A profile
 whose model key is misspelled as `models` would otherwise register with no
@@ -384,9 +392,10 @@ refused rather than allowed to win. A run labelled as a target's evidence has
 to be the target's settings, and letting an override through produced exactly
 the mislabelling profiles exist to prevent: proving under one model while the
 response named another. Omit `verify_profile` to deviate on purpose.
-Evidence profiles must declare all three proof settings: `model`, non-empty
-`provers`, and `timeout_seconds`; an incomplete profile may be registered for
-loading, but cannot label a proof result. Sandboxes are likewise excluded:
+Evidence profiles must declare all five settings that decide what gets proved
+and over what: `model`, non-empty `provers`, `timeout_seconds`, `rte` and
+`nostdinc`; an incomplete profile may be registered for loading, but cannot
+label a proof result. Sandboxes are likewise excluded:
 their generated source is not the registered build target.
 
 The load settings behave the same way by a different route. `reload_project`
@@ -399,8 +408,8 @@ target's evidence either.
 accelerator: goals discharging here are progress, and the project's own command
 is the verdict.
 
-`reload_project {include_paths, defines, force_includes}` become preprocessor
-flags, and Frama-C hands those to a shell (its `-cpp-extra-args` is "unsafe in
+`reload_project {include_paths, isystem_paths, defines, force_includes}` become
+preprocessor flags, and Frama-C hands those to a shell (its `-cpp-extra-args` is "unsafe in
 sandbox mode"). Each entry is therefore restricted to `[A-Za-z0-9_./+-]`, plus
 `=` for defines, with no leading dash, so a value cannot carry a command
 substitution or the `${IFS}` space trick into that shell. A define needing a

--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ payload contract and the change rule. The full set:
 | `GOAL_NOT_VALID` | WP has a non-valid goal |
 | `PROVER_TIMEOUT` | A prover timed out on a goal |
 | `PROPERTY_DEAD` | EVA proved the code unreachable, so nothing proved about it constrains a run |
+| `PROPERTY_VACUOUS` | Frama-C discharged the property only under a hypothesis that cannot hold, so the proof holds over no execution |
 | `PROPERTY_DISPROVED` | Frama-C disproved a property and WP emits no goal for one that already has a status |
 | `PROPERTY_INCONSISTENT` | Frama-C consolidated contradictory statuses, so the verdict cannot be trusted |
 | `LEMMA_NOT_PROVED` | WP assumed a lemma everywhere without discharging it |

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -347,8 +347,11 @@ records what was proved and not what it settles. It is refused on the same
 grounds a run is: the profile must declare `model`, `provers`,
 `timeout_seconds`, `rte` and `nostdinc`, it must prove this function, and the
 receipt must have been produced under that model and over those sources. The
-last two are there because each decides which obligations exist, so a receipt
-made without them covers a smaller set than the target's own command does. Because the tool is
+last two are there for different reasons. `rte` decides whether runtime-error
+obligations exist at all, so a receipt made without it covers a strictly
+smaller set than the target's own command does. `nostdinc` decides which
+declarations the file is compiled against, so a receipt made without it is
+about a different program rather than a smaller part of the same one. Because the tool is
 incremental, the comparison is against the conclusion as it will stand, so a
 later call that replaces the receipt is rechecked against the name already
 stored.

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -35,7 +35,7 @@ When several files fail that way, ask what the ceiling is before working
 around it one file at a time:
 
 ```text
-parse_surface {files, include_paths?, defines?, force_includes?, machdep?, detail?}
+parse_surface {files, include_paths?, isystem_paths?, nostdinc?, defines?, force_includes?, machdep?, detail?}
 ```
 
 It reports how many of a set parse and ranks what blocks the rest, with
@@ -344,9 +344,11 @@ not evidence about the one it is filed under.
 `store_function_conclusion {verify_profile}` is what carries the target into
 the stored verdict, along with the `reproduce` command. Without it a conclusion
 records what was proved and not what it settles. It is refused on the same
-grounds a run is: the profile must declare `model`, `provers` and
-`timeout_seconds`, it must prove this function, and the receipt must have been
-produced under that model and over those sources. Because the tool is
+grounds a run is: the profile must declare `model`, `provers`,
+`timeout_seconds`, `rte` and `nostdinc`, it must prove this function, and the
+receipt must have been produced under that model and over those sources. The
+last two are there because each decides which obligations exist, so a receipt
+made without them covers a smaller set than the target's own command does. Because the tool is
 incremental, the comparison is against the conclusion as it will stand, so a
 later call that replaces the receipt is rechecked against the name already
 stored.

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -2,6 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use super::*;
 
+// The gap machinery, which used to be 900 lines of this file.
+use super::checkgaps::*;
+
 pub const VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES: usize = 16 * 1024;
 
 /// What check_proof_receipt needs from the check it is describing.
@@ -386,7 +389,7 @@ fn check_step_error(error: &McpError) -> serde_json::Value {
     })
 }
 
-fn check_step_failed(value: &serde_json::Value) -> bool {
+pub(crate) fn check_step_failed(value: &serde_json::Value) -> bool {
     value.is_null()
         || value
         .get("ok")
@@ -464,7 +467,7 @@ pub fn render_sequent(raw_vc_text: &serde_json::Value) -> String {
 /// The normalized status of a property row, which is what has to be judged
 /// rather than the raw `status`: EVA spells never-tried `never_tried` while the
 /// rest of the server spells it `noresult`.
-fn property_normalized_status(property: &serde_json::Value) -> &str {
+pub(crate) fn property_normalized_status(property: &serde_json::Value) -> &str {
     own_status(property).unwrap_or_default()
 }
 
@@ -543,7 +546,7 @@ pub fn goal_is_valid_under_hypotheses(goal: &serde_json::Value) -> bool {
 /// undischarged alarm. A dead property is excluded here and reported as
 /// `PROPERTY_DEAD` instead, since unreachable code is a different finding from
 /// a runtime error.
-fn alarm_is_undischarged(alarm: &serde_json::Value) -> bool {
+pub(crate) fn alarm_is_undischarged(alarm: &serde_json::Value) -> bool {
     is_generated_alarm(alarm)
         && !property_is_dead(alarm)
         && matches!(
@@ -571,7 +574,7 @@ fn alarm_is_undischarged(alarm: &serde_json::Value) -> bool {
 /// that function's obligations alone, and the lemma stays debt. `noresult` is
 /// excluded for alarms, where it means EVA had nothing to say; here it is the
 /// whole problem.
-fn property_is_unproved_lemma(property: &serde_json::Value, wp_goals: &serde_json::Value) -> bool {
+pub(crate) fn property_is_unproved_lemma(property: &serde_json::Value, wp_goals: &serde_json::Value) -> bool {
     if property.get("kind").and_then(|value| value.as_str()) != Some("lemma") {
         return false;
     }
@@ -609,7 +612,7 @@ fn property_is_unproved_lemma(property: &serde_json::Value, wp_goals: &serde_jso
 /// clause under it is fine, and the property table carries no parent links to
 /// check that against. Two entries naming one defect is noise; one missing
 /// entry is a false OK.
-fn property_is_disproved(property: &serde_json::Value, wp_goals: &serde_json::Value) -> bool {
+pub(crate) fn property_is_disproved(property: &serde_json::Value, wp_goals: &serde_json::Value) -> bool {
     matches!(
         property_normalized_status(property),
         "invalid" | "invalid_under_hyp"
@@ -683,7 +686,7 @@ fn goals_for_property_all_valid(
 /// comparison, while the alternative is a false OK on the loudest thing
 /// Frama-C can say. Since no fixture can produce the status, the test drives
 /// the classifier directly.
-fn property_is_inconsistent(property: &serde_json::Value) -> bool {
+pub(crate) fn property_is_inconsistent(property: &serde_json::Value) -> bool {
     property_normalized_status(property) == "inconsistent"
 }
 
@@ -703,7 +706,7 @@ fn property_is_inconsistent(property: &serde_json::Value) -> bool {
 /// reported, a reachability property at `invalid_under_hyp` would be filed as
 /// `PROPERTY_DISPROVED`. Same fail-closed answer, wrong name for it. Dead code
 /// is dead code whether or not EVA reached the verdict under hypotheses.
-fn property_is_disproved_reachability(property: &serde_json::Value) -> bool {
+pub(crate) fn property_is_disproved_reachability(property: &serde_json::Value) -> bool {
     property.get("kind").and_then(|value| value.as_str()) == Some("reachable")
         && matches!(
             property_normalized_status(property),
@@ -734,7 +737,7 @@ fn property_is_disproved_reachability(property: &serde_json::Value) -> bool {
 /// contributes nothing and nothing is duplicated. A `check lemma` is left out
 /// by the same rule: WP checks it rather than assuming it, and it is `valid`
 /// only once discharged.
-fn property_is_assumed_valid(property: &serde_json::Value) -> bool {
+pub(crate) fn property_is_assumed_valid(property: &serde_json::Value) -> bool {
     property_normalized_status(property) == "considered_valid"
 }
 
@@ -994,7 +997,7 @@ pub fn wp_backend_anomaly_left_goal_unjudged(
         })
 }
 
-fn check_goal_counts_as_progress(goal: &serde_json::Value) -> bool {
+pub(crate) fn check_goal_counts_as_progress(goal: &serde_json::Value) -> bool {
     if let Some(counts) = goal
         .get("counts_as_progress")
         .and_then(|value| value.as_bool())
@@ -1007,839 +1010,6 @@ fn check_goal_counts_as_progress(goal: &serde_json::Value) -> bool {
     // such row answered false, which reads as "no progress" for a property
     // Frama-C recorded as valid.
     own_status_is_proved(goal)
-}
-
-/// What to say when no alarm and no goal offers a next target.
-///
-/// "Nothing to target" and "nothing wrong" are different sentences, and the
-/// fallback used to write the second when it meant the first. A gap with no
-/// call behind it is the normal case for an assumption or a disabled stage.
-pub fn check_blocked_reason(incomplete: &[serde_json::Value]) -> String {
-    let codes = incomplete
-        .iter()
-        .filter_map(|item| item.get("code").and_then(|code| code.as_str()))
-        .collect::<Vec<_>>();
-    if codes.is_empty() {
-        return "EVA and WP did not report an immediate non-valid target.".to_string();
-    }
-    let blocking = if codes.len() == 1 {
-        "one gap still blocks"
-    } else {
-        "several gaps still block"
-    };
-    format!(
-        "No non-valid alarm or goal to target, but {blocking} a proved verdict: {}.",
-        codes.join(", ")
-    )
-}
-
-/// Every reason check can put in its incomplete array, named once.
-///
-/// These are a published vocabulary: docs/architecture.md freezes
-/// them, README tabulates them, and agents branch on them. They were thirteen
-/// string literals spread over one match and eight push sites, so nothing
-/// connected the emitters to the documents, and the set drifted twice before
-/// anyone noticed.
-///
-/// ALL is what the documents are checked against. It does not stop someone
-/// writing a bare literal at a new push site, and no cheap thing does for a
-/// string vocabulary; what it does is make the bare literal the odd one out
-/// next to its neighbours, and give the doc test something to compare that is
-/// not a grep of the source.
-///
-/// The cap sits on the module rather than on each item, so the doc test in
-/// server's test child reaches ALL without any one const being widened to the
-/// whole crate.
-pub mod incomplete_code {
-    pub const RTE_DISABLED: &str = "RTE_DISABLED";
-    pub const EVA_NOT_RUN: &str = "EVA_NOT_RUN";
-    pub const WP_NOT_RUN: &str = "WP_NOT_RUN";
-    pub const WP_STILL_RUNNING: &str = "WP_STILL_RUNNING";
-    pub const ALARM_NOT_VALID: &str = "ALARM_NOT_VALID";
-    pub const GOAL_NOT_VALID: &str = "GOAL_NOT_VALID";
-    pub const PROVER_TIMEOUT: &str = "PROVER_TIMEOUT";
-    pub const PROPERTY_DEAD: &str = "PROPERTY_DEAD";
-    pub const PROPERTY_DISPROVED: &str = "PROPERTY_DISPROVED";
-    pub const PROPERTY_INCONSISTENT: &str = "PROPERTY_INCONSISTENT";
-    pub const LEMMA_NOT_PROVED: &str = "LEMMA_NOT_PROVED";
-    pub const ASSUMED_VALID: &str = "ASSUMED_VALID";
-    pub const ASSUMED_CALLEE_CONTRACT: &str = "ASSUMED_CALLEE_CONTRACT";
-    pub const UNCONSTRAINED_ASSIGNS: &str = "UNCONSTRAINED_ASSIGNS";
-    pub const RESULT_UNCONSTRAINED: &str = "RESULT_UNCONSTRAINED";
-    pub const UNPROVED_ASSUMPTION: &str = "UNPROVED_ASSUMPTION";
-    pub const VALID_UNDER_HYP: &str = "VALID_UNDER_HYP";
-    pub const EVA_NOT_REQUESTED: &str = "EVA_NOT_REQUESTED";
-    pub const WP_NOT_REQUESTED: &str = "WP_NOT_REQUESTED";
-    pub const WP_BACKEND_ANOMALY: &str = "WP_BACKEND_ANOMALY";
-    pub const AST_ASM_CLOBBER: &str = "AST_ASM_CLOBBER";
-    pub const AST_UNKNOWN_ATTRIBUTE: &str = "AST_UNKNOWN_ATTRIBUTE";
-    pub const AST_UNCLASSIFIED_WARNING: &str = "AST_UNCLASSIFIED_WARNING";
-    pub const AST_PARSE_DIAGNOSTICS_UNAVAILABLE: &str = "AST_PARSE_DIAGNOSTICS_UNAVAILABLE";
-
-    // Only the doc comparison reads the list as a list; the emit sites name
-    // codes one at a time. It used to be cfg(test) gated, which stopped meaning
-    // anything when the tests moved out of this crate: an integration test
-    // links the library built without that cfg.
-    pub const ALL: &[&str] = &[
-        RTE_DISABLED,
-        EVA_NOT_RUN,
-        WP_NOT_RUN,
-        WP_STILL_RUNNING,
-        ALARM_NOT_VALID,
-        GOAL_NOT_VALID,
-        PROVER_TIMEOUT,
-        PROPERTY_DEAD,
-        PROPERTY_DISPROVED,
-        PROPERTY_INCONSISTENT,
-        LEMMA_NOT_PROVED,
-        ASSUMED_VALID,
-        ASSUMED_CALLEE_CONTRACT,
-        UNCONSTRAINED_ASSIGNS,
-        RESULT_UNCONSTRAINED,
-        UNPROVED_ASSUMPTION,
-        VALID_UNDER_HYP,
-        EVA_NOT_REQUESTED,
-        WP_NOT_REQUESTED,
-        WP_BACKEND_ANOMALY,
-        AST_ASM_CLOBBER,
-        AST_UNKNOWN_ATTRIBUTE,
-        AST_UNCLASSIFIED_WARNING,
-        AST_PARSE_DIAGNOSTICS_UNAVAILABLE,
-    ];
-}
-
-/// The schema string on a check payload.
-///
-/// v2 allows new fields and new incomplete codes. Removing or renaming either
-/// needs v3, and a consumer that does not recognise the string should stop
-/// rather than guess.
-///
-/// v2 because "want" made a null analysis mean two things. Under v1 a null
-/// "wp" said the reload failed, and a consumer could read it as a breakage;
-/// now it can also say the caller never asked for WP. The pair of codes tells
-/// them apart, but the field's meaning moved, and that is the change v1's own
-/// rule sends to a new version rather than treating as additive.
-pub const CHECK_SCHEMA: &str = "frama-c-mcp.check.v2";
-
-/// Which analyses one call to check runs.
-///
-/// Two flags rather than the list of wants it is built from, because every
-/// reader asks about one analysis at a time. A list makes each of those a
-/// lookup, and a lookup answers "not wanted" to a misspelled name.
-#[derive(Clone, Copy)]
-pub struct WantedAnalyses {
-    pub eva: bool,
-    pub wp: bool,
-}
-
-impl WantedAnalyses {
-    pub const BOTH: Self = Self {
-        eva: true,
-        wp: true,
-    };
-
-    /// Both unless the caller narrowed it. An empty list is read the same way
-    /// as none at all: asking for nothing is a request nobody means, and
-    /// answering it with a payload that proves nothing would be worse than
-    /// answering the whole question.
-    pub fn from_want(want: Option<&[CheckAnalysis]>) -> Self {
-        match want {
-            None | Some([]) => Self::BOTH,
-            Some(wants) => Self {
-                eva: wants.contains(&CheckAnalysis::Eva),
-                wp: wants.contains(&CheckAnalysis::Wp),
-            },
-        }
-    }
-}
-
-/// Gaps that follow from what the caller asked for rather than from what ran.
-fn unrequested_analysis_gaps(
-    incomplete: &mut Vec<serde_json::Value>,
-    rte: Option<bool>,
-    wanted: WantedAnalyses,
-) {
-    // An analysis nobody asked for is still an analysis that did not run, and
-    // this array exists so that silence and clean are different answers. A
-    // caller who skipped WP knows they skipped it; the point is that the
-    // verdict cannot read "proved" on the strength of half a check.
-    if !wanted.eva {
-        incomplete.push(json!({
-            "code": incomplete_code::EVA_NOT_REQUESTED,
-            "reason": "check did not run EVA, so nothing here excludes the alarms it finds.",
-        }));
-    }
-    if !wanted.wp {
-        incomplete.push(json!({
-            "code": incomplete_code::WP_NOT_REQUESTED,
-            "reason": "check did not run WP, so nothing here is a proof.",
-        }));
-    }
-    if rte == Some(false) {
-        incomplete.push(json!({
-            "code": incomplete_code::RTE_DISABLED,
-            "reason": "check ran without RTE annotations, so absence of alarms/goals excludes implicit runtime-error checks.",
-        }));
-    }
-}
-
-/// Gaps left by a step that failed, was skipped, or had not finished.
-fn step_failure_gaps(
-    incomplete: &mut Vec<serde_json::Value>,
-    reload: &serde_json::Value,
-    eva: &serde_json::Value,
-    eva_alarms: &serde_json::Value,
-    wp: &serde_json::Value,
-    wp_goals: &serde_json::Value,
-    wanted: WantedAnalyses,
-) {
-    // Both blocks are guarded, because a skipped analysis leaves its fields
-    // null and null is how a failed one looks too.
-    if wanted.eva
-        && (check_step_failed(reload) || check_step_failed(eva) || check_step_failed(eva_alarms))
-    {
-        incomplete.push(json!({
-            "code": incomplete_code::EVA_NOT_RUN,
-            "reason": "EVA did not complete, so eva_alarms is not proof of no alarms.",
-            "error": eva.get("error").or_else(|| eva_alarms.get("error")).or_else(|| reload.get("error")).cloned().unwrap_or_else(|| json!(null)),
-        }));
-    }
-    if wanted.wp {
-        if check_step_failed(reload) || check_step_failed(wp) || check_step_failed(wp_goals) {
-            incomplete.push(json!({
-                "code": incomplete_code::WP_NOT_RUN,
-                "reason": "WP did not complete, so wp_goals is not proof of no goals.",
-                "error": wp.get("error").or_else(|| wp_goals.get("error")).or_else(|| reload.get("error")).cloned().unwrap_or_else(|| json!(null)),
-            }));
-        } else if wp.get("drained").and_then(|value| value.as_bool()) != Some(true) {
-            // A goal WP has not finished is a goal "fetchGoals" may not list at
-            // all, so the absence of a failure here proves nothing about it.
-            incomplete.push(json!({
-                "code": incomplete_code::WP_STILL_RUNNING,
-                "reason": "WP was still working when its goals were read, so wp_goals may be missing goals entirely.",
-                "todo": wp.get("todo").cloned().unwrap_or_else(|| json!(null)),
-                "active": wp.get("active").cloned().unwrap_or_else(|| json!(null)),
-            }));
-        }
-    }
-}
-
-/// The edit that closes a gap, for the codes where the shape is known.
-///
-/// Separate from `reason`, which says what is missing. A reader who has just
-/// been told a lemma is undischarged still has to know that no SMT prover will
-/// find the induction, and that waiting longer is not the fix. Codes whose
-/// remedy depends on the program say nothing here rather than guess.
-pub fn gap_guidance(code: &str) -> serde_json::Value {
-    let guidance = match code {
-        incomplete_code::LEMMA_NOT_PROVED => {
-            "An SMT prover does not do induction, so a lemma over a recursive logic function or an \
-             inductive predicate will not close by raising the timeout. Reach for the induction \
-             tactic instead, which WP registers as Wp.induction and drives through -wp-tactic, \
-             -wp-prover tip and -wp-script; or split the lemma into smaller ones the prover can \
-             chain. Until one of those lands, every goal that cites it is valid only under it."
-        }
-        incomplete_code::ASSUMED_VALID => {
-            "This property is recorded valid by assumption, not by proof. If the assumption is \
-             deliberate, keep the axiom and say so where a reader will see it; if it is not, \
-             remove the axiom and prove the property, because WP uses it as a hypothesis \
-             everywhere without ever checking it."
-        }
-        incomplete_code::PROPERTY_DEAD => {
-            "EVA proved this code unreachable, so proving anything about it constrains no run. \
-             Either the guard that makes it unreachable is wrong, or the code is dead and should \
-             go. Do not strengthen the annotation: a property of unreachable code is vacuous \
-             whatever it says."
-        }
-        incomplete_code::PROPERTY_INCONSISTENT => {
-            "Two emitters ruled opposite ways on this property, so the consolidated verdict cannot \
-             be trusted in either direction. Find the disagreement before writing any annotation \
-             that rests on it; a contract built on an inconsistent property proves nothing."
-        }
-        _ => return serde_json::Value::Null,
-    };
-    json!(guidance)
-}
-
-/// Gaps carried by rows of the property table itself, which is where EVA
-/// alarms and every consolidated verdict live.
-fn property_row_gaps(
-    incomplete: &mut Vec<serde_json::Value>,
-    eva_alarms: &serde_json::Value,
-    wp_goals: &serde_json::Value,
-) {
-    // An undischarged runtime-error alarm is as much of a gap as a non-valid WP
-    // goal, and `check` used to report "proved" over one.
-    //
-    // Only RTE assertions count. The alarms want returns the whole kernel
-    // property table, so contract clauses (requires, ensures, behavior) arrive
-    // in the same array. Those are judged by the WP goal loop below, and
-    // flagging them here would both duplicate that and report the not yet
-    // proved state of a snapshot taken before WP ran.
-    //
-    // The status filter matches first_alarm_next_call through
-    // alarm_is_undischarged, so anything reported here also gets a recommended
-    // next call. That excludes `noresult`, which is Frama-C's never_tried
-    // rather than a failure.
-    if let Some(alarms) = eva_alarms.as_array() {
-        for alarm in alarms {
-            // Both findings describe the same property row, so they carry the
-            // same fields and only the code and reason differ.
-            let (code, reason) = if property_is_inconsistent(alarm) {
-                (
-                    incomplete_code::PROPERTY_INCONSISTENT,
-                    "Frama-C consolidated contradictory statuses for this property, so the verdict cannot be trusted in either direction.",
-                )
-            } else if alarm_is_undischarged(alarm) {
-                (
-                    incomplete_code::ALARM_NOT_VALID,
-                    "EVA reported a runtime-error alarm it could not discharge.",
-                )
-            } else if property_is_disproved_reachability(alarm) {
-                (
-                    incomplete_code::PROPERTY_DEAD,
-                    "EVA proved this code unreachable, so nothing proved about it constrains a run.",
-                )
-            } else if property_is_unproved_lemma(alarm, wp_goals) {
-                (
-                    incomplete_code::LEMMA_NOT_PROVED,
-                    "WP assumes every lemma while discharging other goals, so an undischarged one makes the proofs around it worthless.",
-                )
-            } else if property_is_disproved(alarm, wp_goals) {
-                (
-                    incomplete_code::PROPERTY_DISPROVED,
-                    "Frama-C disproved this property, and WP emits no goal for a property that already carries a status, so nothing downstream reports it.",
-                )
-            } else if property_is_assumed_valid(alarm) {
-                (
-                    incomplete_code::ASSUMED_VALID,
-                    "Frama-C recorded this property as valid by external assumption rather than by proof. WP uses it as a hypothesis everywhere without ever checking it.",
-                )
-            } else {
-                continue;
-            };
-            incomplete.push(json!({
-                "code": code,
-                "reason": reason,
-                "property": value_marker(alarm).map(|m| json!(m)).unwrap_or_else(|| json!(null)),
-                "descr": alarm.get("descr").cloned().unwrap_or_else(|| json!(null)),
-                "source_location": alarm.get("source_location").cloned().unwrap_or_else(|| json!(null)),
-                "status": property_normalized_status(alarm),
-            }));
-        }
-    }
-}
-
-/// The guidance for the codes an incomplete[] actually carries, keyed by code.
-///
-/// gap_guidance is a pure function of the code, so every entry sharing a code
-/// carried a byte-identical paragraph. Measured on a 1,144-line file: 110,509
-/// bytes across 418 entries and two distinct strings, so 110,240 of it was one
-/// of two paragraphs repeated. The array stays complete, which is what the
-/// fail-loud rule is about; only the repetition goes.
-///
-/// A map rather than one entry in N: a reader wanting the advice for an entry
-/// looks up its own "code", which it already has.
-pub fn incomplete_guidance(incomplete: &[serde_json::Value]) -> serde_json::Value {
-    let mut guidance = serde_json::Map::new();
-    for entry in incomplete {
-        let Some(code) = entry.get("code").and_then(|code| code.as_str()) else {
-            continue;
-        };
-        if guidance.contains_key(code) {
-            continue;
-        }
-        let text = gap_guidance(code);
-        if !text.is_null() {
-            guidance.insert(code.to_string(), text);
-        }
-    }
-    serde_json::Value::Object(guidance)
-}
-
-/// Gaps carried by WP's own goals.
-///
-/// Returns the goals this pass judged, keyed by WP's obligation id, because
-/// the proofread findings below can only be attributed to a goal that was
-/// judged here.
-/// The gap a goal WP proved can still leave, or None when it leaves none.
-///
-/// Reaching this at all means the property verdict disagreed with the goal,
-/// since a property that consolidated to valid was skipped before the call.
-/// Dead code is one way; resting on an unestablished hypothesis is the other,
-/// and a goal in that second arm used to match neither test and go unreported
-/// with the verdict reading proved over it.
-fn proved_goal_gap(goal: &serde_json::Value, status: &str) -> Option<serde_json::Value> {
-    let field = |name: &str| goal.get(name).cloned().unwrap_or_else(|| json!(null));
-    if property_is_dead(goal) {
-        return Some(json!({
-            "code": incomplete_code::PROPERTY_DEAD,
-            "reason": "WP proved this goal, but its property sits in code EVA proved unreachable.",
-            "stable_goal_id": field("stable_goal_id"),
-            "frama_c_goal_name": field("frama_c_goal_name"),
-            "goal_kind": field("goal_kind"),
-            "normalized_status": status,
-            "property_status": field("normalized_property_status"),
-        }));
-    }
-    if goal_is_valid_under_hypotheses(goal) {
-        return Some(json!({
-            "code": incomplete_code::VALID_UNDER_HYP,
-            "reason": "WP proved this goal, but Frama-C consolidated its property as valid only under hypotheses that are not themselves established.",
-            "stable_goal_id": field("stable_goal_id"),
-            "frama_c_goal_name": field("frama_c_goal_name"),
-            "goal_kind": field("goal_kind"),
-            "normalized_status": status,
-            "property_status": field("normalized_property_status"),
-
-            // Which hypotheses, when the goal carries them.
-            // enrich_goal_with_property_status resolves "deps" against the
-            // property table, and naming them is the difference between this
-            // finding and the guess the unproved-assumption finding has to
-            // make.
-            "hypotheses": field("hypotheses"),
-        }));
-    }
-    None
-}
-
-fn wp_goal_gaps<'a>(
-    incomplete: &mut Vec<serde_json::Value>,
-    eva_alarms: &'a serde_json::Value,
-    wp_goals: &'a serde_json::Value,
-) -> BTreeMap<&'a str, &'a serde_json::Value> {
-    // Lemma goals are reported once, as LEMMA_NOT_PROVED, which says the thing
-    // that matters: WP assumed it everywhere. A second GOAL_NOT_VALID for the
-    // same obligation is noise.
-    let lemma_markers: HashSet<&str> = eva_alarms
-        .as_array()
-        .map(|alarms| {
-            alarms
-                .iter()
-                .filter(|alarm| alarm.get("kind").and_then(|value| value.as_str()) == Some("lemma"))
-                .filter_map(value_marker)
-                .collect()
-        })
-        .unwrap_or_default();
-
-    // Which goals the loop below actually judged, keyed by WP's own obligation
-    // id and carrying the identity the loop reported them under.
-    //
-    // Keyed on "wpo" rather than "stable_goal_id" because the two arrays reach
-    // here by different routes. wp_goals is enriched against the property table
-    // and so carries source_location and predicate, both of which
-    // stable_goal_id_for digests; the proofread report is built from the raw
-    // fetchGoals array, which has neither, so the same goal digests to two
-    // different ids. Matching on those ids matched nothing at all. "wpo" is
-    // assigned by WP itself and is present before any enrichment.
-    let mut judged_goals: BTreeMap<&str, &serde_json::Value> = BTreeMap::new();
-
-    if let Some(goals) = wp_goals.as_array() {
-        for goal in goals {
-            if check_goal_counts_as_progress(goal) {
-                continue;
-            }
-            if goal
-                .get("property")
-                .or_else(|| goal.get("property_marker"))
-                .and_then(|value| value.as_str())
-                .is_some_and(|marker| lemma_markers.contains(marker))
-            {
-                continue;
-            }
-
-            // Recorded past every skip above, so the set cannot disagree with
-            // what this loop judged. Built beside the loop instead, it already
-            // diverged: the lemma skip is here and was not there.
-            if let Some(wpo) = goal
-                .get("wpo_id")
-                .or_else(|| goal.get("wpo"))
-                .and_then(|value| value.as_str())
-            {
-                judged_goals.insert(wpo, goal);
-            }
-
-            // own_status, not the consolidated one: the property verdict is
-            // what the skip above already judged, and letting it answer here is
-            // the bug this branch's comment records.
-            let status = own_status(goal).unwrap_or("unknown");
-
-            // A goal WP proved is not a failing goal, whatever the consolidated
-            // property says, so GOAL_NOT_VALID would be the wrong sentence for
-            // anything in here. check_goal_counts_as_progress reads
-            // counts_as_progress, which enrich_goal_with_property_status
-            // overwrites with the property verdict, so a valid goal attached to
-            // a dead property arrived here as GOAL_NOT_VALID. On
-            // abs-int-buggy.c that produced all three findings while the real
-            // overflow was reported nowhere.
-            //
-            // Reaching this branch at all means the property verdict disagreed
-            // with the goal, since a property that consolidated to valid would
-            // have been skipped above. Dead code is one way; resting on an
-            // unestablished hypothesis is the other, and a goal in that second
-            // arm used to match neither test and go unreported, with the
-            // verdict reading proved over it.
-            if is_proved(status) {
-                incomplete.extend(proved_goal_gap(goal, status));
-                continue;
-            }
-            incomplete.push(json!({
-                "code": incomplete_code::GOAL_NOT_VALID,
-                "reason": "WP has a non-valid goal.",
-                "stable_goal_id": goal.get("stable_goal_id").cloned().unwrap_or_else(|| json!(null)),
-                "frama_c_goal_name": goal.get("frama_c_goal_name").cloned().unwrap_or_else(|| json!(null)),
-                "goal_kind": goal.get("goal_kind").cloned().unwrap_or_else(|| json!(null)),
-                "normalized_status": status,
-            }));
-            if status.eq_ignore_ascii_case("timeout") {
-                incomplete.push(json!({
-                    "code": incomplete_code::PROVER_TIMEOUT,
-                    "reason": "A WP prover timed out on this goal.",
-                    "stable_goal_id": goal.get("stable_goal_id").cloned().unwrap_or_else(|| json!(null)),
-                    "frama_c_goal_name": goal.get("frama_c_goal_name").cloned().unwrap_or_else(|| json!(null)),
-                    "goal_kind": goal.get("goal_kind").cloned().unwrap_or_else(|| json!(null)),
-                    "normalized_status": status,
-                }));
-            }
-        }
-    }
-    judged_goals
-}
-
-/// Gaps that only the proofread pass sees: an assumption WP took on faith, a
-/// contract that constrains nothing it writes, a callee contract believed
-/// rather than proved.
-fn proofread_finding_gaps(
-    incomplete: &mut Vec<serde_json::Value>,
-    wp: &serde_json::Value,
-    judged_goals: &BTreeMap<&str, &serde_json::Value>,
-) {
-    if let Some(findings) = wp
-        .get("proofread_report")
-        .and_then(|report| report.get("findings"))
-        .and_then(|findings| findings.as_array())
-    {
-        for finding in findings {
-            let category = finding.get("category").and_then(|value| value.as_str());
-            if category == Some("unproved_assumption") {
-                // A goal the loop above did not judge is out of scope, or had
-                // its property consolidated to valid by something else. Either
-                // way GOAL_NOT_VALID already speaks for everything in scope, so
-                // dropping it costs no gap report and keeps the verdict honest.
-                let Some(judged) = finding
-                    .get("wpo")
-                    .and_then(|value| value.as_str())
-                    .and_then(|wpo| judged_goals.get(wpo))
-                else {
-                    continue;
-                };
-                incomplete.push(json!({
-                    "code": incomplete_code::UNPROVED_ASSUMPTION,
-                    "reason": finding.get("why_problem").cloned().unwrap_or_else(|| json!(
-                        "WP assumes an unproved assertion or postcondition, so a goal reported valid may rest on it."
-                    )),
-                    "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
-
-                    // Taken from the goal the loop judged, not from the
-                    // finding. The same goal is also reported as
-                    // GOAL_NOT_VALID, and the name alone does not say which
-                    // one, since Frama-C names every unnamed assertion in a
-                    // function "Assertion". Pairing the two is the whole point
-                    // of carrying an id, and the finding's own id is digested
-                    // from the raw goal, so it never equals the one
-                    // GOAL_NOT_VALID reports.
-                    "stable_goal_id": judged.get("stable_goal_id").cloned().unwrap_or_else(|| json!(null)),
-                    "frama_c_goal_name": finding.get("trigger").cloned().unwrap_or_else(|| json!(null)),
-                    "goal_kind": finding.get("clause_or_goal_kind").cloned().unwrap_or_else(|| json!(null)),
-                }));
-                continue;
-            }
-            if category == Some("result_unconstrained") {
-                // Completeness, like unconstrained_assigns: every goal can be
-                // valid while this is reported, because what it names is a
-                // contract that permits outcomes it never explains.
-                incomplete.push(json!({
-                    "code": incomplete_code::RESULT_UNCONSTRAINED,
-                    "reason": finding.get("message").cloned().unwrap_or_else(|| json!(
-                        "The contract bounds the result without determining it."
-                    )),
-                    "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
-                    "result_range": finding.get("result_range").cloned().unwrap_or_else(|| json!(null)),
-                    "undetermined_results": finding.get("undetermined_results").cloned().unwrap_or_else(|| json!(null)),
-                }));
-                continue;
-            }
-            if category == Some("unconstrained_assigns") {
-                // Every goal can be valid while this is reported: it says the
-                // contract left a written location free, so the proof covers
-                // less than its goal count reads as. Landing here makes the
-                // verdict "incomplete", which is the point, since a run whose
-                // goals are all valid is exactly the run that would otherwise
-                // read "proved" over a contract that establishes nothing about
-                // what it wrote.
-                incomplete.push(json!({
-                    "code": incomplete_code::UNCONSTRAINED_ASSIGNS,
-                    "reason": finding.get("message").cloned().unwrap_or_else(|| json!(
-                        "The contract assigns a location no postcondition constrains."
-                    )),
-                    "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
-                    "assigns_target": finding.get("assigns_target").cloned().unwrap_or_else(|| json!(null)),
-                }));
-                continue;
-            }
-            if category != Some("assumed_callee_contract") {
-                continue;
-            }
-            incomplete.push(json!({
-                "code": incomplete_code::ASSUMED_CALLEE_CONTRACT,
-                "reason": finding.get("message").cloned().unwrap_or_else(|| json!("WP relied on a direct callee contract with no finite assigns clause.")),
-                "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
-                "callee": finding.get("callee").cloned().unwrap_or_else(|| json!(null)),
-                "source_location": finding.get("source_location").cloned().unwrap_or_else(|| json!(null)),
-            }));
-        }
-    }
-}
-
-/// What a variant varied that could change the analysed code. `model` is not
-/// in it: no WP option reaches the AST.
-type AstInputs = (Vec<String>, Option<String>);
-
-/// Per AST digest, the variants that produced it, one entry per distinct set of
-/// AST-relevant inputs. A second entry under one digest is the finding: two
-/// configurations asked for different code and got the same. Repeats within a
-/// group are a model sweep and are not.
-type DigestGroups = std::collections::HashMap<String, Vec<(String, AstInputs)>>;
-
-/// The verdict over a finished set of variant entries.
-///
-/// Free-standing so the decision can be tested without a Frama-C instance: the
-/// case that matters most is the one no integration test can stage, a run where
-/// every variant proved and no digest was ever established.
-/// Take "label", or the first "label#n" nobody has taken, and record it.
-///
-/// Looped, not suffixed once: a caller who passes "a" twice and also passes
-/// "a#1" would otherwise get two variants called "a#1", and duplicate_ast
-/// names a label, so it would point at whichever of them landed first.
-fn claim_label(
-    taken: &mut std::collections::HashSet<String>,
-    label: String,
-    from: usize,
-) -> String {
-    if taken.insert(label.clone()) {
-        return label;
-    }
-    (from..)
-        .map(|suffix| format!("{label}#{suffix}"))
-        .find(|candidate| taken.insert(candidate.clone()))
-        .unwrap_or(label)
-}
-
-pub fn check_variants_summary(results: Vec<serde_json::Value>) -> serde_json::Value {
-    let digest_of = |entry: &serde_json::Value| {
-        entry
-            .get("ast_digest")
-            .and_then(|value| value.as_str())
-            .map(str::to_string)
-    };
-
-    let duplicate_count = results
-        .iter()
-        .filter(|entry| entry.get("duplicate_ast").is_some())
-        .count();
-    let all_proved = results
-        .iter()
-        .all(|entry| entry.get("verdict").and_then(|v| v.as_str()) == Some("proved"));
-    let distinct_asts = results
-        .iter()
-        .filter_map(digest_of)
-        .collect::<std::collections::HashSet<_>>()
-        .len();
-
-    // A digest that could not be established compares equal to nothing, so a
-    // variant carrying one was never compared to anything. Counted and
-    // reported, because the alternative is the failure this tool exists to
-    // catch, one level up: with no digests at all the summary would read
-    // distinct_asts 0, duplicate_ast_count 0, verdict proved, which is
-    // indistinguishable from a matrix that really was checked and really was
-    // clean. A comparison that did not happen must not read as one that
-    // happened and found nothing.
-    let unestablished = results
-        .iter()
-        .filter(|entry| digest_of(entry).is_none())
-        .count();
-
-    let reason = if duplicate_count > 0 {
-        json!(
-            "Two or more variants asked for different code and analysed byte-identical \
-               ASTs, so they are one configuration checked twice rather than several \
-               checked once. Equal goal counts cannot show this; the digests can. \
-               Variants that differ only in the WP model are not counted here: no proof \
-               option changes the AST, so sharing one is expected."
-        )
-    } else if unestablished > 0 {
-        json!(
-            "At least one variant has no AST digest, so it was compared to nothing and this \
-               run cannot say whether the configurations differ. Read \
-               proof_receipt.subject.ast_digest_unavailable_reason on that variant: the usual \
-               causes are the ast-utils plug-in not being installed and printSource outrunning \
-               its budget on a large project."
-        )
-    } else {
-        serde_json::Value::Null
-    };
-
-    json!({
-        "schema": "frama-c-mcp.check-variants.v1",
-
-        // Not "proved" unless every variant proved AND every pair was actually
-        // comparable. Both gaps mean the same thing: the question this tool was
-        // asked has not been answered.
-        "verdict": if duplicate_count == 0 && unestablished == 0 && all_proved {
-            "proved"
-        } else {
-            "incomplete"
-        },
-        "variant_count": results.len(),
-        "distinct_asts": distinct_asts,
-        "duplicate_ast_count": duplicate_count,
-        "ast_digest_unavailable_count": unestablished,
-        "reason": reason,
-        "variants": results,
-    })
-}
-
-pub fn check_incomplete_items(
-    rte: Option<bool>,
-    reload: &serde_json::Value,
-    eva: &serde_json::Value,
-    eva_alarms: &serde_json::Value,
-    wp: &serde_json::Value,
-    wp_goals: &serde_json::Value,
-    wanted: WantedAnalyses,
-) -> Vec<serde_json::Value> {
-    let mut incomplete = Vec::new();
-    ast_diagnostic_gaps(&mut incomplete, reload, AST_WARNING_ALLOWLIST);
-    unrequested_analysis_gaps(&mut incomplete, rte, wanted);
-    step_failure_gaps(
-        &mut incomplete,
-        reload,
-        eva,
-        eva_alarms,
-        wp,
-        wp_goals,
-        wanted,
-    );
-    property_row_gaps(&mut incomplete, eva_alarms, wp_goals);
-    let judged_goals = wp_goal_gaps(&mut incomplete, eva_alarms, wp_goals);
-    proofread_finding_gaps(&mut incomplete, wp, &judged_goals);
-    incomplete
-}
-
-/// Warning categories this server has read and declared benign, with the
-/// reason it is willing to say so. Empty on purpose: silence about a category
-/// nobody has looked at would be this server deciding a warning is harmless
-/// without saying so. A row leaves the aggregate below and goes nowhere else.
-pub const AST_WARNING_ALLOWLIST: &[(&str, &str)] = &[];
-
-/// The code and reason a category becomes, for the two the front end drops
-/// soundness with. The spellings come from the module that reads them off the
-/// log, so the classifier and the zero rows cannot disagree about what a
-/// category is called.
-fn ast_soundness_reason(category: &str) -> Option<(&'static str, &'static str)> {
-    match category {
-        project::ASM_CLOBBER => Some((
-            incomplete_code::AST_ASM_CLOBBER,
-            "Frama-C assumed inline assembly has no effects beyond its operands, so the analyzed statement is weaker than the compiled one.",
-        )),
-        project::ATTRS_UNKNOWN => Some((
-            incomplete_code::AST_UNKNOWN_ATTRIBUTE,
-            "Frama-C ignored an unknown attribute, so the analyzed declaration differs from the source.",
-        )),
-        _ => None,
-    }
-}
-
-/// What the parse of the loaded files cost, read off the reload payload.
-///
-/// The two soundness classes get a code each; everything else that nobody has
-/// classified or allowlisted shares one aggregate entry, because a payload
-/// carrying one entry per category is unbounded in the size of the program.
-///
-/// The allowlist is a parameter rather than a read of the const below, so a
-/// test can prove that a row removes its category from the aggregate and
-/// changes nothing else. A guard over an empty const proves neither.
-pub fn ast_diagnostic_gaps(
-    incomplete: &mut Vec<serde_json::Value>,
-    reload: &serde_json::Value,
-    allowlist: &[(&str, &str)],
-) {
-    let diagnostics = &reload["ast_reload_health"]["parse_diagnostics"];
-
-    // No completeness flag on any of this, and that is a property of how the
-    // record is produced rather than an omission. It is always a process's boot
-    // parse, because ensure_main_spawned respawns rather than hand back a
-    // reparse, and a boot parse can neither miss a warn-once category nor pick
-    // up a concurrent call's output. So a zero here is evidence of absence,
-    // which is what lets the zero-count branch below skip a category instead of
-    // having to hedge it, and it is what keeps two checks of one session
-    // reporting the same codes: an entry that appeared only on the second would
-    // move proof_receipt.sha256, since the receipt digests incomplete. A record
-    // that says why it is empty is a finding rather than silence. Reading it as
-    // a clean parse would let check answer "proved" on the one shape where
-    // nothing established that the analyzed program is the compiled one, which
-    // is the claim these codes exist to make.
-    if let Some(reason) = diagnostics["unavailable"].as_str() {
-        incomplete.push(json!({
-            "code": incomplete_code::AST_PARSE_DIAGNOSTICS_UNAVAILABLE,
-            "reason": "This server has no record of what Frama-C's front end dropped while parsing, so nothing here says the analyzed program is the compiled one.",
-            "detail": reason,
-        }));
-        return;
-    }
-
-    let Some(categories) = diagnostics["categories"].as_object() else {
-        return;
-    };
-
-    let mut unclassified = serde_json::Map::new();
-    for (category, record) in categories {
-        if record["count"].as_u64().unwrap_or(0) == 0 {
-            continue;
-        }
-        if let Some((code, reason)) = ast_soundness_reason(category) {
-            incomplete.push(json!({
-                "code": code,
-                "reason": reason,
-                "category": category,
-                "count": record["count"],
-                "count_unit": record["count_unit"],
-                "locations": record["locations"],
-                "locations_omitted": record["locations_omitted"],
-            }));
-            continue;
-        }
-
-        // A classified category left the loop above, so the only thing that
-        // keeps one out of the aggregate here is a row saying why its silence
-        // is deliberate.
-        if !allowlist.iter().any(|(allowed, _)| allowed == category) {
-            // The whole record, not the bare count. One entry is what keeps the
-            // payload bounded in the number of categories; dropping the unit
-            // and the capped sample inside it would leave a caller a number it
-            // cannot interpret and a warning it cannot find, and buys nothing,
-            // since each sample is already capped.
-            unclassified.insert(category.clone(), record.clone());
-        }
-    }
-
-    if !unclassified.is_empty() {
-        incomplete.push(json!({
-            "code": incomplete_code::AST_UNCLASSIFIED_WARNING,
-            "reason": "Frama-C emitted parse warnings in categories this server has not classified, so their effect on the analyzed program is unknown.",
-            "categories": unclassified,
-        }));
-    }
 }
 
 /// How Frama-C prints the goal name for each PKEnsures clause. All five are
@@ -2098,7 +1268,7 @@ async fn main_contract_shape_findings(
 /// at a symptom, which is what a run over count-logic.c did, recommending an
 /// investigation of a mem_access alarm while three assumed lemmas left ten
 /// goals valid only under hypothesis.
-fn first_unproved_lemma_next_call(
+pub(crate) fn first_unproved_lemma_next_call(
     alarms: &serde_json::Value,
     wp_goals: &serde_json::Value,
 ) -> Option<serde_json::Value> {
@@ -2118,7 +1288,7 @@ fn first_unproved_lemma_next_call(
     })
 }
 
-fn first_alarm_next_call(alarms: &serde_json::Value) -> Option<serde_json::Value> {
+pub(crate) fn first_alarm_next_call(alarms: &serde_json::Value) -> Option<serde_json::Value> {
     alarms.as_array()?.iter().find_map(|alarm| {
         if !alarm_is_undischarged(alarm) {
             return None;
@@ -2172,7 +1342,7 @@ pub fn classification_with_advice(
     classification
 }
 
-fn first_wp_goal_next_call(
+pub(crate) fn first_wp_goal_next_call(
     goals: &serde_json::Value,
     function: Option<&str>,
 ) -> Option<serde_json::Value> {
@@ -2471,12 +1641,43 @@ pub fn profile_matches_loaded_project(
     // fields below say. Refusing it is the only honest answer: the alternative
     // is calling a run evidence about a target while the flags it actually ran
     // under came from somewhere the profile does not reach.
-    options.compilation_database.is_none()
+    // Destructured exhaustively, for the reason given on ProjectLoadOptions.
+    // The profile side stays field by field on purpose: its Option fields mean
+    // "unset, do not constrain", which no derived equality can express.
+    let ProjectLoadOptions {
+        include_paths,
+        defines,
+        force_includes,
+        machdep,
+        compilation_database,
+        rte,
+        isystem_paths,
+        nostdinc,
+    } = options;
+
+    compilation_database.is_none()
         && (profile.sources.is_empty() || profile.sources == files)
-        && profile.include_paths == options.include_paths
-        && profile.defines == options.defines
-        && profile.force_includes == options.force_includes
-        && profile.machdep == options.machdep
+        && &profile.include_paths == include_paths
+        && &profile.defines == defines
+        && &profile.force_includes == force_includes
+        && &profile.machdep == machdep
+
+        // -wp-rte decides which obligations exist at all, so a load without it
+        // gives a strictly smaller set and is a different program to prove.
+        // Unset means the profile does not speak to it, and only a profile that
+        // does can be proof evidence, which the evidence gate enforces.
+        && profile.rte.is_none_or(|want| want == *rte)
+
+        // Same argument as rte: these decide which declarations the file is
+        // compiled against, so a load differing here is a different program.
+        // Unset means the profile does not speak to it, and only a profile that
+        // does can be proof evidence, which the evidence gate enforces. An
+        // empty isystem_paths is serde's default for a profile that never
+        // mentioned the field, so it has to mean "unset" here for the same
+        // reason None does beside it; a profile that constrains the list to
+        // empty is not expressible and is not worth a second spelling.
+        && (profile.isystem_paths.is_empty() || &profile.isystem_paths == isystem_paths)
+        && profile.nostdinc.is_none_or(|want| want == *nostdinc)
 }
 
 #[tool_router(router = analysis_router, vis = "pub(crate)")]
@@ -2823,8 +2024,8 @@ impl FramaCMcpServer {
         // run and whose alarms came from the other, under one receipt. Ending
         // the guard when run_eva_payload returned left exactly that window.
         //
-        // Ordered after main_wp_lock, never before: reload_project takes wp
-        // then eva, and nothing takes eva then wp.
+        // Ordered after main_wp_lock, never before. This site holds only eva,
+        // so it adds no edge; see the lock order on FramaCMcpServer.
         let _eva_op_guard = self.main_eva_lock.lock().await;
         let eva = match self.run_eva_payload(eva_params).await {
             Ok(payload) => payload,
@@ -2949,6 +2150,34 @@ impl FramaCMcpServer {
         payload
     }
 
+    /// Which RTE setting check loads under.
+    ///
+    /// The caller wins, then the named profile, then check's own default of on.
+    /// Settled here rather than left to reload_project, which resolves an unset
+    /// rte through the profile and then to false. That is the right default for
+    /// a load and the wrong one for check: a profile silent on rte would turn
+    /// RTE off the moment a target was named, and quietly shrink the obligation
+    /// set check reports against. Nothing requires a profile used by check to
+    /// state rte; the gate that does is run_wp's.
+    async fn check_rte_setting(&self, requested: Option<bool>, profile: Option<&str>) -> bool {
+        if let Some(rte) = requested {
+            return rte;
+        }
+        let Some(name) = profile else {
+            return true;
+        };
+
+        // Through verify_profile_named, which is where both tools taking a
+        // verify_profile resolve one. An unknown name answers with check's own
+        // default here and is refused by reload_project a moment later, which
+        // is the call that owns that message.
+        self.verify_profile_named(name)
+            .await
+            .ok()
+            .and_then(|profile| profile.rte)
+            .unwrap_or(true)
+    }
+
     pub async fn check_payload(&self, params: CheckParams) -> Result<serde_json::Value, McpError> {
         let wanted = WantedAnalyses::from_want(params.want.as_deref());
 
@@ -2969,12 +2198,18 @@ impl FramaCMcpServer {
         };
         let receipt_files = files.clone().unwrap_or_default();
 
+        let rte = self
+            .check_rte_setting(params.rte, params.verify_profile.as_deref())
+            .await;
+
         let reload = match self
             .reload_project(Parameters(ReloadProjectParams {
                 files,
                 include_paths: params.include_paths,
                 defines: params.defines,
                 force_includes: params.force_includes,
+                isystem_paths: params.isystem_paths,
+                nostdinc: params.nostdinc,
                 machdep: params.machdep,
                 compilation_database: params.compilation_database,
 
@@ -2984,7 +2219,8 @@ impl FramaCMcpServer {
                 verify_profiles: None,
                 verify_profiles_source: None,
                 verify_profile: params.verify_profile.clone(),
-                rte: Some(params.rte.unwrap_or(true)),
+                // Resolved above, so a named profile cannot silently turn it off.
+                rte: Some(rte),
 
                 // check's own detail governs goals and alarms; the function
                 // list it embeds is never the point of the call, and at full
@@ -3114,65 +2350,15 @@ impl FramaCMcpServer {
             }));
         }
 
-        // Ordered after "incomplete" so the fallback can name the gaps it
-        // found. Not every gap has an alarm or a goal to point at: an axiom
-        // leaves every one of them valid, and a fallback that cannot name it
-        // reads as all clear next to a verdict of incomplete.
-        //
-        // The backend diagnosis comes first for the same reason a timeout is
-        // read before a goal's text: reading a VC no prover ever received sends
-        // the caller to rewrite an annotation that was never judged.
-        //
-        // Gated on the same condition as the incomplete entry above: an abort
-        // that cost no goal its verdict should not displace the call that
-        // targets a goal which is still open.
-        let recommended_next_call = backend_diagnosis
-            .get("next_action")
-            .filter(|value| anomaly_left_goals_unjudged && value.is_object())
-            .cloned()
-            .or_else(|| first_unproved_lemma_next_call(&eva_alarms, &wp_goals))
-            .or_else(|| first_alarm_next_call(&eva_alarms))
-            .or_else(|| first_wp_goal_next_call(&wp_goals, params.function.as_deref()))
-            .unwrap_or_else(|| {
-                // An analysis the caller left out is answered by asking for it,
-                // not by reading the table it never filled. Pointing at
-                // get_wp_goals after a run that skipped WP sends the caller to
-                // a list that is empty because nothing produced it.
-                let (tool, args) = if wanted.eva && wanted.wp {
-                    ("get_wp_goals", json!({"want": ["counts"]}))
-                } else {
-                    ("check", json!({"want": ["eva", "wp"]}))
-                };
-
-                // A clean run is exactly when vacuity is worth testing, and
-                // exactly when nothing else prompts for it. check runs no smoke
-                // tests, so it cannot see a contract that proves by excluding
-                // its own branch: the goals are valid, the verdict is proved,
-                // and an over-strong requires has quietly removed the case the
-                // function exists to handle.
-                //
-                // Carried in the reason rather than by redirecting the call.
-                // Two stronger versions were tried and both were wrong: as an
-                // incomplete[] code it gated the verdict, so "proved" became
-                // unreachable and the abs-int canary went red; as a replacement
-                // tool it broke the recommendation this payload has always made
-                // on a clean run.
-                let reason = if incomplete.is_empty() {
-                    "Every goal is valid, which says the code matches the contract, not that \
-                     the contract was worth matching. check runs no vacuity tests: run_wp \
-                     {smoke: true, provers: [...]} is the only check that sees an over-strong \
-                     requires, which proves everything and silently excludes the branch it \
-                     forbids."
-                        .to_string()
-                } else {
-                    check_blocked_reason(&incomplete)
-                };
-                json!({
-                    "tool": tool,
-                    "args": args,
-                    "reason": reason,
-                })
-            });
+        let recommended_next_call = check_next_call(NextCallInputs {
+            backend_diagnosis: &backend_diagnosis,
+            anomaly_left_goals_unjudged,
+            eva_alarms: &eva_alarms,
+            wp_goals: &wp_goals,
+            incomplete: &incomplete,
+            wanted,
+            function: params.function.as_deref(),
+        });
         let verdict = if incomplete.is_empty() {
             "proved"
         } else {
@@ -3841,10 +3027,12 @@ impl FramaCMcpServer {
             || profile.provers.is_empty()
             || profile.timeout_seconds.is_none()
             || profile.functions.is_empty()
+            || profile.rte.is_none()
+            || profile.nostdinc.is_none()
         {
             return Err(McpError::invalid_params(
                 format!(
-                    "verify_profile \"{name}\" is missing functions, model, provers, or timeout_seconds, so it cannot be proof evidence"
+                    "verify_profile \"{name}\" is missing functions, model, provers, timeout_seconds, rte, or nostdinc, so it cannot be proof evidence"
                 ),
                 None,
             ));
@@ -3905,6 +3093,9 @@ impl FramaCMcpServer {
             "model": profile.model,
             "provers": profile.provers,
             "timeout_seconds": profile.timeout_seconds,
+            "rte": profile.rte,
+            "nostdinc": profile.nostdinc,
+            "isystem_paths": profile.isystem_paths,
             "reproduce": profile.reproduce,
         })))
     }
@@ -4043,7 +3234,7 @@ impl FramaCMcpServer {
             let main_state = self.main_frama_c_state.lock().await;
             let state = main_state.as_ref().ok_or_else(no_project_loaded_err)?;
             (
-                state.with_rte,
+                state.project_options.rte,
                 state.files.clone(),
                 state.wp_model_used.clone(),
             )
@@ -4085,6 +3276,12 @@ impl FramaCMcpServer {
         let cancel_epoch = self
             .wp_cancel_epoch
             .load(std::sync::atomic::Ordering::SeqCst);
+
+        // Read before any proof is scheduled. A timeout-heavy run drives the
+        // one-minute average toward saturation on its own, so a reading taken
+        // at response assembly would withdraw confidence from the very timeouts
+        // it was asked to explain. See host_load.
+        let host_load = crate::mcp::server::wpclass::host_load();
 
         // Frama-C answers a model it cannot switch to with Log.AbortFatal("wp")
         // and no further detail, which reads as though the source broke rather
@@ -4145,20 +3342,22 @@ impl FramaCMcpServer {
             state.set_wp_completed();
         }
 
-        let mut response = wp_run_response(
+        let mut response = wp_run_response(crate::mcp::server::WpRunResponse {
             tasks,
-            &params,
-            function_names.clone(),
-            "main",
+            params: &params,
+            functions: function_names.clone(),
+            scope: "main",
 
             // Guards generated here count as RTE being on for this run, which
             // is what `rte` in the config has always meant to a reader. True
             // even for a target that needed none: zero obligations is the
             // complete set for a function with no arithmetic.
-            rte_enabled || !rte_guarded.is_empty(),
-            protocol_diagnostics,
-            Some(proofread_report),
-        );
+            rte_enabled: rte_enabled || !rte_guarded.is_empty(),
+            frama_c_protocol: protocol_diagnostics,
+            proofread_report: Some(proofread_report),
+            goals: Some(wp_goals.as_slice()),
+            host_load,
+        });
 
         // "Guarded", not "generated": generation ran over these targets, which
         // is not a claim that obligations appeared for each. Kept separate from
@@ -5432,7 +4631,7 @@ impl FramaCMcpServer {
                         (
                             state.files.clone(),
                             state.project_options.clone(),
-                            state.with_rte,
+                            state.project_options.rte,
                         )
                     })
             }

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -1668,15 +1668,17 @@ pub fn profile_matches_loaded_project(
         // does can be proof evidence, which the evidence gate enforces.
         && profile.rte.is_none_or(|want| want == *rte)
 
-        // Same argument as rte: these decide which declarations the file is
-        // compiled against, so a load differing here is a different program.
-        // Unset means the profile does not speak to it, and only a profile that
-        // does can be proof evidence, which the evidence gate enforces. An
-        // empty isystem_paths is serde's default for a profile that never
-        // mentioned the field, so it has to mean "unset" here for the same
-        // reason None does beside it; a profile that constrains the list to
-        // empty is not expressible and is not worth a second spelling.
-        && (profile.isystem_paths.is_empty() || &profile.isystem_paths == isystem_paths)
+        // Compared exactly, like the three lists above it and unlike the two
+        // Option flags beside it. It was briefly loosened to treat an empty
+        // list as "unset", for symmetry with nostdinc, and that was the wrong
+        // symmetry: rte and nostdinc are Option, so they can say "unset", while
+        // a Vec cannot, and the evidence gate requires the two flags but not
+        // this list. A profile omitting it would therefore have matched a load
+        // carrying any -isystem at all, and run_wp would have labelled that run
+        // as the target's evidence under a load identity that is not the
+        // target's. Omission means the target passes no -isystem, which is what
+        // include_paths and defines have always meant here.
+        && &profile.isystem_paths == isystem_paths
         && profile.nostdinc.is_none_or(|want| want == *nostdinc)
 }
 
@@ -2234,7 +2236,11 @@ impl FramaCMcpServer {
                 return Ok(self
                     .check_reload_failed_payload(
                         &error,
-                        params.rte,
+
+                        // The resolved value, not the caller's. A profile
+                        // stating rte:false loads without RTE, and reporting
+                        // the caller's None here left the gap unsaid.
+                        Some(rte),
                         params.function.as_deref(),
                         wanted,
                         receipt_files,
@@ -2306,7 +2312,11 @@ impl FramaCMcpServer {
         };
 
         let mut incomplete = check_incomplete_items(
-            params.rte,
+            // The value this call actually loaded under, which is the caller's
+            // only when the caller gave one. A profile stating rte:false loads
+            // without RTE, and passing the caller's None here reported no
+            // RTE_DISABLED gap for a load that had RTE off.
+            Some(rte),
             &reload,
             &eva,
             &eva_alarms,

--- a/src/mcp/checkgaps.rs
+++ b/src/mcp/checkgaps.rs
@@ -40,7 +40,7 @@ pub struct NextCallInputs<'a> {
 }
 
 pub fn check_next_call(inputs: NextCallInputs<'_>) -> serde_json::Value {
-        // Ordered after "incomplete" so the fallback can name the gaps it
+    // Ordered after "incomplete" so the fallback can name the gaps it
     // found. Not every gap has an alarm or a goal to point at: an axiom
     // leaves every one of them valid, and a fallback that cannot name it
     // reads as all clear next to a verdict of incomplete.
@@ -53,13 +53,13 @@ pub fn check_next_call(inputs: NextCallInputs<'_>) -> serde_json::Value {
     // that cost no goal its verdict should not displace the call that
     // targets a goal which is still open.
     let NextCallInputs {
-    backend_diagnosis,
-    anomaly_left_goals_unjudged,
-    eva_alarms,
-    wp_goals,
-    incomplete,
-    wanted,
-    function,
+        backend_diagnosis,
+        anomaly_left_goals_unjudged,
+        eva_alarms,
+        wp_goals,
+        incomplete,
+        wanted,
+        function,
     } = inputs;
 
     backend_diagnosis
@@ -156,6 +156,7 @@ pub mod incomplete_code {
     pub const GOAL_NOT_VALID: &str = "GOAL_NOT_VALID";
     pub const PROVER_TIMEOUT: &str = "PROVER_TIMEOUT";
     pub const PROPERTY_DEAD: &str = "PROPERTY_DEAD";
+    pub const PROPERTY_VACUOUS: &str = "PROPERTY_VACUOUS";
     pub const PROPERTY_DISPROVED: &str = "PROPERTY_DISPROVED";
     pub const PROPERTY_INCONSISTENT: &str = "PROPERTY_INCONSISTENT";
     pub const LEMMA_NOT_PROVED: &str = "LEMMA_NOT_PROVED";
@@ -186,6 +187,7 @@ pub mod incomplete_code {
         GOAL_NOT_VALID,
         PROVER_TIMEOUT,
         PROPERTY_DEAD,
+        PROPERTY_VACUOUS,
         PROPERTY_DISPROVED,
         PROPERTY_INCONSISTENT,
         LEMMA_NOT_PROVED,
@@ -348,6 +350,14 @@ pub fn gap_guidance(code: &str) -> serde_json::Value {
              go. Do not strengthen the annotation: a property of unreachable code is vacuous \
              whatever it says."
         }
+        incomplete_code::PROPERTY_VACUOUS => {
+            "Frama-C discharged this property only because the path reaching it carries a \
+             contradictory hypothesis, so the proof holds over no execution. This is not dead \
+             code: the statement is reachable, and an earlier instance of the same property in \
+             the function did not prove, which is what makes the later valid status suspect. \
+             Prove that earlier instance, or find the requires that excludes the path, before \
+             reading this one as evidence."
+        }
         incomplete_code::PROPERTY_INCONSISTENT => {
             "Two emitters ruled opposite ways on this property, so the consolidated verdict cannot \
              be trusted in either direction. Find the disagreement before writing any annotation \
@@ -479,6 +489,33 @@ fn proved_goal_gap(goal: &serde_json::Value, status: &str) -> Option<serde_json:
             "property_status": field("normalized_property_status"),
         }));
     }
+    // Before the hypotheses test, and separate from the dead test above it.
+    // "valid_under_false_hypothesis" is a proof leaning on a hypothesis that
+    // cannot hold, which is neither unreachable code nor a conditional proof:
+    // property_is_dead matches only "_but_dead", and goal_is_valid_under_hypotheses
+    // matches "valid_under_hyp", so a goal in this state answered both tests
+    // false and produced no gap at all. check then read "proved" over a proof
+    // that holds over no execution. get_wp_goals already reported it, through
+    // goal_needs_failure_classification, so the two paths disagreed.
+    if status_is_vacuous(
+        goal.get("normalized_property_status")
+            .and_then(|value| value.as_str())
+            .unwrap_or_else(|| property_normalized_status(goal)),
+    ) {
+        return Some(json!({
+            "code": incomplete_code::PROPERTY_VACUOUS,
+            "reason": "WP proved this goal, but Frama-C discharged its property only under a hypothesis that cannot hold, so the proof holds over no execution.",
+            "stable_goal_id": field("stable_goal_id"),
+            "frama_c_goal_name": field("frama_c_goal_name"),
+            "goal_kind": field("goal_kind"),
+            "normalized_status": status,
+            "property_status": field("normalized_property_status"),
+
+            // Why Frama-C called it vacuous, when the property row says.
+            "vacuity_reason": field("vacuity_reason"),
+            "vacuity_dependency": field("vacuity_dependency"),
+        }));
+    }
     if goal_is_valid_under_hypotheses(goal) {
         return Some(json!({
             "code": incomplete_code::VALID_UNDER_HYP,
@@ -500,7 +537,7 @@ fn proved_goal_gap(goal: &serde_json::Value, status: &str) -> Option<serde_json:
     None
 }
 
-fn wp_goal_gaps<'a>(
+pub fn wp_goal_gaps<'a>(
     incomplete: &mut Vec<serde_json::Value>,
     eva_alarms: &'a serde_json::Value,
     wp_goals: &'a serde_json::Value,

--- a/src/mcp/checkgaps.rs
+++ b/src/mcp/checkgaps.rs
@@ -1,0 +1,940 @@
+//! What makes a check incomplete, and what to do about it.
+//!
+//! Split out of analysis.rs, which was 5,664 lines with 2,600 of free
+//! functions above one impl block that #[tool_router] pins together. This band
+//! is the part with a name: every gap code check reports, the guidance behind
+//! it, and the next call it recommends. The test side already recognized the
+//! seam, since tests/unit/check-gaps.rs came out of tests/unit/server.rs for
+//! the same reason and covers exactly this.
+//!
+//! Nothing here touches a client or a lock. It reads the payloads the tool
+//! methods assembled and answers from them alone, which is what made it
+//! separable when the rest of that file is a sequence over the live instance.
+
+use super::*;
+
+// The band this came out of. The dependency runs one way at the item level,
+// but analysis.rs also calls back into here, so both carry a glob rather than a
+// list that goes stale on the next move.
+use super::analysis::*;
+
+/// What to say when no alarm and no goal offers a next target.
+///
+/// "Nothing to target" and "nothing wrong" are different sentences, and the
+/// fallback used to write the second when it meant the first. A gap with no
+/// call behind it is the normal case for an assumption or a disabled stage.
+/// What check tells the caller to do next.
+///
+/// Its own function, against CLAUDE.md's older claim that check_payload has no
+/// independent sub-unit. Everything else in that function is a sequence over
+/// the live instance; this is a pure derivation with seven inputs and one
+/// answer, and pulling it out is what gave the ceiling somewhere to give.
+pub struct NextCallInputs<'a> {
+    pub backend_diagnosis: &'a serde_json::Value,
+    pub anomaly_left_goals_unjudged: bool,
+    pub eva_alarms: &'a serde_json::Value,
+    pub wp_goals: &'a serde_json::Value,
+    pub incomplete: &'a [serde_json::Value],
+    pub wanted: WantedAnalyses,
+    pub function: Option<&'a str>,
+}
+
+pub fn check_next_call(inputs: NextCallInputs<'_>) -> serde_json::Value {
+        // Ordered after "incomplete" so the fallback can name the gaps it
+    // found. Not every gap has an alarm or a goal to point at: an axiom
+    // leaves every one of them valid, and a fallback that cannot name it
+    // reads as all clear next to a verdict of incomplete.
+    //
+    // The backend diagnosis comes first for the same reason a timeout is
+    // read before a goal's text: reading a VC no prover ever received sends
+    // the caller to rewrite an annotation that was never judged.
+    //
+    // Gated on the same condition as the incomplete entry above: an abort
+    // that cost no goal its verdict should not displace the call that
+    // targets a goal which is still open.
+    let NextCallInputs {
+    backend_diagnosis,
+    anomaly_left_goals_unjudged,
+    eva_alarms,
+    wp_goals,
+    incomplete,
+    wanted,
+    function,
+    } = inputs;
+
+    backend_diagnosis
+        .get("next_action")
+        .filter(|value| anomaly_left_goals_unjudged && value.is_object())
+        .cloned()
+        .or_else(|| first_unproved_lemma_next_call(eva_alarms, wp_goals))
+        .or_else(|| first_alarm_next_call(eva_alarms))
+        .or_else(|| first_wp_goal_next_call(wp_goals, function))
+        .unwrap_or_else(|| {
+            // An analysis the caller left out is answered by asking for it,
+            // not by reading the table it never filled. Pointing at
+            // get_wp_goals after a run that skipped WP sends the caller to
+            // a list that is empty because nothing produced it.
+            let (tool, args) = if wanted.eva && wanted.wp {
+                ("get_wp_goals", json!({"want": ["counts"]}))
+            } else {
+                ("check", json!({"want": ["eva", "wp"]}))
+            };
+
+            // A clean run is exactly when vacuity is worth testing, and
+            // exactly when nothing else prompts for it. check runs no smoke
+            // tests, so it cannot see a contract that proves by excluding
+            // its own branch: the goals are valid, the verdict is proved,
+            // and an over-strong requires has quietly removed the case the
+            // function exists to handle.
+            //
+            // Carried in the reason rather than by redirecting the call.
+            // Two stronger versions were tried and both were wrong: as an
+            // incomplete[] code it gated the verdict, so "proved" became
+            // unreachable and the abs-int canary went red; as a replacement
+            // tool it broke the recommendation this payload has always made
+            // on a clean run.
+            let reason = if incomplete.is_empty() {
+                "Every goal is valid, which says the code matches the contract, not that \
+                 the contract was worth matching. check runs no vacuity tests: run_wp \
+                 {smoke: true, provers: [...]} is the only check that sees an over-strong \
+                 requires, which proves everything and silently excludes the branch it \
+                 forbids."
+                    .to_string()
+            } else {
+                check_blocked_reason(incomplete)
+            };
+            json!({
+                "tool": tool,
+                "args": args,
+                "reason": reason,
+            })
+        })
+}
+
+pub fn check_blocked_reason(incomplete: &[serde_json::Value]) -> String {
+    let codes = incomplete
+        .iter()
+        .filter_map(|item| item.get("code").and_then(|code| code.as_str()))
+        .collect::<Vec<_>>();
+    if codes.is_empty() {
+        return "EVA and WP did not report an immediate non-valid target.".to_string();
+    }
+    let blocking = if codes.len() == 1 {
+        "one gap still blocks"
+    } else {
+        "several gaps still block"
+    };
+    format!(
+        "No non-valid alarm or goal to target, but {blocking} a proved verdict: {}.",
+        codes.join(", ")
+    )
+}
+
+/// Every reason check can put in its incomplete array, named once.
+///
+/// These are a published vocabulary: docs/architecture.md freezes
+/// them, README tabulates them, and agents branch on them. They were thirteen
+/// string literals spread over one match and eight push sites, so nothing
+/// connected the emitters to the documents, and the set drifted twice before
+/// anyone noticed.
+///
+/// ALL is what the documents are checked against. It does not stop someone
+/// writing a bare literal at a new push site, and no cheap thing does for a
+/// string vocabulary; what it does is make the bare literal the odd one out
+/// next to its neighbours, and give the doc test something to compare that is
+/// not a grep of the source.
+///
+/// The cap sits on the module rather than on each item, so the doc test in
+/// server's test child reaches ALL without any one const being widened to the
+/// whole crate.
+pub mod incomplete_code {
+    pub const RTE_DISABLED: &str = "RTE_DISABLED";
+    pub const EVA_NOT_RUN: &str = "EVA_NOT_RUN";
+    pub const WP_NOT_RUN: &str = "WP_NOT_RUN";
+    pub const WP_STILL_RUNNING: &str = "WP_STILL_RUNNING";
+    pub const ALARM_NOT_VALID: &str = "ALARM_NOT_VALID";
+    pub const GOAL_NOT_VALID: &str = "GOAL_NOT_VALID";
+    pub const PROVER_TIMEOUT: &str = "PROVER_TIMEOUT";
+    pub const PROPERTY_DEAD: &str = "PROPERTY_DEAD";
+    pub const PROPERTY_DISPROVED: &str = "PROPERTY_DISPROVED";
+    pub const PROPERTY_INCONSISTENT: &str = "PROPERTY_INCONSISTENT";
+    pub const LEMMA_NOT_PROVED: &str = "LEMMA_NOT_PROVED";
+    pub const ASSUMED_VALID: &str = "ASSUMED_VALID";
+    pub const ASSUMED_CALLEE_CONTRACT: &str = "ASSUMED_CALLEE_CONTRACT";
+    pub const UNCONSTRAINED_ASSIGNS: &str = "UNCONSTRAINED_ASSIGNS";
+    pub const RESULT_UNCONSTRAINED: &str = "RESULT_UNCONSTRAINED";
+    pub const UNPROVED_ASSUMPTION: &str = "UNPROVED_ASSUMPTION";
+    pub const VALID_UNDER_HYP: &str = "VALID_UNDER_HYP";
+    pub const EVA_NOT_REQUESTED: &str = "EVA_NOT_REQUESTED";
+    pub const WP_NOT_REQUESTED: &str = "WP_NOT_REQUESTED";
+    pub const WP_BACKEND_ANOMALY: &str = "WP_BACKEND_ANOMALY";
+    pub const AST_ASM_CLOBBER: &str = "AST_ASM_CLOBBER";
+    pub const AST_UNKNOWN_ATTRIBUTE: &str = "AST_UNKNOWN_ATTRIBUTE";
+    pub const AST_UNCLASSIFIED_WARNING: &str = "AST_UNCLASSIFIED_WARNING";
+    pub const AST_PARSE_DIAGNOSTICS_UNAVAILABLE: &str = "AST_PARSE_DIAGNOSTICS_UNAVAILABLE";
+
+    // Only the doc comparison reads the list as a list; the emit sites name
+    // codes one at a time. It used to be cfg(test) gated, which stopped meaning
+    // anything when the tests moved out of this crate: an integration test
+    // links the library built without that cfg.
+    pub const ALL: &[&str] = &[
+        RTE_DISABLED,
+        EVA_NOT_RUN,
+        WP_NOT_RUN,
+        WP_STILL_RUNNING,
+        ALARM_NOT_VALID,
+        GOAL_NOT_VALID,
+        PROVER_TIMEOUT,
+        PROPERTY_DEAD,
+        PROPERTY_DISPROVED,
+        PROPERTY_INCONSISTENT,
+        LEMMA_NOT_PROVED,
+        ASSUMED_VALID,
+        ASSUMED_CALLEE_CONTRACT,
+        UNCONSTRAINED_ASSIGNS,
+        RESULT_UNCONSTRAINED,
+        UNPROVED_ASSUMPTION,
+        VALID_UNDER_HYP,
+        EVA_NOT_REQUESTED,
+        WP_NOT_REQUESTED,
+        WP_BACKEND_ANOMALY,
+        AST_ASM_CLOBBER,
+        AST_UNKNOWN_ATTRIBUTE,
+        AST_UNCLASSIFIED_WARNING,
+        AST_PARSE_DIAGNOSTICS_UNAVAILABLE,
+    ];
+}
+
+/// The schema string on a check payload.
+///
+/// v2 allows new fields and new incomplete codes. Removing or renaming either
+/// needs v3, and a consumer that does not recognise the string should stop
+/// rather than guess.
+///
+/// v2 because "want" made a null analysis mean two things. Under v1 a null
+/// "wp" said the reload failed, and a consumer could read it as a breakage;
+/// now it can also say the caller never asked for WP. The pair of codes tells
+/// them apart, but the field's meaning moved, and that is the change v1's own
+/// rule sends to a new version rather than treating as additive.
+pub const CHECK_SCHEMA: &str = "frama-c-mcp.check.v2";
+
+/// Which analyses one call to check runs.
+///
+/// Two flags rather than the list of wants it is built from, because every
+/// reader asks about one analysis at a time. A list makes each of those a
+/// lookup, and a lookup answers "not wanted" to a misspelled name.
+#[derive(Clone, Copy)]
+pub struct WantedAnalyses {
+    pub eva: bool,
+    pub wp: bool,
+}
+
+impl WantedAnalyses {
+    pub const BOTH: Self = Self {
+        eva: true,
+        wp: true,
+    };
+
+    /// Both unless the caller narrowed it. An empty list is read the same way
+    /// as none at all: asking for nothing is a request nobody means, and
+    /// answering it with a payload that proves nothing would be worse than
+    /// answering the whole question.
+    pub fn from_want(want: Option<&[CheckAnalysis]>) -> Self {
+        match want {
+            None | Some([]) => Self::BOTH,
+            Some(wants) => Self {
+                eva: wants.contains(&CheckAnalysis::Eva),
+                wp: wants.contains(&CheckAnalysis::Wp),
+            },
+        }
+    }
+}
+
+/// Gaps that follow from what the caller asked for rather than from what ran.
+fn unrequested_analysis_gaps(
+    incomplete: &mut Vec<serde_json::Value>,
+    rte: Option<bool>,
+    wanted: WantedAnalyses,
+) {
+    // An analysis nobody asked for is still an analysis that did not run, and
+    // this array exists so that silence and clean are different answers. A
+    // caller who skipped WP knows they skipped it; the point is that the
+    // verdict cannot read "proved" on the strength of half a check.
+    if !wanted.eva {
+        incomplete.push(json!({
+            "code": incomplete_code::EVA_NOT_REQUESTED,
+            "reason": "check did not run EVA, so nothing here excludes the alarms it finds.",
+        }));
+    }
+    if !wanted.wp {
+        incomplete.push(json!({
+            "code": incomplete_code::WP_NOT_REQUESTED,
+            "reason": "check did not run WP, so nothing here is a proof.",
+        }));
+    }
+    if rte == Some(false) {
+        incomplete.push(json!({
+            "code": incomplete_code::RTE_DISABLED,
+            "reason": "check ran without RTE annotations, so absence of alarms/goals excludes implicit runtime-error checks.",
+        }));
+    }
+}
+
+/// Gaps left by a step that failed, was skipped, or had not finished.
+fn step_failure_gaps(
+    incomplete: &mut Vec<serde_json::Value>,
+    reload: &serde_json::Value,
+    eva: &serde_json::Value,
+    eva_alarms: &serde_json::Value,
+    wp: &serde_json::Value,
+    wp_goals: &serde_json::Value,
+    wanted: WantedAnalyses,
+) {
+    // Both blocks are guarded, because a skipped analysis leaves its fields
+    // null and null is how a failed one looks too.
+    if wanted.eva
+        && (check_step_failed(reload) || check_step_failed(eva) || check_step_failed(eva_alarms))
+    {
+        incomplete.push(json!({
+            "code": incomplete_code::EVA_NOT_RUN,
+            "reason": "EVA did not complete, so eva_alarms is not proof of no alarms.",
+            "error": eva.get("error").or_else(|| eva_alarms.get("error")).or_else(|| reload.get("error")).cloned().unwrap_or_else(|| json!(null)),
+        }));
+    }
+    if wanted.wp {
+        if check_step_failed(reload) || check_step_failed(wp) || check_step_failed(wp_goals) {
+            incomplete.push(json!({
+                "code": incomplete_code::WP_NOT_RUN,
+                "reason": "WP did not complete, so wp_goals is not proof of no goals.",
+                "error": wp.get("error").or_else(|| wp_goals.get("error")).or_else(|| reload.get("error")).cloned().unwrap_or_else(|| json!(null)),
+            }));
+        } else if wp.get("drained").and_then(|value| value.as_bool()) != Some(true) {
+            // A goal WP has not finished is a goal "fetchGoals" may not list at
+            // all, so the absence of a failure here proves nothing about it.
+            incomplete.push(json!({
+                "code": incomplete_code::WP_STILL_RUNNING,
+                "reason": "WP was still working when its goals were read, so wp_goals may be missing goals entirely.",
+                "todo": wp.get("todo").cloned().unwrap_or_else(|| json!(null)),
+                "active": wp.get("active").cloned().unwrap_or_else(|| json!(null)),
+            }));
+        }
+    }
+}
+
+/// The edit that closes a gap, for the codes where the shape is known.
+///
+/// Separate from `reason`, which says what is missing. A reader who has just
+/// been told a lemma is undischarged still has to know that no SMT prover will
+/// find the induction, and that waiting longer is not the fix. Codes whose
+/// remedy depends on the program say nothing here rather than guess.
+pub fn gap_guidance(code: &str) -> serde_json::Value {
+    let guidance = match code {
+        incomplete_code::LEMMA_NOT_PROVED => {
+            "An SMT prover does not do induction, so a lemma over a recursive logic function or an \
+             inductive predicate will not close by raising the timeout. Reach for the induction \
+             tactic instead, which WP registers as Wp.induction and drives through -wp-tactic, \
+             -wp-prover tip and -wp-script; or split the lemma into smaller ones the prover can \
+             chain. Until one of those lands, every goal that cites it is valid only under it."
+        }
+        incomplete_code::ASSUMED_VALID => {
+            "This property is recorded valid by assumption, not by proof. If the assumption is \
+             deliberate, keep the axiom and say so where a reader will see it; if it is not, \
+             remove the axiom and prove the property, because WP uses it as a hypothesis \
+             everywhere without ever checking it."
+        }
+        incomplete_code::PROPERTY_DEAD => {
+            "EVA proved this code unreachable, so proving anything about it constrains no run. \
+             Either the guard that makes it unreachable is wrong, or the code is dead and should \
+             go. Do not strengthen the annotation: a property of unreachable code is vacuous \
+             whatever it says."
+        }
+        incomplete_code::PROPERTY_INCONSISTENT => {
+            "Two emitters ruled opposite ways on this property, so the consolidated verdict cannot \
+             be trusted in either direction. Find the disagreement before writing any annotation \
+             that rests on it; a contract built on an inconsistent property proves nothing."
+        }
+        _ => return serde_json::Value::Null,
+    };
+    json!(guidance)
+}
+
+/// Gaps carried by rows of the property table itself, which is where EVA
+/// alarms and every consolidated verdict live.
+fn property_row_gaps(
+    incomplete: &mut Vec<serde_json::Value>,
+    eva_alarms: &serde_json::Value,
+    wp_goals: &serde_json::Value,
+) {
+    // An undischarged runtime-error alarm is as much of a gap as a non-valid WP
+    // goal, and `check` used to report "proved" over one.
+    //
+    // Only RTE assertions count. The alarms want returns the whole kernel
+    // property table, so contract clauses (requires, ensures, behavior) arrive
+    // in the same array. Those are judged by the WP goal loop below, and
+    // flagging them here would both duplicate that and report the not yet
+    // proved state of a snapshot taken before WP ran.
+    //
+    // The status filter matches first_alarm_next_call through
+    // alarm_is_undischarged, so anything reported here also gets a recommended
+    // next call. That excludes `noresult`, which is Frama-C's never_tried
+    // rather than a failure.
+    if let Some(alarms) = eva_alarms.as_array() {
+        for alarm in alarms {
+            // Both findings describe the same property row, so they carry the
+            // same fields and only the code and reason differ.
+            let (code, reason) = if property_is_inconsistent(alarm) {
+                (
+                    incomplete_code::PROPERTY_INCONSISTENT,
+                    "Frama-C consolidated contradictory statuses for this property, so the verdict cannot be trusted in either direction.",
+                )
+            } else if alarm_is_undischarged(alarm) {
+                (
+                    incomplete_code::ALARM_NOT_VALID,
+                    "EVA reported a runtime-error alarm it could not discharge.",
+                )
+            } else if property_is_disproved_reachability(alarm) {
+                (
+                    incomplete_code::PROPERTY_DEAD,
+                    "EVA proved this code unreachable, so nothing proved about it constrains a run.",
+                )
+            } else if property_is_unproved_lemma(alarm, wp_goals) {
+                (
+                    incomplete_code::LEMMA_NOT_PROVED,
+                    "WP assumes every lemma while discharging other goals, so an undischarged one makes the proofs around it worthless.",
+                )
+            } else if property_is_disproved(alarm, wp_goals) {
+                (
+                    incomplete_code::PROPERTY_DISPROVED,
+                    "Frama-C disproved this property, and WP emits no goal for a property that already carries a status, so nothing downstream reports it.",
+                )
+            } else if property_is_assumed_valid(alarm) {
+                (
+                    incomplete_code::ASSUMED_VALID,
+                    "Frama-C recorded this property as valid by external assumption rather than by proof. WP uses it as a hypothesis everywhere without ever checking it.",
+                )
+            } else {
+                continue;
+            };
+            incomplete.push(json!({
+                "code": code,
+                "reason": reason,
+                "property": value_marker(alarm).map(|m| json!(m)).unwrap_or_else(|| json!(null)),
+                "descr": alarm.get("descr").cloned().unwrap_or_else(|| json!(null)),
+                "source_location": alarm.get("source_location").cloned().unwrap_or_else(|| json!(null)),
+                "status": property_normalized_status(alarm),
+            }));
+        }
+    }
+}
+
+/// The guidance for the codes an incomplete[] actually carries, keyed by code.
+///
+/// gap_guidance is a pure function of the code, so every entry sharing a code
+/// carried a byte-identical paragraph. Measured on a 1,144-line file: 110,509
+/// bytes across 418 entries and two distinct strings, so 110,240 of it was one
+/// of two paragraphs repeated. The array stays complete, which is what the
+/// fail-loud rule is about; only the repetition goes.
+///
+/// A map rather than one entry in N: a reader wanting the advice for an entry
+/// looks up its own "code", which it already has.
+pub fn incomplete_guidance(incomplete: &[serde_json::Value]) -> serde_json::Value {
+    let mut guidance = serde_json::Map::new();
+    for entry in incomplete {
+        let Some(code) = entry.get("code").and_then(|code| code.as_str()) else {
+            continue;
+        };
+        if guidance.contains_key(code) {
+            continue;
+        }
+        let text = gap_guidance(code);
+        if !text.is_null() {
+            guidance.insert(code.to_string(), text);
+        }
+    }
+    serde_json::Value::Object(guidance)
+}
+
+/// Gaps carried by WP's own goals.
+///
+/// Returns the goals this pass judged, keyed by WP's obligation id, because
+/// the proofread findings below can only be attributed to a goal that was
+/// judged here.
+/// The gap a goal WP proved can still leave, or None when it leaves none.
+///
+/// Reaching this at all means the property verdict disagreed with the goal,
+/// since a property that consolidated to valid was skipped before the call.
+/// Dead code is one way; resting on an unestablished hypothesis is the other,
+/// and a goal in that second arm used to match neither test and go unreported
+/// with the verdict reading proved over it.
+fn proved_goal_gap(goal: &serde_json::Value, status: &str) -> Option<serde_json::Value> {
+    let field = |name: &str| goal.get(name).cloned().unwrap_or_else(|| json!(null));
+    if property_is_dead(goal) {
+        return Some(json!({
+            "code": incomplete_code::PROPERTY_DEAD,
+            "reason": "WP proved this goal, but its property sits in code EVA proved unreachable.",
+            "stable_goal_id": field("stable_goal_id"),
+            "frama_c_goal_name": field("frama_c_goal_name"),
+            "goal_kind": field("goal_kind"),
+            "normalized_status": status,
+            "property_status": field("normalized_property_status"),
+        }));
+    }
+    if goal_is_valid_under_hypotheses(goal) {
+        return Some(json!({
+            "code": incomplete_code::VALID_UNDER_HYP,
+            "reason": "WP proved this goal, but Frama-C consolidated its property as valid only under hypotheses that are not themselves established.",
+            "stable_goal_id": field("stable_goal_id"),
+            "frama_c_goal_name": field("frama_c_goal_name"),
+            "goal_kind": field("goal_kind"),
+            "normalized_status": status,
+            "property_status": field("normalized_property_status"),
+
+            // Which hypotheses, when the goal carries them.
+            // enrich_goal_with_property_status resolves "deps" against the
+            // property table, and naming them is the difference between this
+            // finding and the guess the unproved-assumption finding has to
+            // make.
+            "hypotheses": field("hypotheses"),
+        }));
+    }
+    None
+}
+
+fn wp_goal_gaps<'a>(
+    incomplete: &mut Vec<serde_json::Value>,
+    eva_alarms: &'a serde_json::Value,
+    wp_goals: &'a serde_json::Value,
+) -> BTreeMap<&'a str, &'a serde_json::Value> {
+    // Lemma goals are reported once, as LEMMA_NOT_PROVED, which says the thing
+    // that matters: WP assumed it everywhere. A second GOAL_NOT_VALID for the
+    // same obligation is noise.
+    let lemma_markers: HashSet<&str> = eva_alarms
+        .as_array()
+        .map(|alarms| {
+            alarms
+                .iter()
+                .filter(|alarm| alarm.get("kind").and_then(|value| value.as_str()) == Some("lemma"))
+                .filter_map(value_marker)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Which goals the loop below actually judged, keyed by WP's own obligation
+    // id and carrying the identity the loop reported them under.
+    //
+    // Keyed on "wpo" rather than "stable_goal_id" because the two arrays reach
+    // here by different routes. wp_goals is enriched against the property table
+    // and so carries source_location and predicate, both of which
+    // stable_goal_id_for digests; the proofread report is built from the raw
+    // fetchGoals array, which has neither, so the same goal digests to two
+    // different ids. Matching on those ids matched nothing at all. "wpo" is
+    // assigned by WP itself and is present before any enrichment.
+    let mut judged_goals: BTreeMap<&str, &serde_json::Value> = BTreeMap::new();
+
+    if let Some(goals) = wp_goals.as_array() {
+        for goal in goals {
+            if check_goal_counts_as_progress(goal) {
+                continue;
+            }
+            if goal
+                .get("property")
+                .or_else(|| goal.get("property_marker"))
+                .and_then(|value| value.as_str())
+                .is_some_and(|marker| lemma_markers.contains(marker))
+            {
+                continue;
+            }
+
+            // Recorded past every skip above, so the set cannot disagree with
+            // what this loop judged. Built beside the loop instead, it already
+            // diverged: the lemma skip is here and was not there.
+            if let Some(wpo) = goal
+                .get("wpo_id")
+                .or_else(|| goal.get("wpo"))
+                .and_then(|value| value.as_str())
+            {
+                judged_goals.insert(wpo, goal);
+            }
+
+            // own_status, not the consolidated one: the property verdict is
+            // what the skip above already judged, and letting it answer here is
+            // the bug this branch's comment records.
+            let status = own_status(goal).unwrap_or("unknown");
+
+            // A goal WP proved is not a failing goal, whatever the consolidated
+            // property says, so GOAL_NOT_VALID would be the wrong sentence for
+            // anything in here. check_goal_counts_as_progress reads
+            // counts_as_progress, which enrich_goal_with_property_status
+            // overwrites with the property verdict, so a valid goal attached to
+            // a dead property arrived here as GOAL_NOT_VALID. On
+            // abs-int-buggy.c that produced all three findings while the real
+            // overflow was reported nowhere.
+            //
+            // Reaching this branch at all means the property verdict disagreed
+            // with the goal, since a property that consolidated to valid would
+            // have been skipped above. Dead code is one way; resting on an
+            // unestablished hypothesis is the other, and a goal in that second
+            // arm used to match neither test and go unreported, with the
+            // verdict reading proved over it.
+            if is_proved(status) {
+                incomplete.extend(proved_goal_gap(goal, status));
+                continue;
+            }
+            incomplete.push(json!({
+                "code": incomplete_code::GOAL_NOT_VALID,
+                "reason": "WP has a non-valid goal.",
+                "stable_goal_id": goal.get("stable_goal_id").cloned().unwrap_or_else(|| json!(null)),
+                "frama_c_goal_name": goal.get("frama_c_goal_name").cloned().unwrap_or_else(|| json!(null)),
+                "goal_kind": goal.get("goal_kind").cloned().unwrap_or_else(|| json!(null)),
+                "normalized_status": status,
+            }));
+            if status.eq_ignore_ascii_case("timeout") {
+                incomplete.push(json!({
+                    "code": incomplete_code::PROVER_TIMEOUT,
+                    "reason": "A WP prover timed out on this goal.",
+                    "stable_goal_id": goal.get("stable_goal_id").cloned().unwrap_or_else(|| json!(null)),
+                    "frama_c_goal_name": goal.get("frama_c_goal_name").cloned().unwrap_or_else(|| json!(null)),
+                    "goal_kind": goal.get("goal_kind").cloned().unwrap_or_else(|| json!(null)),
+                    "normalized_status": status,
+                }));
+            }
+        }
+    }
+    judged_goals
+}
+
+/// Gaps that only the proofread pass sees: an assumption WP took on faith, a
+/// contract that constrains nothing it writes, a callee contract believed
+/// rather than proved.
+fn proofread_finding_gaps(
+    incomplete: &mut Vec<serde_json::Value>,
+    wp: &serde_json::Value,
+    judged_goals: &BTreeMap<&str, &serde_json::Value>,
+) {
+    if let Some(findings) = wp
+        .get("proofread_report")
+        .and_then(|report| report.get("findings"))
+        .and_then(|findings| findings.as_array())
+    {
+        for finding in findings {
+            let category = finding.get("category").and_then(|value| value.as_str());
+            if category == Some("unproved_assumption") {
+                // A goal the loop above did not judge is out of scope, or had
+                // its property consolidated to valid by something else. Either
+                // way GOAL_NOT_VALID already speaks for everything in scope, so
+                // dropping it costs no gap report and keeps the verdict honest.
+                let Some(judged) = finding
+                    .get("wpo")
+                    .and_then(|value| value.as_str())
+                    .and_then(|wpo| judged_goals.get(wpo))
+                else {
+                    continue;
+                };
+                incomplete.push(json!({
+                    "code": incomplete_code::UNPROVED_ASSUMPTION,
+                    "reason": finding.get("why_problem").cloned().unwrap_or_else(|| json!(
+                        "WP assumes an unproved assertion or postcondition, so a goal reported valid may rest on it."
+                    )),
+                    "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
+
+                    // Taken from the goal the loop judged, not from the
+                    // finding. The same goal is also reported as
+                    // GOAL_NOT_VALID, and the name alone does not say which
+                    // one, since Frama-C names every unnamed assertion in a
+                    // function "Assertion". Pairing the two is the whole point
+                    // of carrying an id, and the finding's own id is digested
+                    // from the raw goal, so it never equals the one
+                    // GOAL_NOT_VALID reports.
+                    "stable_goal_id": judged.get("stable_goal_id").cloned().unwrap_or_else(|| json!(null)),
+                    "frama_c_goal_name": finding.get("trigger").cloned().unwrap_or_else(|| json!(null)),
+                    "goal_kind": finding.get("clause_or_goal_kind").cloned().unwrap_or_else(|| json!(null)),
+                }));
+                continue;
+            }
+            if category == Some("result_unconstrained") {
+                // Completeness, like unconstrained_assigns: every goal can be
+                // valid while this is reported, because what it names is a
+                // contract that permits outcomes it never explains.
+                incomplete.push(json!({
+                    "code": incomplete_code::RESULT_UNCONSTRAINED,
+                    "reason": finding.get("message").cloned().unwrap_or_else(|| json!(
+                        "The contract bounds the result without determining it."
+                    )),
+                    "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
+                    "result_range": finding.get("result_range").cloned().unwrap_or_else(|| json!(null)),
+                    "undetermined_results": finding.get("undetermined_results").cloned().unwrap_or_else(|| json!(null)),
+                }));
+                continue;
+            }
+            if category == Some("unconstrained_assigns") {
+                // Every goal can be valid while this is reported: it says the
+                // contract left a written location free, so the proof covers
+                // less than its goal count reads as. Landing here makes the
+                // verdict "incomplete", which is the point, since a run whose
+                // goals are all valid is exactly the run that would otherwise
+                // read "proved" over a contract that establishes nothing about
+                // what it wrote.
+                incomplete.push(json!({
+                    "code": incomplete_code::UNCONSTRAINED_ASSIGNS,
+                    "reason": finding.get("message").cloned().unwrap_or_else(|| json!(
+                        "The contract assigns a location no postcondition constrains."
+                    )),
+                    "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
+                    "assigns_target": finding.get("assigns_target").cloned().unwrap_or_else(|| json!(null)),
+                }));
+                continue;
+            }
+            if category != Some("assumed_callee_contract") {
+                continue;
+            }
+            incomplete.push(json!({
+                "code": incomplete_code::ASSUMED_CALLEE_CONTRACT,
+                "reason": finding.get("message").cloned().unwrap_or_else(|| json!("WP relied on a direct callee contract with no finite assigns clause.")),
+                "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
+                "callee": finding.get("callee").cloned().unwrap_or_else(|| json!(null)),
+                "source_location": finding.get("source_location").cloned().unwrap_or_else(|| json!(null)),
+            }));
+        }
+    }
+}
+
+/// What a variant varied that could change the analysed code. `model` is not
+/// in it: no WP option reaches the AST.
+type AstInputs = (Vec<String>, Option<String>);
+
+/// Per AST digest, the variants that produced it, one entry per distinct set of
+/// AST-relevant inputs. A second entry under one digest is the finding: two
+/// configurations asked for different code and got the same. Repeats within a
+/// group are a model sweep and are not.
+pub(crate) type DigestGroups = std::collections::HashMap<String, Vec<(String, AstInputs)>>;
+
+/// The verdict over a finished set of variant entries.
+///
+/// Free-standing so the decision can be tested without a Frama-C instance: the
+/// case that matters most is the one no integration test can stage, a run where
+/// every variant proved and no digest was ever established.
+/// Take "label", or the first "label#n" nobody has taken, and record it.
+///
+/// Looped, not suffixed once: a caller who passes "a" twice and also passes
+/// "a#1" would otherwise get two variants called "a#1", and duplicate_ast
+/// names a label, so it would point at whichever of them landed first.
+pub(crate) fn claim_label(
+    taken: &mut std::collections::HashSet<String>,
+    label: String,
+    from: usize,
+) -> String {
+    if taken.insert(label.clone()) {
+        return label;
+    }
+    (from..)
+        .map(|suffix| format!("{label}#{suffix}"))
+        .find(|candidate| taken.insert(candidate.clone()))
+        .unwrap_or(label)
+}
+
+pub fn check_variants_summary(results: Vec<serde_json::Value>) -> serde_json::Value {
+    let digest_of = |entry: &serde_json::Value| {
+        entry
+            .get("ast_digest")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+    };
+
+    let duplicate_count = results
+        .iter()
+        .filter(|entry| entry.get("duplicate_ast").is_some())
+        .count();
+    let all_proved = results
+        .iter()
+        .all(|entry| entry.get("verdict").and_then(|v| v.as_str()) == Some("proved"));
+    let distinct_asts = results
+        .iter()
+        .filter_map(digest_of)
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+
+    // A digest that could not be established compares equal to nothing, so a
+    // variant carrying one was never compared to anything. Counted and
+    // reported, because the alternative is the failure this tool exists to
+    // catch, one level up: with no digests at all the summary would read
+    // distinct_asts 0, duplicate_ast_count 0, verdict proved, which is
+    // indistinguishable from a matrix that really was checked and really was
+    // clean. A comparison that did not happen must not read as one that
+    // happened and found nothing.
+    let unestablished = results
+        .iter()
+        .filter(|entry| digest_of(entry).is_none())
+        .count();
+
+    let reason = if duplicate_count > 0 {
+        json!(
+            "Two or more variants asked for different code and analysed byte-identical \
+               ASTs, so they are one configuration checked twice rather than several \
+               checked once. Equal goal counts cannot show this; the digests can. \
+               Variants that differ only in the WP model are not counted here: no proof \
+               option changes the AST, so sharing one is expected."
+        )
+    } else if unestablished > 0 {
+        json!(
+            "At least one variant has no AST digest, so it was compared to nothing and this \
+               run cannot say whether the configurations differ. Read \
+               proof_receipt.subject.ast_digest_unavailable_reason on that variant: the usual \
+               causes are the ast-utils plug-in not being installed and printSource outrunning \
+               its budget on a large project."
+        )
+    } else {
+        serde_json::Value::Null
+    };
+
+    json!({
+        "schema": "frama-c-mcp.check-variants.v1",
+
+        // Not "proved" unless every variant proved AND every pair was actually
+        // comparable. Both gaps mean the same thing: the question this tool was
+        // asked has not been answered.
+        "verdict": if duplicate_count == 0 && unestablished == 0 && all_proved {
+            "proved"
+        } else {
+            "incomplete"
+        },
+        "variant_count": results.len(),
+        "distinct_asts": distinct_asts,
+        "duplicate_ast_count": duplicate_count,
+        "ast_digest_unavailable_count": unestablished,
+        "reason": reason,
+        "variants": results,
+    })
+}
+
+pub fn check_incomplete_items(
+    rte: Option<bool>,
+    reload: &serde_json::Value,
+    eva: &serde_json::Value,
+    eva_alarms: &serde_json::Value,
+    wp: &serde_json::Value,
+    wp_goals: &serde_json::Value,
+    wanted: WantedAnalyses,
+) -> Vec<serde_json::Value> {
+    let mut incomplete = Vec::new();
+    ast_diagnostic_gaps(&mut incomplete, reload, AST_WARNING_ALLOWLIST);
+    unrequested_analysis_gaps(&mut incomplete, rte, wanted);
+    step_failure_gaps(
+        &mut incomplete,
+        reload,
+        eva,
+        eva_alarms,
+        wp,
+        wp_goals,
+        wanted,
+    );
+    property_row_gaps(&mut incomplete, eva_alarms, wp_goals);
+    let judged_goals = wp_goal_gaps(&mut incomplete, eva_alarms, wp_goals);
+    proofread_finding_gaps(&mut incomplete, wp, &judged_goals);
+    incomplete
+}
+
+/// Warning categories this server has read and declared benign, with the
+/// reason it is willing to say so. Empty on purpose: silence about a category
+/// nobody has looked at would be this server deciding a warning is harmless
+/// without saying so. A row leaves the aggregate below and goes nowhere else.
+pub const AST_WARNING_ALLOWLIST: &[(&str, &str)] = &[];
+
+/// The code and reason a category becomes, for the two the front end drops
+/// soundness with. The spellings come from the module that reads them off the
+/// log, so the classifier and the zero rows cannot disagree about what a
+/// category is called.
+fn ast_soundness_reason(category: &str) -> Option<(&'static str, &'static str)> {
+    match category {
+        project::ASM_CLOBBER => Some((
+            incomplete_code::AST_ASM_CLOBBER,
+            "Frama-C assumed inline assembly has no effects beyond its operands, so the analyzed statement is weaker than the compiled one.",
+        )),
+        project::ATTRS_UNKNOWN => Some((
+            incomplete_code::AST_UNKNOWN_ATTRIBUTE,
+            "Frama-C ignored an unknown attribute, so the analyzed declaration differs from the source.",
+        )),
+        _ => None,
+    }
+}
+
+/// What the parse of the loaded files cost, read off the reload payload.
+///
+/// The two soundness classes get a code each; everything else that nobody has
+/// classified or allowlisted shares one aggregate entry, because a payload
+/// carrying one entry per category is unbounded in the size of the program.
+///
+/// The allowlist is a parameter rather than a read of the const below, so a
+/// test can prove that a row removes its category from the aggregate and
+/// changes nothing else. A guard over an empty const proves neither.
+pub fn ast_diagnostic_gaps(
+    incomplete: &mut Vec<serde_json::Value>,
+    reload: &serde_json::Value,
+    allowlist: &[(&str, &str)],
+) {
+    let diagnostics = &reload["ast_reload_health"]["parse_diagnostics"];
+
+    // No completeness flag on any of this, and that is a property of how the
+    // record is produced rather than an omission. It is always a process's boot
+    // parse, because ensure_main_spawned respawns rather than hand back a
+    // reparse, and a boot parse can neither miss a warn-once category nor pick
+    // up a concurrent call's output. So a zero here is evidence of absence,
+    // which is what lets the zero-count branch below skip a category instead of
+    // having to hedge it, and it is what keeps two checks of one session
+    // reporting the same codes: an entry that appeared only on the second would
+    // move proof_receipt.sha256, since the receipt digests incomplete. A record
+    // that says why it is empty is a finding rather than silence. Reading it as
+    // a clean parse would let check answer "proved" on the one shape where
+    // nothing established that the analyzed program is the compiled one, which
+    // is the claim these codes exist to make.
+    if let Some(reason) = diagnostics["unavailable"].as_str() {
+        incomplete.push(json!({
+            "code": incomplete_code::AST_PARSE_DIAGNOSTICS_UNAVAILABLE,
+            "reason": "This server has no record of what Frama-C's front end dropped while parsing, so nothing here says the analyzed program is the compiled one.",
+            "detail": reason,
+        }));
+        return;
+    }
+
+    let Some(categories) = diagnostics["categories"].as_object() else {
+        return;
+    };
+
+    let mut unclassified = serde_json::Map::new();
+    for (category, record) in categories {
+        if record["count"].as_u64().unwrap_or(0) == 0 {
+            continue;
+        }
+        if let Some((code, reason)) = ast_soundness_reason(category) {
+            incomplete.push(json!({
+                "code": code,
+                "reason": reason,
+                "category": category,
+                "count": record["count"],
+                "count_unit": record["count_unit"],
+                "locations": record["locations"],
+                "locations_omitted": record["locations_omitted"],
+            }));
+            continue;
+        }
+
+        // A classified category left the loop above, so the only thing that
+        // keeps one out of the aggregate here is a row saying why its silence
+        // is deliberate.
+        if !allowlist.iter().any(|(allowed, _)| allowed == category) {
+            // The whole record, not the bare count. One entry is what keeps the
+            // payload bounded in the number of categories; dropping the unit
+            // and the capped sample inside it would leave a caller a number it
+            // cannot interpret and a warning it cannot find, and buys nothing,
+            // since each sample is already capped.
+            unclassified.insert(category.clone(), record.clone());
+        }
+    }
+
+    if !unclassified.is_empty() {
+        incomplete.push(json!({
+            "code": incomplete_code::AST_UNCLASSIFIED_WARNING,
+            "reason": "Frama-C emitted parse warnings in categories this server has not classified, so their effect on the analyzed program is unknown.",
+            "categories": unclassified,
+        }));
+    }
+}

--- a/src/mcp/conclusions.rs
+++ b/src/mcp/conclusions.rs
@@ -81,7 +81,7 @@ pub fn profile_evidence_error(
         // whichever setting happened to match it.
         let (Some(rte), Some(nostdinc)) = (profile.rte, profile.nostdinc) else {
             return Some(format!(
-                "verify_profile \"{name}\" does not state rte or nostdinc, so a receipt cannot be checked against it"
+                "verify_profile \"{name}\" must state both rte and nostdinc for a receipt to be checked against it"
             ));
         };
 

--- a/src/mcp/conclusions.rs
+++ b/src/mcp/conclusions.rs
@@ -74,6 +74,17 @@ pub fn profile_evidence_error(
         ));
     }
     if let Some(receipt) = receipt {
+        // Stated, never defaulted. run_wp refuses a profile that leaves either
+        // unset, so accepting one here would let a conclusion rest on evidence
+        // that same profile could not have produced: the comparison below would
+        // run against an invented "false" and pass for a receipt made under
+        // whichever setting happened to match it.
+        let (Some(rte), Some(nostdinc)) = (profile.rte, profile.nostdinc) else {
+            return Some(format!(
+                "verify_profile \"{name}\" does not state rte or nostdinc, so a receipt cannot be checked against it"
+            ));
+        };
+
         // Built through the same spelling the receipt writes, so a field added
         // to the identity reaches this comparison rather than silently making
         // every receipt look different from every target.
@@ -83,6 +94,9 @@ pub fn profile_evidence_error(
             force_includes: profile.force_includes.clone(),
             machdep: profile.machdep.clone(),
             compilation_database: None,
+            rte,
+            isystem_paths: profile.isystem_paths.clone(),
+            nostdinc,
         });
         if receipt.pointer("/subject/project_load") != Some(&expected_load) {
             return Some(format!(

--- a/src/mcp/coverage.rs
+++ b/src/mcp/coverage.rs
@@ -539,10 +539,11 @@ pub fn proof_coverage_report(
             );
             *by_status.entry(status.clone()).or_default() += 1;
             if status == "valid" {
-                let replayed = goal
-                    .get("from_cache")
-                    .and_then(serde_json::Value::as_bool)
-                    .unwrap_or(false);
+                // Through the accessor, which falls back to the summary where
+                // the lifted field is absent. Reading the key alone called such
+                // a goal freshly proved, which is the flattering direction for
+                // a coverage number.
+                let replayed = crate::mcp::server::wpclass::goal_is_from_cache(goal);
                 valid_goals += 1;
                 cached_valid_goals += usize::from(replayed);
                 fresh_valid_goals += usize::from(!replayed);

--- a/src/mcp/eacsl.rs
+++ b/src/mcp/eacsl.rs
@@ -128,15 +128,28 @@ fn compile_args(
     ];
 
     // -E is what Frama-C preprocesses the sources with and -e is what the C
-    // compiler builds the instrumented program with. Both get the same flags: a
-    // project that needs a -D to parse needs the same -D to compile, and giving
-    // it to only one of them is how instrumentation fails on a project that
-    // analyzed cleanly.
+    // compiler builds the instrumented program with. They get the same defines
+    // and include paths: a project that needs a -D to parse needs the same -D
+    // to compile, and giving it to only one of them is how instrumentation
+    // fails on a project that analyzed cleanly.
+    //
+    // -nostdinc is the exception, and it goes to the analyzer only. Frama-C's
+    // modeled libc exists to be analyzed, not compiled: dropping the real
+    // system headers from the gcc behind -e leaves the instrumented program
+    // with no stdio, no stdlib and no E-ACSL runtime headers, so a project that
+    // loads with nostdinc analyzes cleanly and then fails to build. The
+    // -isystem set still goes to both, because a directory the caller named is
+    // as likely to be the project's own as it is to be a model.
     if let Some(cpp_flags) = cpp_extra_args(project_options) {
         args.push("-E".to_string());
-        args.push(cpp_flags.clone());
-        args.push("-e".to_string());
         args.push(cpp_flags);
+    }
+    if let Some(compile_flags) = cpp_extra_args(&ProjectLoadOptions {
+        nostdinc: false,
+        ..project_options.clone()
+    }) {
+        args.push("-e".to_string());
+        args.push(compile_flags);
     }
     if let Some(machdep) = &project_options.machdep {
         match machdep.as_str() {

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -409,10 +409,69 @@ impl FramaCMcpServer {
                 "sources": profile.sources,
                 "model": profile.model,
                 "machdep": profile.machdep,
+
+                // What the profile had to say about the load, so a reader can
+                // see that these came from the target rather than from a
+                // default. Each of them changes which obligations exist, which
+                // makes them the settings most worth attributing.
+                "rte": profile.rte,
+                "isystem_paths": profile.isystem_paths,
+                "nostdinc": profile.nostdinc,
                 "reproduce": profile.reproduce,
             })
         });
         Ok((profile, profile_used))
+    }
+
+    /// What this call loads: the file set it names and the flags it loads them
+    /// under.
+    ///
+    /// Split out of reload_project because it is the one part that answers from
+    /// its arguments alone: no lock, no client, no process. The rest of that
+    /// function is a sequence over the live instance, which is why the length
+    /// ceiling had nowhere else to give.
+    ///
+    /// The caller wins in every field, then the profile, then the type's own
+    /// default. That order is what makes loading a target by name bring the
+    /// target's settings with it rather than silently defaulting to a load the
+    /// target was never proved under.
+    fn requested_load(
+        params: &mut ReloadProjectParams,
+        profile: Option<&crate::state::VerificationProfile>,
+    ) -> Result<(Option<Vec<String>>, ProjectLoadOptions), McpError> {
+        // The profile's sources are what "load this target" means, and they
+        // stand in only where the caller named none.
+        let requested_files = params.files.clone().or_else(|| {
+            profile
+                .filter(|profile| !profile.sources.is_empty())
+                .map(|profile| profile.sources.clone())
+        });
+
+        let flag = |explicit: Option<bool>,
+                    pick: fn(&crate::state::VerificationProfile) -> Option<bool>| {
+            explicit.or_else(|| profile.and_then(pick)).unwrap_or(false)
+        };
+        let list = |explicit: Option<Vec<String>>,
+                    pick: fn(&crate::state::VerificationProfile) -> &Vec<String>| {
+            explicit
+                .unwrap_or_else(|| profile.map(|profile| pick(profile).clone()).unwrap_or_default())
+        };
+
+        let options = ProjectLoadOptions {
+            include_paths: list(params.include_paths.take(), |p| &p.include_paths),
+            defines: list(params.defines.take(), |p| &p.defines),
+            force_includes: list(params.force_includes.take(), |p| &p.force_includes),
+            machdep: params
+                .machdep
+                .take()
+                .or_else(|| profile.and_then(|profile| profile.machdep.clone())),
+            compilation_database: params.compilation_database.take(),
+            rte: flag(params.rte, |p| p.rte),
+            isystem_paths: list(params.isystem_paths.take(), |p| &p.isystem_paths),
+            nostdinc: flag(params.nostdinc, |p| p.nostdinc),
+        };
+        validate_project_options(&options)?;
+        Ok((requested_files, options))
     }
 
     #[tool(
@@ -421,7 +480,7 @@ impl FramaCMcpServer {
     )]
     pub async fn reload_project(
         &self,
-        Parameters(params): Parameters<ReloadProjectParams>,
+        Parameters(mut params): Parameters<ReloadProjectParams>,
     ) -> Result<CallToolResult, McpError> {
         // Check project lock
         if *self.project_locked.read().await {
@@ -435,31 +494,9 @@ impl FramaCMcpServer {
 
         let (profile, profile_used) = self.resolve_verify_profile(&params).await?;
 
-        // The profile's sources are what "load this target" means, and they
-        // stand in only where the caller named none.
-        let requested_files = params.files.clone().or_else(|| {
-            profile
-                .as_ref()
-                .filter(|profile| !profile.sources.is_empty())
-                .map(|profile| profile.sources.clone())
-        });
-
-        let rte = params.rte.unwrap_or(false);
-        let from_profile = |explicit: Option<Vec<String>>, pick: fn(&crate::state::VerificationProfile) -> &Vec<String>| {
-            explicit.unwrap_or_else(|| {
-                profile.as_ref().map(|profile| pick(profile).clone()).unwrap_or_default()
-            })
-        };
-        let project_options = ProjectLoadOptions {
-            include_paths: from_profile(params.include_paths, |p| &p.include_paths),
-            defines: from_profile(params.defines, |p| &p.defines),
-            force_includes: from_profile(params.force_includes, |p| &p.force_includes),
-            machdep: params
-                .machdep
-                .or_else(|| profile.as_ref().and_then(|profile| profile.machdep.clone())),
-            compilation_database: params.compilation_database,
-        };
-        validate_project_options(&project_options)?;
+        let (requested_files, project_options) =
+            Self::requested_load(&mut params, profile.as_ref())?;
+        let rte = project_options.rte;
 
         // Serialized with run_wp on the main instance: the steps below read the
         // live instance (marker snapshot) and ensure_main_spawned can respawn
@@ -470,8 +507,10 @@ impl FramaCMcpServer {
 
         // And the EVA transaction, because a re-parse swaps the AST that a
         // concurrent check's alarms are read against. Taken after the WP lock
-        // and never before it: this is the only site that holds both, so the
-        // order here is the whole ordering rule.
+        // and never before it. This is the only site that holds more than two
+        // of the server's locks, so it is where the order documented on
+        // FramaCMcpServer comes from; changing the sequence here changes the
+        // rule for everything.
         let _eva_op_guard = self.main_eva_lock.lock().await;
         if *self.project_locked.read().await {
             return Err(project_locked_error(
@@ -554,7 +593,7 @@ impl FramaCMcpServer {
         };
 
         // Spawns, respawns, or reloads in place as the options require.
-        self.ensure_main_spawned(files.clone(), rte, project_options.clone())
+        self.ensure_main_spawned(files.clone(), project_options.clone())
             .await?;
 
         // ast_reload_health resets the fetch cursors before fetching. Skipping
@@ -665,6 +704,14 @@ impl FramaCMcpServer {
             "include_paths": project_options.include_paths,
             "defines": project_options.defines,
             "force_includes": project_options.force_includes,
+
+            // Echoed like every sibling here, and for a stronger reason than
+            // most: these two decide which headers the files were compiled
+            // against, so they are part of the load identity a receipt is
+            // hashed over. A caller could not otherwise see which program this
+            // load actually built.
+            "isystem_paths": project_options.isystem_paths,
+            "nostdinc": project_options.nostdinc,
             "machdep": project_options.machdep,
             "compilation_database": project_options.compilation_database,
             "source_location_stability": {
@@ -996,6 +1043,16 @@ impl FramaCMcpServer {
             force_includes: params.force_includes.unwrap_or_default(),
             machdep: params.machdep,
             compilation_database: None,
+
+            // This path measures whether files parse; it never runs WP, so no
+            // obligations are generated either way.
+            rte: false,
+
+            // These two do change the answer: they decide which headers a file
+            // is compiled against, and a survey run without the flags the build
+            // passes measures a different program than the build parses.
+            isystem_paths: params.isystem_paths.unwrap_or_default(),
+            nostdinc: params.nostdinc.unwrap_or(false),
         };
         validate_project_options(&options)?;
         let args = project_cli_args(&options);
@@ -1241,15 +1298,43 @@ pub fn classify_parse_failure(output: &str) -> ParseBlock {
         // Matched case-insensitively. Frama-C writes "User Error:" as often as
         // "user error", and a case-sensitive search left the one branch whose
         // job is to quote what it could not classify returning an empty string.
-        message: output
-            .lines()
-            .find(|line| {
-                let lower = line.to_ascii_lowercase();
-                lower.contains("user error") || lower.contains("error:")
-            })
-            .map(|line| line.trim().to_string())
-            .unwrap_or_default(),
+        message: unclassified_message(output),
     }
+}
+
+/// The error line plus the body under it.
+///
+/// Frama-C puts the location on the line carrying "User Error:" and the reason
+/// on the indented lines after it, so quoting one line yields
+/// "src/syscall/sys.c:86: User Error:" and names nothing. That is the branch
+/// whose whole job is to say what it could not classify, and it was the half
+/// that mattered: the line below it read "Cannot find field ru_maxrss in type
+/// struct rusage", which identifies the cause outright.
+///
+/// Bounded, because the echoed source that follows can run long and this is a
+/// diagnostic rather than a transcript.
+fn unclassified_message(output: &str) -> String {
+    const MAX_BODY_LINES: usize = 4;
+
+    let mut lines = output.lines().skip_while(|line| {
+        let lower = line.to_ascii_lowercase();
+        !(lower.contains("user error") || lower.contains("error:"))
+    });
+    let Some(head) = lines.next() else {
+        return String::new();
+    };
+
+    // Continuation is indentation: the next unindented line is a new message,
+    // not more of this one.
+    let body = lines
+        .take_while(|line| line.starts_with(char::is_whitespace) && !line.trim().is_empty())
+        .take(MAX_BODY_LINES);
+
+    std::iter::once(head)
+        .chain(body)
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Whether a line is an include directive naming this header.
@@ -1457,12 +1542,12 @@ pub fn validate_project_options(options: &ProjectLoadOptions) -> Result<(), McpE
         "force_includes entries must be non-empty header names of [A-Za-z0-9_./+-] \
          without a leading dash (write \"builtins.h\", not \"-include builtins.h\")",
     )?;
+    validate_cpp_entries(
+        &options.isystem_paths,
+        "isystem_paths entries must be non-empty directories of [A-Za-z0-9_./+-] \
+         without a leading dash (write \"include\", not \"-isystem include\")",
+    )?;
 
-    // These two land in the same argv as the three lists above, as their own
-    // tokens, so the leading-dash rule applies to them for the same reason it
-    // applies there. It used to stop at the three, and the gap read as
-    // deliberate because the error text above teaches the rule.
-    //
     // compilation_database gets only the dash rule, because it is a path the
     // caller chose and a real one can hold a character the preprocessor
     // allowlist was never written for. Refusing those would be this validator

--- a/src/mcp/receipt.rs
+++ b/src/mcp/receipt.rs
@@ -40,13 +40,13 @@ pub fn receipt_source_path(file: &str) -> String {
 /// that is current now. A receipt is only evidence about the program it was
 /// produced over, and these are the settings that decide which program that is.
 pub fn project_load_identity(options: &super::ProjectLoadOptions) -> serde_json::Value {
-    json!({
-        "include_paths": options.include_paths,
-        "defines": options.defines,
-        "force_includes": options.force_includes,
-        "machdep": options.machdep,
-        "compilation_database": options.compilation_database,
-    })
+    // The struct's own Serialize, so the identity covers every field by
+    // construction. This was an exhaustive destructure feeding a json! that
+    // restated all eight names, which is a third hand-maintained copy of the
+    // field list guarding a property the derive gives outright. Forgetting one
+    // left two different programs sharing a receipt digest, and nothing
+    // downstream could detect it.
+    serde_json::to_value(options).unwrap_or(serde_json::Value::Null)
 }
 
 fn proof_receipt_source_files(files: &[String]) -> Vec<serde_json::Value> {
@@ -116,7 +116,13 @@ pub fn proof_receipt_goals(
                 // receipts match are supposed to be comparable, and a replayed
                 // verdict was not computed by the run claiming it, so it cannot
                 // hash the same as one that was.
-                "from_cache": goal.get("from_cache").cloned().unwrap_or_else(|| json!(false)),
+                //
+                // Read through the accessor rather than off the key.
+                // enrich_goal_stable_id omits the field on a goal that had no
+                // summary to project, so a raw read defaults such a goal to
+                // "not cached", which is the direction that hides a replayed
+                // verdict, on the payload the receipt hashes.
+                "from_cache": json!(crate::mcp::server::wpclass::goal_is_from_cache(&goal)),
             })
         })
         .collect::<Vec<_>>();

--- a/src/mcp/selfcheck.rs
+++ b/src/mcp/selfcheck.rs
@@ -1128,7 +1128,7 @@ pub fn buggy_fixture_reason(
         return Some(format!("verdict {verdict}, expected incomplete"));
     }
     let names_the_alarm = incomplete.iter().any(|item| {
-        item["code"].as_str() == Some(super::analysis::incomplete_code::ALARM_NOT_VALID)
+        item["code"].as_str() == Some(super::checkgaps::incomplete_code::ALARM_NOT_VALID)
             && item["descr"].as_str().is_some_and(|d| d.contains("signed_overflow"))
     });
     if !names_the_alarm {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1266,15 +1266,45 @@ pub fn default_wp_model() -> &'static str {
     "Typed+nocast"
 }
 
-pub fn wp_run_response(
-    tasks: serde_json::Value,
-    params: &RunWpParams,
-    functions: Vec<String>,
-    scope: &str,
-    rte_enabled: bool,
-    frama_c_protocol: Vec<serde_json::Value>,
-    proofread_report: Option<serde_json::Value>,
-) -> serde_json::Value {
+/// One WP run, as the thing that renders its response sees it.
+///
+/// A struct rather than nine positional arguments, for the reason
+/// ProofReceiptRequest beside it is one. Nine of anything past a call site is
+/// unreadable, and clippy refuses it at seven. The fields do all have distinct
+/// types, so the compiler would catch a swap either way; what the names buy is
+/// a reader who can see which argument is which without counting commas
+/// against the declaration.
+pub struct WpRunResponse<'a> {
+    pub tasks: serde_json::Value,
+    pub params: &'a RunWpParams,
+    pub functions: Vec<String>,
+    pub scope: &'a str,
+    pub rte_enabled: bool,
+    pub frama_c_protocol: Vec<serde_json::Value>,
+    pub proofread_report: Option<serde_json::Value>,
+
+    /// This run's goals, so the response can say how much of its own evidence
+    /// was measured here rather than replayed from WP's cache.
+    pub goals: Option<&'a [serde_json::Value]>,
+
+    /// The host load as it was before this run scheduled anything. Carried
+    /// rather than read at render time: read then, it is mostly this run's own
+    /// provers. See host_load.
+    pub host_load: crate::mcp::server::wpclass::HostLoad,
+}
+
+pub fn wp_run_response(run: WpRunResponse<'_>) -> serde_json::Value {
+    let WpRunResponse {
+        tasks,
+        params,
+        functions,
+        scope,
+        rte_enabled,
+        frama_c_protocol,
+        proofread_report,
+        goals,
+        host_load,
+    } = run;
     let model = params.model.as_deref().unwrap_or(default_wp_model());
 
     // Reported as the list it names, in either spelling. Echoing the singular
@@ -1355,15 +1385,34 @@ pub fn wp_run_response(
         "split_strategy": serde_json::Value::Null,
         "raw_task_ids": collect_json_string_fields(&tasks, &["id", "task_id", "taskId"]),
     });
-    let timeout_triage =
-        wp_timeout_triage_from_tasks_and_report(&tasks, proofread_report.as_ref());
+    let measurement = goals.map(crate::mcp::server::wpclass::run_measurement);
+    let timeout_triage = wp_timeout_triage_from_tasks_and_report(
+        &tasks,
+        proofread_report.as_ref(),
+        measurement.as_ref(),
+        host_load,
+    );
     let failure_kind = wp_failure_kind_from_tasks(&tasks, &timeout_triage);
+
+    // The reading itself, beside the response and never inside the triage. The
+    // triage is hashed into the proof receipt, so it carries only the category;
+    // a caller that wants to see how loaded the machine actually was reads it
+    // here, where two runs differing by nothing else still compare equal.
+    let host_load = json!({
+        "per_cpu": host_load.per_cpu(),
+        "category": host_load.category(),
+        "saturated_above": crate::mcp::server::wpclass::HOST_SATURATED_LOAD_PER_CPU,
+    });
 
     match tasks {
         serde_json::Value::Object(mut object) => {
             object.insert("effective_wp_config".to_string(), config);
             object.insert("frama_c_options".to_string(), json!(frama_c_options));
             object.insert("frama_c_protocol".to_string(), json!(frama_c_protocol));
+            if let Some(measurement) = &measurement {
+                object.insert("measurement".to_string(), measurement.to_json());
+            }
+            object.insert("host_load".to_string(), host_load);
             object.insert("wp_timeout_triage".to_string(), timeout_triage);
             object.insert("failure_kind".to_string(), json!(failure_kind));
             if let Some(report) = proofread_report {
@@ -1377,9 +1426,17 @@ pub fn wp_run_response(
                 "effective_wp_config": config,
                 "frama_c_options": frama_c_options,
                 "frama_c_protocol": frama_c_protocol,
+                "host_load": host_load,
                 "wp_timeout_triage": timeout_triage,
                 "failure_kind": failure_kind,
             });
+
+            // Both arms, because drain_wp_tasks returns whatever Frama-C sent
+            // whenever it cannot count the queue, and a response missing the
+            // counts reads as a run with nothing replayed.
+            if let Some(measurement) = &measurement {
+                response["measurement"] = measurement.to_json();
+            }
             if let Some(report) = proofread_report {
                 response["proofread_report"] = report;
             }
@@ -1545,17 +1602,35 @@ pub fn validate_wp_cache_mode(requested: &str) -> Result<&'static str, McpError>
 /// path and the defines already in effect; a header force-included before its
 /// own -I would not resolve its own includes.
 pub fn cpp_extra_args(options: &ProjectLoadOptions) -> Option<String> {
-    let flags = options
-        .include_paths
-        .iter()
-        .map(|path| format!("-I{path}"))
-        .chain(options.defines.iter().map(|define| format!("-D{define}")))
-        .chain(
-            options
-                .force_includes
-                .iter()
-                .map(|header| format!("-include {header}")),
-        )
+    // -nostdinc leads, because it removes search directories the flags after it
+    // then put back deliberately. -isystem follows the -I set, which is the
+    // order the preprocessor searches them in, so the modeled libc is found
+    // only where the project's own headers do not answer first.
+    //
+    // Destructured exhaustively, for the reason given on ProjectLoadOptions.
+    let ProjectLoadOptions {
+        include_paths,
+        defines,
+        force_includes,
+        isystem_paths,
+        nostdinc,
+
+        // Not preprocessor flags: they reach Frama-C as its own arguments, in
+        // project_cli_args.
+        machdep: _,
+        compilation_database: _,
+
+        // Not a flag at all: it selects whether Frama-C is started with -rte.
+        rte: _,
+    } = options;
+
+    let flags = nostdinc
+        .then(|| "-nostdinc".to_string())
+        .into_iter()
+        .chain(include_paths.iter().map(|path| format!("-I{path}")))
+        .chain(isystem_paths.iter().map(|path| format!("-isystem {path}")))
+        .chain(defines.iter().map(|define| format!("-D{define}")))
+        .chain(force_includes.iter().map(|header| format!("-include {header}")))
         .collect::<Vec<_>>();
     if flags.is_empty() {
         return None;
@@ -1607,15 +1682,37 @@ impl FramaCMcpServer {
 }
 
 pub fn project_cli_args(options: &ProjectLoadOptions) -> Vec<String> {
+    // Destructured exhaustively, as cpp_extra_args is and for the reason given
+    // on ProjectLoadOptions: a field added there is a compile error here rather
+    // than a Frama-C invocation that quietly loads a different program.
+    let ProjectLoadOptions {
+        machdep,
+        compilation_database,
+
+        // Preprocessor flags, folded into one -cpp-extra-args below.
+        include_paths: _,
+        defines: _,
+        force_includes: _,
+        isystem_paths: _,
+        nostdinc: _,
+
+        // Not emitted here. These arguments serve short-lived CLI runs that
+        // generate their own obligations, and each already decides for itself:
+        // wpcli passes -wp-rte where the run needs it, and parse_surface runs
+        // no proof at all. Emitting -rte here would add obligations to runs
+        // whose callers pass the flag a second time.
+        rte: _,
+    } = options;
+
     let mut args = Vec::new();
     if let Some(cpp_args) = cpp_extra_args(options) {
         args.push(format!("-cpp-extra-args={cpp_args}"));
     }
-    if let Some(machdep) = &options.machdep {
+    if let Some(machdep) = machdep {
         args.push("-machdep".to_string());
         args.push(machdep.clone());
     }
-    if let Some(compilation_database) = &options.compilation_database {
+    if let Some(compilation_database) = compilation_database {
         args.push("-compilation-db".to_string());
         args.push(compilation_database.clone());
     }
@@ -2042,13 +2139,15 @@ async fn source_identity(files: Vec<String>, machdep: Option<String>) -> (String
 /// **Known limitation**: SIGKILL/OOM/crash bypass Drop, so the Frama-C child
 /// can still be orphaned
 /// until a kernel-level PR_SET_PDEATHSIG fix is added.
-/// `socket_path` / `files` / `with_rte` / project options drive
-/// ensure_main_spawned's in-place-vs-respawn decision.
+/// The socket path, the file set and the project options drive
+/// ensure_main_spawned's
+/// in-place-vs-respawn decision. RTE lives in the options rather than beside
+/// them, so there is one spelling for a setting that decides which obligations
+/// the process generates.
 pub struct MainFramaCState {
     pub child: tokio::process::Child,
     pub socket_path: PathBuf,
     pub files: Vec<String>,
-    pub with_rte: bool,
     pub project_options: ProjectLoadOptions,
     pub pid: u32,
     pub command_line: Vec<String>,
@@ -2127,13 +2226,51 @@ impl Drop for MainFramaCState {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// What was loaded, and under which flags.
+///
+/// Serialize is derived rather than written, and project_load_identity is that
+/// derive. The identity has to cover every field, which is exactly what the
+/// derive means, so a field added here reaches the receipt with no discipline
+/// to remember. The hand-written version was three copies of the field list
+/// away from that guarantee and enforced it by an exhaustive destructure whose
+/// only job was to fail to compile.
+///
+/// Field order is the identity's key order, because serde_json is built with
+/// preserve_order and the identity is hashed. Inserting a field in the middle
+/// moves the digest of every receipt; append instead.
+///
+/// The functions that consume these fields selectively (cpp_extra_args,
+/// project_cli_args, names_bytes_outside_the_file_set,
+/// profile_matches_loaded_project) destructure exhaustively rather than reading
+/// field by field, so a field added here is a compile error at each of them
+/// instead of a silently weaker answer. Every one of them fails open when a
+/// field is forgotten, which is why the discipline is stated once here rather
+/// than argued four times.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize)]
 pub struct ProjectLoadOptions {
     pub include_paths: Vec<String>,
     pub defines: Vec<String>,
     pub force_includes: Vec<String>,
     pub machdep: Option<String>,
     pub compilation_database: Option<String>,
+
+    /// Whether this load generates runtime-error obligations.
+    ///
+    /// Part of the load identity, not a run setting: -wp-rte is applied when
+    /// Frama-C starts, and it changes which obligations exist, so two loads
+    /// differing only here are different programs to prove.
+    pub rte: bool,
+
+    /// System include directories, as `-isystem <dir>`.
+    pub isystem_paths: Vec<String>,
+
+    /// Whether the preprocessor's default system directories are dropped.
+    ///
+    /// Part of the load identity for the same reason the include paths are: on
+    /// a platform whose real headers shadow the modeled libc, this decides
+    /// which declarations a file is compiled against, so two loads differing
+    /// only here are different programs to prove.
+    pub nostdinc: bool,
 }
 
 impl ProjectLoadOptions {
@@ -2145,13 +2282,28 @@ impl ProjectLoadOptions {
     /// path is a decision to take here, and taking it anywhere else means the
     /// author of that field never sees the question.
     ///
-    /// include_paths and defines are not in it. They reach the preprocessor,
-    /// but only a source with a directive can act on them, and such a source is
-    /// already refused. Nor is machdep: it names bytes, but loaded_source_state
-    /// hashes them, so the identity answers for it rather than this predicate
-    /// refusing every project that sets one.
+    /// include_paths, isystem_paths and defines are not in it. They reach the
+    /// preprocessor, but only a source with a directive can act on them, and
+    /// such a source is already refused. Nor is machdep: it names bytes, but
+    /// loaded_source_state hashes them, so the identity answers for it rather
+    /// than this predicate refusing every project that sets one. nostdinc and
+    /// rte name no bytes at all: one removes search directories, the other adds
+    /// obligations to the AST.
     fn names_bytes_outside_the_file_set(&self) -> bool {
-        !self.force_includes.is_empty() || self.compilation_database.is_some()
+        // Destructured for the reason the doc gives: the answer is a property
+        // of the fields, so a new one has to be answered for here rather than
+        // silently inheriting whichever verdict the expression happens to give.
+        let ProjectLoadOptions {
+            force_includes,
+            compilation_database,
+            include_paths: _,
+            isystem_paths: _,
+            defines: _,
+            machdep: _,
+            nostdinc: _,
+            rte: _,
+        } = self;
+        !force_includes.is_empty() || compilation_database.is_some()
     }
 }
 
@@ -2251,6 +2403,40 @@ impl SandboxRegistry {
     }
 }
 
+/// The MCP server, and the locks that serialize the one Frama-C process.
+///
+/// # Lock order
+///
+/// Seven locks, one order, and it is the whole rule. Take them in this
+/// sequence and never in any other:
+///
+///     main_wp_lock -> main_eva_lock -> main_spawn_lock -> main_frama_c_state
+///         -> client -> state -> sandboxes
+///
+/// It is written here rather than beside each lock because it used to be
+/// exactly that: four doc comments each stating its own fragment, two of them
+/// calling themselves the outermost lock. Both claims were locally true and
+/// together they described no order at all, while the full chain, which
+/// reload_project walks end to end, appeared nowhere. A fragment cannot be
+/// checked against the others by reading; a sequence can.
+///
+/// Where the sequence comes from, so a new holder can tell whether it is
+/// adding an edge or breaking one:
+///
+/// - reload_project (project.rs) takes main_wp_lock, then main_eva_lock, then
+///   calls ensure_main_spawned. It is the only site that holds more than two,
+///   and it is therefore the site that fixes the order.
+/// - ensure_main_spawned (this file) is reached only from reload_project. It
+///   takes main_spawn_lock, then main_frama_c_state, then client.
+/// - check's EVA half (analysis.rs) takes main_eva_lock alone; run_wp,
+///   proof_coverage and verify_program_step take main_wp_lock alone. Nothing
+///   takes eva before wp.
+///
+/// Not machine-checked. A lock-order test needs either instrumented guards or
+/// a run that actually contends, and neither is worth its weight against seven
+/// locks whose every acquisition site is in the list above. What keeps this
+/// honest is that the sites are few and named: grep for the transaction locks
+/// and the answer should be the eight acquisitions this paragraph accounts for.
 #[derive(Clone)]
 pub struct FramaCMcpServer {
     /// Main Frama-C client. Lazy mode starts with None.
@@ -2307,12 +2493,10 @@ pub struct FramaCMcpServer {
     /// the next inline-source check, which is also when the session stops
     /// referring to the old one.
     current_check_source_dir: Arc<AsyncMutex<Option<tempfile::TempDir>>>,
-    /// Main Frama-C process state (child + socket + files + rte).
-    /// Replaces the old `main_frama_c_child: Option<Child>` - multiple
-    /// sockets/files/rte to support
-    /// ensure_main_spawned's in-place vs respawn judgment.
-    /// Lock sequence: main_frame_c_state → client → state → sandboxes (to avoid
-    /// deadlock).
+    /// Main Frama-C process state (child + socket + files + project options).
+    /// Replaces the old main_frama_c_child field: multiple sockets and files,
+    /// to support ensure_main_spawned's in-place vs respawn judgment. See the
+    /// lock order on this struct.
     main_frama_c_state: Arc<AsyncMutex<Option<MainFramaCState>>>,
     /// Held for the whole of ensure_main_spawned, decision through assignment.
     ///
@@ -2324,7 +2508,8 @@ pub struct FramaCMcpServer {
     /// did not ask for. The window used to be the couple of seconds Frama-C
     /// took to bind its socket, and is now up to SPAWN_CONNECT_BACKSTOP.
     ///
-    /// Outermost lock: taken before main_frama_c_state, never inside it.
+    /// Taken inside the two transaction locks and outside main_frama_c_state.
+    /// See the lock order on this struct.
     main_spawn_lock: Arc<AsyncMutex<()>>,
     /// Project lock: when true, reload_project and run_wp on main instance are
     /// rejected. Sandbox operations are unaffected. verify_program_step toggles
@@ -2360,7 +2545,7 @@ pub struct FramaCMcpServer {
     /// of a run that is holding it, and taking the lock there would deadlock
     /// the escape.
     ///
-    /// Outermost lock: taken before the client lock, never inside it.
+    /// First in the lock order on this struct: nothing is taken before it.
     main_wp_lock: Arc<AsyncMutex<()>>,
 
     /// Held across a whole EVA transaction on the main instance: the parameter
@@ -2372,8 +2557,7 @@ pub struct FramaCMcpServer {
     /// covers for WP, and the same cost: a compute measured in minutes holds
     /// this the whole time.
     ///
-    /// Ordered after main_wp_lock. reload_project is the only site that holds
-    /// both, and it takes wp then eva, so that is the whole ordering rule.
+    /// Second in the lock order on this struct, directly after main_wp_lock.
     /// Nothing reached under this guard acquires the WP lock: check_eva_step
     /// holds it across run_eva_payload and eva_alarms_payload only, and neither
     /// takes a lock beyond the client mutex.
@@ -2884,10 +3068,15 @@ impl FramaCMcpServer {
         ]
     }
 
+    /// The argv for a new main instance.
+    ///
+    /// RTE is read off project_options rather than passed beside it. It used to
+    /// be both, and nothing made the two agree: a caller that passed one value
+    /// and an options struct carrying the other started a process the receipt
+    /// did not describe.
     fn main_frama_c_command_line(
         &self,
         files: &[String],
-        rte: bool,
         project_options: &ProjectLoadOptions,
         socket_path: &Path,
     ) -> Vec<String> {
@@ -2914,7 +3103,7 @@ impl FramaCMcpServer {
             "-wp-model".to_string(),
             default_wp_model().to_string(),
         ]);
-        if rte {
+        if project_options.rte {
             command_line.push("-rte".to_string());
         }
         command_line
@@ -3180,6 +3369,9 @@ impl FramaCMcpServer {
                     .ok_or_else(|| McpError::from(FramaCError::FunctionNotFound(function.clone())))
             })
             .collect::<Result<Vec<_>, _>>()?;
+        // Read before any proof is scheduled: after the drain the average is
+        // largely this run's own provers. See host_load_per_cpu.
+        let host_load = crate::mcp::server::wpclass::host_load();
         let protocol_diagnostics = start_wp_proofs(&client, Some(&decl_markers)).await?;
 
         let tasks = drain_wp_tasks(&client, WP_DRAIN_BUDGET).await?;
@@ -3199,15 +3391,17 @@ impl FramaCMcpServer {
                 .unwrap_or_default()
         };
 
-        let mut response = wp_run_response(
+        let mut response = wp_run_response(WpRunResponse {
             tasks,
             params,
-            names.clone(),
-            "sandbox",
-            true,
-            protocol_diagnostics,
-            Some(proofread_report),
-        );
+            functions: names.clone(),
+            scope: "sandbox",
+            rte_enabled: true,
+            frama_c_protocol: protocol_diagnostics,
+            proofread_report: Some(proofread_report),
+            goals: Some(wp_goals.as_slice()),
+            host_load,
+        });
 
         // The property table read here is the sandbox's own, which is the only
         // difference from the main path.
@@ -3400,7 +3594,6 @@ impl FramaCMcpServer {
     async fn ensure_main_spawned(
         &self,
         new_files: Vec<String>,
-        new_rte: bool,
         new_project_options: ProjectLoadOptions,
     ) -> Result<(), McpError> {
         // Held to the end, so the respawn decision and the assignment that acts
@@ -3436,7 +3629,6 @@ impl FramaCMcpServer {
                 // source either way, so this costs process lifetime rather than
                 // anything the caller had.
                 s.poisoned
-                    || s.with_rte != new_rte
                     || s.project_options != new_project_options
                     || client_lock.as_ref().is_some_and(|c| c.is_poisoned())
                     || !parse_record_survives(s, &identity)
@@ -3548,12 +3740,8 @@ impl FramaCMcpServer {
         // parse, and that reload reuses a record for an AST nobody built.
         let ast_parse_source_digest = identity.0.clone();
 
-        let command_line = self.main_frama_c_command_line(
-            &new_files,
-            new_rte,
-            &new_project_options,
-            &socket_path,
-        );
+        let command_line =
+            self.main_frama_c_command_line(&new_files, &new_project_options, &socket_path);
         let mut child = spawn_frama_c(&command_line, &stdout_log_path, &stderr_log_path)?;
         let pid = child.id().unwrap_or_default();
 
@@ -3626,7 +3814,6 @@ impl FramaCMcpServer {
             child,
             socket_path,
             files: new_files,
-            with_rte: new_rte,
             project_options: new_project_options,
             pid,
             command_line,
@@ -4301,6 +4488,12 @@ use wpclass::*;
 #[path = "analysis.rs"]
 pub mod analysis;
 use analysis::unproved_assumption_findings;
+/// What makes a check incomplete, and the guidance behind each gap code.
+/// Split from analysis.rs, whose free functions outgrew the impl block they
+/// serve; see the module's own header.
+#[path = "checkgaps.rs"]
+pub mod checkgaps;
+
 #[path = "coverage.rs"]
 pub mod coverage;
 #[path = "annotations.rs"]

--- a/src/mcp/status.rs
+++ b/src/mcp/status.rs
@@ -133,6 +133,18 @@ pub fn status_is_failed(status: &str) -> bool {
     status.eq_ignore_ascii_case("failed")
 }
 
+/// Whether a status says the prover ran out of its wall-clock budget.
+///
+/// The sibling of status_is_failed, here for the reason spelled out above it:
+/// four callers arrived at this predicate independently. classify_failure_reason
+/// and wp_timeout_triage_from_goal compare the normalized and the raw spelling,
+/// run_measurement counts goals at timeout, and the proofread report categorizes
+/// them, which is four answers available to one question. Which status to read
+/// stays the call site's decision; the comparison itself lives here.
+pub fn status_is_timeout(status: &str) -> bool {
+    status.eq_ignore_ascii_case("timeout")
+}
+
 /// The derived flags every status-bearing payload carries next to its
 /// normalized status.
 pub fn insert_status_flags(
@@ -207,4 +219,16 @@ pub fn is_proved(status: &str) -> bool {
 /// proved, which is the safe direction: a row nobody judged has not been.
 pub fn own_status_is_proved(row: &Value) -> bool {
     own_status(row).is_some_and(is_proved)
+}
+
+/// Whether WP's prover ran out of its budget on this goal.
+///
+/// own_status, not consolidated_status, and the distinction is the whole point
+/// of this module: a goal at TIMEOUT can hang off a property that consolidated
+/// to valid, and the consolidated reader answers "valid" for it. run_measurement
+/// asked the property's verdict for a question about the goal, beside a line
+/// asking the goal's own verdict for whether it was proved, so one loop asked
+/// two different questions about the same row.
+pub fn own_status_is_timeout(row: &Value) -> bool {
+    own_status(row).is_some_and(status_is_timeout)
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -1,6 +1,36 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// Tolerant bool deserializer, for the same client that makes the Vec one
+/// necessary: a parameter schema carrying no "type" lets a caller send "true"
+/// where true was meant. Only the two JSON spellings are accepted, so a typo
+/// is still refused rather than read as false, which is the confident
+/// direction for every flag this is applied to.
+///
+/// Usage: `#[serde(default, deserialize_with = "deserialize_bool_or_string")]`
+pub fn deserialize_bool_or_string<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    match Option::<serde_json::Value>::deserialize(deserializer)? {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::Bool(b)) => Ok(Some(b)),
+        Some(serde_json::Value::String(s)) => match s.trim() {
+            // An empty string is the shape that client sends for "unset".
+            "" => Ok(None),
+            "true" => Ok(Some(true)),
+            "false" => Ok(Some(false)),
+            other => Err(D::Error::custom(format!(
+                "expected true or false, got the string {other:?}"
+            ))),
+        },
+        Some(other) => Err(D::Error::custom(format!(
+            "expected a boolean, got {other}"
+        ))),
+    }
+}
+
 /// Tolerant Vec deserializer: accepts standard JSON arrays, and also accepts
 /// stringify JSON arrays
 /// (Claude Code's MCP client sometimes serializes nested arrays into strings).
@@ -122,6 +152,17 @@ pub struct ParseSurfaceParams {
     /// them.
     #[serde(default, deserialize_with = "deserialize_vec_or_string")]
     pub force_includes: Option<Vec<String>>,
+    /// System include directories passed as `-isystem <dir>`, searched after
+    /// include_paths and before the compiler's own. Pair with nostdinc to put
+    /// a modeled libc where the real system headers would otherwise be found.
+    #[serde(default, deserialize_with = "deserialize_vec_or_string")]
+    pub isystem_paths: Option<Vec<String>>,
+    /// Drop the preprocessor's default system include directories, as
+    /// `-nostdinc`. On a platform whose real headers shadow Frama-C's modeled
+    /// libc this decides which program is loaded, not merely how fast it
+    /// parses, so it is part of the load identity rather than a convenience.
+    #[serde(default, deserialize_with = "deserialize_bool_or_string")]
+    pub nostdinc: Option<bool>,
     /// Target machine model, as reload_project takes it.
     pub machdep: Option<String>,
     /// Response size. "summary" (default) reports the counts and the causes,
@@ -157,6 +198,17 @@ pub struct ReloadProjectParams {
     /// argument types for the same name.
     #[serde(default, deserialize_with = "deserialize_vec_or_string")]
     pub force_includes: Option<Vec<String>>,
+    /// System include directories passed as `-isystem <dir>`, searched after
+    /// include_paths and before the compiler's own. Pair with nostdinc to put
+    /// a modeled libc where the real system headers would otherwise be found.
+    #[serde(default, deserialize_with = "deserialize_vec_or_string")]
+    pub isystem_paths: Option<Vec<String>>,
+    /// Drop the preprocessor's default system include directories, as
+    /// `-nostdinc`. On a platform whose real headers shadow Frama-C's modeled
+    /// libc this decides which program is loaded, not merely how fast it
+    /// parses, so it is part of the load identity rather than a convenience.
+    #[serde(default, deserialize_with = "deserialize_bool_or_string")]
+    pub nostdinc: Option<bool>,
     /// Target machine model passed to Frama-C as `-machdep <machine>`.
     pub machdep: Option<String>,
     /// Response size. "summary" (default) lists each function's name and
@@ -185,18 +237,29 @@ pub struct ReloadProjectParams {
     pub compilation_database: Option<String>,
     /// Enable generated RTE annotations by restarting Frama-C with `-rte`.
     /// Default: false.
+    #[serde(default, deserialize_with = "deserialize_bool_or_string")]
     pub rte: Option<bool>,
     /// Register what the project's build system proves each target under, as an
     /// object keyed by target name. Emit it from the build system rather than
     /// writing it here, so it cannot drift from the command that decides:
     /// "make print-verify-profiles" or the equivalent. An entry used only to
-    /// load may carry sources, machdep, include_paths, defines, force_includes
-    /// and reproduce. One that a run or a conclusion will name additionally
-    /// needs functions, model, provers and timeout_seconds, and is refused
-    /// without them: the proof settings because it would otherwise prove under
-    /// this server's defaults while reporting the target's name, and the
-    /// function set because there would be nothing to check coverage against.
+    /// load may carry sources, machdep, include_paths, isystem_paths, nostdinc,
+    /// defines, force_includes and reproduce. One that a run or a conclusion
+    /// will name additionally needs functions, model, provers,
+    /// timeout_seconds, rte and nostdinc, and is refused without them: the
+    /// proof settings because it would otherwise prove under this server's
+    /// defaults while reporting the target's name, the function set because
+    /// there would be nothing to check coverage against, and rte and nostdinc
+    /// because each decides which obligations exist at all. A profile written
+    /// before those two were required loads as before and is refused only
+    /// where it would have become evidence; state them to restore it.
     /// Registered for the session; passing it again replaces the set.
+    ///
+    /// Tolerant of the JSON text of the object as well as the object, like the
+    /// other Value-typed parameters: a client whose schema for this carries no
+    /// "type" sends the quoted form, and refusing it fails a payload that says
+    /// exactly what it means.
+    #[serde(default, deserialize_with = "deserialize_value_or_string")]
     pub verify_profiles: Option<serde_json::Value>,
     /// Where verify_profiles came from, recorded so a later reader can re-run
     /// it
@@ -400,6 +463,17 @@ pub struct CheckParams {
     /// resolved through include_paths. Applied after include_paths and defines.
     #[serde(default, deserialize_with = "deserialize_vec_or_string")]
     pub force_includes: Option<Vec<String>>,
+    /// System include directories passed as `-isystem <dir>`, searched after
+    /// include_paths and before the compiler's own. Pair with nostdinc to put
+    /// a modeled libc where the real system headers would otherwise be found.
+    #[serde(default, deserialize_with = "deserialize_vec_or_string")]
+    pub isystem_paths: Option<Vec<String>>,
+    /// Drop the preprocessor's default system include directories, as
+    /// `-nostdinc`. On a platform whose real headers shadow Frama-C's modeled
+    /// libc this decides which program is loaded, not merely how fast it
+    /// parses, so it is part of the load identity rather than a convenience.
+    #[serde(default, deserialize_with = "deserialize_bool_or_string")]
+    pub nostdinc: Option<bool>,
     /// Target machine model passed to Frama-C as `-machdep <machine>`.
     pub machdep: Option<String>,
     /// Configurations to check instead of one. Each entry may carry `defines`,
@@ -428,6 +502,7 @@ pub struct CheckParams {
     #[serde(alias = "compilation_db")]
     pub compilation_database: Option<String>,
     /// Enable RTE annotation generation before EVA/WP. Default: true.
+    #[serde(default, deserialize_with = "deserialize_bool_or_string")]
     pub rte: Option<bool>,
     /// Response size. "summary" (default) returns counts plus the first few
     /// non-valid goals and undischarged alarms; "full" returns every goal and

--- a/src/mcp/wpclass.rs
+++ b/src/mcp/wpclass.rs
@@ -69,8 +69,8 @@ fn classify_failure_reason(
     text: &str,
     push_evidence: &mut impl FnMut(&str, serde_json::Value),
 ) -> (&'static str, &'static str, &'static str) {
-    if normalized_status == "timeout"
-        || raw_status.eq_ignore_ascii_case("timeout")
+    if crate::mcp::status::status_is_timeout(normalized_status)
+        || crate::mcp::status::status_is_timeout(raw_status)
     {
         push_evidence("normalized_status", json!(normalized_status));
         (
@@ -1059,6 +1059,25 @@ fn stable_goal_id_for(
 /// So the cache changes only where a verdict came from, which is exactly what
 /// a proof receipt has to record.
 pub fn goal_is_from_cache(goal: &serde_json::Value) -> bool {
+    // The lifted field first. enrich_goal_stable_id puts it on every goal whose
+    // summary it could read, so no consumer has to know the answer comes from a
+    // word in a free-form string, and this function is a consumer like any
+    // other. Reading only the summary meant an enriched goal whose stats had
+    // been projected away answered "not cached", which is the confident
+    // direction and the one that hides a replayed verdict.
+    if let Some(lifted) = goal.get("from_cache").and_then(serde_json::Value::as_bool) {
+        return lifted;
+    }
+    summary_says_cached(goal)
+}
+
+/// The reading straight off the summary, with no lifted field consulted.
+///
+/// Separate from goal_is_from_cache because the enrichment that writes the
+/// field must not read it: doing so made the first enrichment's answer
+/// permanent while the reader above treated it as authoritative, so a goal
+/// enriched before its stats arrived could never be corrected.
+fn summary_says_cached(goal: &serde_json::Value) -> bool {
     goal.get("stats")
         .and_then(|stats| stats.get("summary"))
         .and_then(|summary| summary.as_str())
@@ -1074,16 +1093,235 @@ pub fn enrich_goal_stable_id(
 
     // Lifted onto the goal here because every goal passes through, so no
     // consumer has to know it comes from a word in a free-form summary string.
-    let from_cache = goal_is_from_cache(goal);
+    //
+    // Written only where there is a summary to project, and overwritten rather
+    // than filled in. A goal with no stats yet gets no field, so it falls
+    // through to the summary read like an unenriched one instead of carrying an
+    // invented "false" that outranks a summary arriving later.
+    let summary_answer = goal.get("stats").is_some().then(|| summary_says_cached(goal));
     if let Some(obj) = goal.as_object_mut() {
         obj.entry("stable_goal_id".to_string())
             .or_insert_with(|| serde_json::Value::String(stable_goal_id));
-        obj.entry("from_cache".to_string())
-            .or_insert(serde_json::Value::Bool(from_cache));
+        if let Some(from_cache) = summary_answer {
+            obj.insert("from_cache".to_string(), serde_json::Value::Bool(from_cache));
+        }
         if let Some(name) = obj.get("name").cloned() {
             obj.entry("frama_c_goal_name".to_string()).or_insert(name);
         }
     }
+}
+
+/// Above this, a wall-clock prover budget measures the machine rather than the
+/// goal. One runnable thread per CPU is the point where that starts, not the
+/// point where the host is merely busy.
+pub const HOST_SATURATED_LOAD_PER_CPU: f64 = 1.0;
+
+/// The host's load, as the timeout verdict needs it.
+///
+/// An enum rather than an Option<f64> beside a category string. The verdict is
+/// a match on the category, and matching a string needs a catch-all arm, so a
+/// renamed spelling would fall through it and leave the run confident. That is
+/// the direction this whole function exists to withhold, and it is the same
+/// argument RunMeasurement makes for keeping its predicate a method rather than
+/// a key routed out through JSON and back.
+///
+/// Normalized once, here. Three places used to refuse non-finite and negative
+/// readings, and because the last of them decided the verdict, every one of
+/// them had to be trusted for the refusal to hold.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum HostLoad {
+    /// Nothing to read: getloadavg or sysconf refused.
+    Unavailable,
+
+    /// A reading arrived and is not a usable number. Kept apart from
+    /// Unavailable so a machine whose load average is broken is not filed as
+    /// one that was never asked.
+    Unreadable,
+
+    /// Runnable threads per CPU.
+    Load(f64),
+}
+
+impl HostLoad {
+    pub fn from_reading(load_per_cpu: Option<f64>) -> Self {
+        match load_per_cpu {
+            None => Self::Unavailable,
+            Some(load) if !load.is_finite() || load < 0.0 => Self::Unreadable,
+            Some(load) => Self::Load(load),
+        }
+    }
+
+    /// The spelling that reaches a payload, and never the reading itself.
+    ///
+    /// run_wp hashes the timeout triage into the proof receipt, so a
+    /// continuous environment-dependent float in there would give two
+    /// byte-identical runs on the same machine different receipt digests. That
+    /// is the one property a receipt exists to carry, and rounding does not
+    /// save it: 0.42 and 0.55 differ however few decimals they are printed to.
+    /// A category moves only when the verdict moves. The reading is reported
+    /// beside the response through per_cpu, where nothing hashes it.
+    pub fn category(self) -> &'static str {
+        match self {
+            Self::Unavailable => "unavailable",
+            Self::Unreadable => "unreadable",
+            Self::Load(load) if load > HOST_SATURATED_LOAD_PER_CPU => "saturated",
+            Self::Load(_) => "quiet",
+        }
+    }
+
+    /// The reading, for the response block the receipt does not cover.
+    pub fn per_cpu(self) -> Option<f64> {
+        match self {
+            Self::Load(load) => Some(load),
+            Self::Unavailable | Self::Unreadable => None,
+        }
+    }
+
+    /// Why this reading leaves the host standing as a possible cause, or None
+    /// where it rules the host out.
+    fn timeout_caveat(self) -> Option<&'static str> {
+        match self {
+            Self::Load(load) if load > HOST_SATURATED_LOAD_PER_CPU => Some(
+                "Goals reached the prover budget on an oversubscribed host, where a wall-clock budget expires whatever a goal's difficulty. This run says nothing about whether they are provable. Re-run on an idle machine before drawing any conclusion; retry_unproved only grinds twice as long.",
+            ),
+            Self::Load(_) => None,
+            Self::Unavailable | Self::Unreadable => Some(
+                "Goals reached the prover budget, and host load could not be read, so an oversubscribed machine cannot be ruled out as the cause. Treat this as unclassified rather than as evidence the goals are unprovable; re-run where the load is readable.",
+            ),
+        }
+    }
+}
+
+/// Host load average over the last minute, divided by the host CPU count.
+///
+/// A prover budget is wall clock, so on an oversubscribed host every goal
+/// grinds to it whatever its difficulty, and a timeout stops saying anything
+/// about the goal. Nothing else in this file can see that, which is how a run
+/// made while another job saturated the machine gets reported as evidence
+/// about the code.
+///
+/// A coarse indicator, and deliberately so. The figure is a one-minute average,
+/// it counts uninterruptible sleep as well as runnable work, and it cannot tell
+/// load this server caused from load it merely suffered. It is used only to
+/// withhold a confident verdict, never to assert one.
+///
+/// Sample it before scheduling any proof, never after. A timeout-heavy WP run
+/// at WP's own parallelism drives the one-minute average toward one runnable
+/// thread per CPU by itself, and the stdio suite runs many servers at once by
+/// design, so a reading taken during response assembly is mostly this server's
+/// own provers. Read afterwards, the saturation branch fires on load this run
+/// created and withdraws confidence from the timeouts it was asked to explain.
+///
+/// Unavailable is reported as unknown rather than guessed at: an absent number
+/// must not read as a quiet machine.
+pub fn host_load() -> HostLoad {
+    // The load average is host-wide, whereas `available_parallelism` honors a
+    // container's CPU quota. Pair the former with the host's online CPUs so a
+    // one-CPU container on an otherwise idle many-core host is not "saturated".
+    let cpus = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+    if cpus <= 0 {
+        return HostLoad::Unavailable;
+    }
+
+    // getloadavg rather than reading /proc or spawning sysctl: it is in libc on
+    // both platforms this runs on, so there is no subprocess to block a Tokio
+    // worker, no PATH to resolve, and no output format to parse.
+    let mut avg = [0.0f64; 1];
+    // Safety: getloadavg writes at most nelem doubles, and the buffer holds
+    // exactly that many.
+    if unsafe { libc::getloadavg(avg.as_mut_ptr(), 1) } != 1 {
+        return HostLoad::Unavailable;
+    }
+
+    // from_reading refuses a non-finite or negative figure, so this hands over
+    // the raw quotient rather than screening it first. One screen, one place.
+    HostLoad::from_reading(Some(avg[0] / cpus as f64))
+}
+
+/// How much of this run's evidence was measured here rather than replayed.
+///
+/// WP's cache defaults to Update, so it stores and replays timeout verdicts as
+/// readily as valid ones. A run whose only failing goal came back from the
+/// cache attempted nothing and can look identical to one that did, down to the
+/// receipt digest. The counts below are what makes that visible without
+/// reading the goal array.
+pub struct RunMeasurement {
+    pub goals: usize,
+    pub replayed: usize,
+    pub unproved: usize,
+    pub unproved_replayed: usize,
+
+    /// Of the goals sitting at a prover timeout, how many, and how many of
+    /// those were replayed. Counted apart from the unproved pair because the
+    /// timeout verdict is about these and only these.
+    pub timed_out: usize,
+    pub timed_out_replayed: usize,
+}
+
+impl RunMeasurement {
+    /// Whether this run attempted none of the timeouts it is about to explain.
+    ///
+    /// Scoped to the timed-out goals rather than to every unproved one, because
+    /// the input is the whole fetchGoals table: it carries goals from functions
+    /// proved earlier in the session and goals left at NORESULT by -wp-prop,
+    /// which are unproved and not cached. One of those made
+    /// unproved_replayed != unproved and kept the verdict confident even where
+    /// every timed-out goal had been replayed, which is the single case this
+    /// predicate exists to catch.
+    ///
+    /// The one a reader has to act on, and the reason this is a method on a
+    /// struct rather than a key in a map: the triage reads it in the same
+    /// module that computes it, and routing a bool out through JSON and back
+    /// made a typo in either spelling mean "not replayed", which is the
+    /// confident direction.
+    pub fn every_timed_out_goal_was_replayed(&self) -> bool {
+        self.timed_out > 0 && self.timed_out_replayed == self.timed_out
+    }
+
+    /// Every counter, for the response block a caller reads. The verdict does
+    /// not travel through here: it goes into the triage as one bool, so the
+    /// object is not serialized into two places in the same payload.
+    pub fn to_json(&self) -> serde_json::Value {
+        json!({
+            "goals": self.goals,
+            "replayed": self.replayed,
+            "unproved": self.unproved,
+            "unproved_replayed": self.unproved_replayed,
+            "timed_out": self.timed_out,
+            "timed_out_replayed": self.timed_out_replayed,
+            "every_timed_out_goal_was_replayed": self.every_timed_out_goal_was_replayed(),
+        })
+    }
+}
+
+pub fn run_measurement(goals: &[serde_json::Value]) -> RunMeasurement {
+    let mut measured = RunMeasurement {
+        goals: goals.len(),
+        replayed: 0,
+        unproved: 0,
+        unproved_replayed: 0,
+        timed_out: 0,
+        timed_out_replayed: 0,
+    };
+    for goal in goals {
+        // The module that owns "is this goal proved" answers it. Spelling the
+        // test here was how the two callers of its sibling drifted apart.
+        let unproved = !crate::mcp::status::own_status_is_proved(goal);
+        // The goal's own verdict, like the line above it. Reading the
+        // consolidated one asked what the property it hangs off decided, which
+        // answers "valid" for a timed-out goal under a property that
+        // consolidated valid, and that is the goal this predicate exists to
+        // count. own_status also covers a row straight off the wire, which
+        // carries "status" alone.
+        let timed_out = crate::mcp::status::own_status_is_timeout(goal);
+        let cached = goal_is_from_cache(goal);
+        measured.replayed += usize::from(cached);
+        measured.unproved += usize::from(unproved);
+        measured.unproved_replayed += usize::from(unproved && cached);
+        measured.timed_out += usize::from(timed_out);
+        measured.timed_out_replayed += usize::from(timed_out && cached);
+    }
+    measured
 }
 
 pub fn wp_timeout_triage(
@@ -1117,7 +1355,9 @@ pub fn wp_timeout_triage_from_goal(goal: &serde_json::Value) -> serde_json::Valu
         .unwrap_or("unknown");
     let raw_status = crate::mcp::status::raw_status(goal)
         .unwrap_or(normalized_status);
-    if normalized_status == "timeout" || raw_status.eq_ignore_ascii_case("timeout") {
+    if crate::mcp::status::status_is_timeout(normalized_status)
+        || crate::mcp::status::status_is_timeout(raw_status)
+    {
         return wp_timeout_triage(
             "prover_timeout",
             true,
@@ -1163,6 +1403,8 @@ pub fn wp_timeout_triage_from_goal(goal: &serde_json::Value) -> serde_json::Valu
 pub fn wp_timeout_triage_from_tasks_and_report(
     tasks: &serde_json::Value,
     report: Option<&serde_json::Value>,
+    measurement: Option<&RunMeasurement>,
+    host_load: HostLoad,
 ) -> serde_json::Value {
     let from_tasks = wp_timeout_triage_from_tasks(tasks);
     if from_tasks.get("kind").and_then(|k| k.as_str()) != Some("none") {
@@ -1187,6 +1429,61 @@ pub fn wp_timeout_triage_from_tasks_and_report(
         .iter()
         .filter_map(|f| f.get("trigger").cloned())
         .collect();
+    prover_timeout_triage(timed_out.len(), names, host_load, measurement)
+}
+
+/// The prover-timeout verdict, given a load reading rather than reading one.
+///
+/// Split from its caller so the load can be supplied: the interesting case is
+/// a saturated host, which a test cannot produce by loading the machine it
+/// runs on.
+pub fn prover_timeout_triage(
+    goals_at_timeout: usize,
+    triggers: Vec<serde_json::Value>,
+    host_load: HostLoad,
+    measurement: Option<&RunMeasurement>,
+) -> serde_json::Value {
+    let all_replayed = measurement.is_some_and(RunMeasurement::every_timed_out_goal_was_replayed);
+
+    let evidence = json!([
+        {"field": "goals_at_timeout", "value": goals_at_timeout},
+        {"field": "triggers", "value": triggers},
+
+        // The predicate rather than the counts. The counts are reported beside
+        // the response, and repeating the whole object here put two copies of
+        // it in every payload; what the verdict below rests on is this bool.
+        {"field": "every_timed_out_goal_was_replayed", "value": all_replayed},
+
+        // Categorized, never the reading: this payload is hashed into the
+        // proof receipt. See HostLoad::category.
+        {"field": "host_load", "value": host_load.category()},
+    ]);
+
+    // High is the claim that this run measured everything its verdict rests on.
+    // Each caveat below withdraws it for one thing the run did not measure, and
+    // every one that applies is named: a run that both replayed its failures
+    // and ran on a loaded host has two problems, and reporting only the first
+    // sends the caller to re-run with cache "None" on the machine that will
+    // grind to the budget again.
+    let withdrawn: Vec<&str> = [
+        all_replayed.then_some(
+            "Every timed-out goal in this run came back from WP's cache rather than being attempted, so this run measured nothing about them. WP's cache defaults to Update and stores timeout verdicts too. Re-run with cache: \"None\" before drawing any conclusion.",
+        ),
+        host_load.timeout_caveat(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    let (confidence, reason) = if withdrawn.is_empty() {
+        (
+            "high",
+            "Goals reached the prover budget without a verdict. That does not mean they need more time: an unprovable goal grinds to the budget too. Use retry_unproved to see whether any flip at double the budget.".to_string(),
+        )
+    } else {
+        ("low", withdrawn.join(" "))
+    };
+
     wp_timeout_triage(
         "prover_timeout",
 
@@ -1195,12 +1492,9 @@ pub fn wp_timeout_triage_from_tasks_and_report(
         // advice that sends a caller round a loop that never terminates. See
         // classify_failure_reason for how to tell the two apart.
         false,
-        "high",
-        "Goals reached the prover budget without a verdict. That does not mean they need more time: an unprovable goal grinds to the budget too. Use retry_unproved to see whether any flip at double the budget.",
-        json!([
-            {"field": "goals_at_timeout", "value": timed_out.len()},
-            {"field": "triggers", "value": names},
-        ]),
+        confidence,
+        &reason,
+        evidence,
     )
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -276,6 +276,27 @@ pub struct VerificationProfile {
     #[serde(default)]
     pub provers: Vec<String>,
     pub timeout_seconds: Option<u32>,
+
+    /// System include directories the target's own command passes.
+    #[serde(default)]
+    pub isystem_paths: Vec<String>,
+
+    /// Whether the target's own command drops the default system includes.
+    ///
+    /// Pinned like the include paths: on a platform whose real headers shadow
+    /// the modeled libc, a load without this compiles different declarations,
+    /// so a run under it is not evidence about this target. Unset means the
+    /// profile does not speak to it.
+    pub nostdinc: Option<bool>,
+
+    /// Whether the target's own command generates runtime-error obligations.
+    ///
+    /// Pinned like the model and the provers, and for the same reason: -wp-rte
+    /// decides which obligations exist at all, so a run without it discharges a
+    /// strictly smaller set. Without this field a caller could pass rte:false
+    /// and have the thinner run recorded as this target's evidence.
+    pub rte: Option<bool>,
+
     /// The command that makes this target's verdict outside this server.
     ///
     /// Carried so a conclusion can name it. This server is an accelerator: a
@@ -292,9 +313,29 @@ pub struct VerificationProfile {
 pub fn parse_verification_profiles(
     value: &serde_json::Value,
 ) -> Result<BTreeMap<String, VerificationProfile>, String> {
-    let object = value
-        .as_object()
-        .ok_or_else(|| "profiles must be an object keyed by target name".to_string())?;
+    // The quoted-object form a schema-less client sends is unwrapped at the
+    // boundary, by deserialize_value_or_string on the parameter itself, which
+    // is where the other Value-typed parameters handle it. This used to redo it
+    // here, one layer down and slightly differently: the two disagreed on the
+    // empty string, and the second copy existed only because the parameter
+    // carried no deserializer.
+    let object = value.as_object().ok_or_else(|| {
+        let got = match value {
+            serde_json::Value::Null => "null",
+            serde_json::Value::Bool(_) => "a boolean",
+            serde_json::Value::Number(_) => "a number",
+            serde_json::Value::Array(_) => "an array",
+
+            // Reachable through a double-encoded payload: the boundary unwraps
+            // one layer of quoting, so text that decodes to another string
+            // arrives here as one.
+            serde_json::Value::String(_) => "a string",
+
+            // Unreachable: this runs only where as_object() already said no.
+            serde_json::Value::Object(_) => "an object",
+        };
+        format!("profiles must be an object keyed by target name, got {got}")
+    })?;
     if object.is_empty() {
         return Err("profiles is empty, so no target could be named later".to_string());
     }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -10,8 +10,26 @@ pub fn workspace_path(rel: &str) -> PathBuf {
     PathBuf::from(crate_dir).join(rel)
 }
 
+/// The server binary these tests drive.
+///
+/// The release build when there is one, because that is what a developer has
+/// usually just built and what the timing-sensitive lifecycle tests were
+/// written against. Otherwise the binary Cargo built for this test run:
+/// integration tests get `CARGO_BIN_EXE_<name>` for free, and Cargo builds the
+/// bin as a dependency of the test target, so it is always present.
+///
+/// The fallback is why nothing here has to assert the binary exists. A plain
+/// `cargo test` on a tree with no release build used to fail thirteen tests at
+/// once on a missing file, which reads like a defect in the code under test
+/// rather than a missing prerequisite. Building it from inside the test was the
+/// first fix and the wrong one: a nested Cargo waits on the target-directory
+/// lock the parent `cargo test` may still hold.
 pub fn release_binary() -> PathBuf {
-    workspace_path("target/release/frama-c-mcp")
+    let release = workspace_path("target/release/frama-c-mcp");
+    if release.exists() {
+        return release;
+    }
+    PathBuf::from(env!("CARGO_BIN_EXE_frama-c-mcp"))
 }
 
 /// Conclusions and sandbox metadata for one test binary, kept out of the repo.
@@ -86,12 +104,6 @@ fn path_segment(name: &str) -> String {
 /// times is one that gets changed four times, and the two spellings then differ
 /// in a way nothing reports.
 pub fn server_command(binary: &Path, frama_c: &str, cwd: Option<&Path>) -> StdCommand {
-    assert!(
-        binary.exists(),
-        "MCP binary missing: {}\nRun `cargo build --release` first.",
-        binary.display()
-    );
-
     let mut cmd = StdCommand::new(binary);
     cmd.arg("--frama-c").arg(frama_c);
 

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -12,24 +12,43 @@ pub fn workspace_path(rel: &str) -> PathBuf {
 
 /// The server binary these tests drive.
 ///
-/// The release build when there is one, because that is what a developer has
-/// usually just built and what the timing-sensitive lifecycle tests were
-/// written against. Otherwise the binary Cargo built for this test run:
-/// integration tests get `CARGO_BIN_EXE_<name>` for free, and Cargo builds the
-/// bin as a dependency of the test target, so it is always present.
+/// The fresher of the release build and the one Cargo built for this run,
+/// compared by modification time. Integration tests get CARGO_BIN_EXE_<name>
+/// for free and Cargo builds the bin as a dependency of the test target, so
+/// that one is always present and always current.
 ///
-/// The fallback is why nothing here has to assert the binary exists. A plain
-/// `cargo test` on a tree with no release build used to fail thirteen tests at
-/// once on a missing file, which reads like a defect in the code under test
-/// rather than a missing prerequisite. Building it from inside the test was the
-/// first fix and the wrong one: a nested Cargo waits on the target-directory
-/// lock the parent `cargo test` may still hold.
+/// Preferring release unconditionally was the trap. A stale
+/// target/release/frama-c-mcp is still a file, so an exists() check still chose
+/// it, and the whole suite then exercised the code as it was before the change
+/// under test. That is the failure CLAUDE.md records for
+/// McpHandle::spawn, and a green run said nothing about the edit that had just
+/// been made. Release is still preferred when it is the newer of the two,
+/// because it is what a developer has usually just built and what the
+/// timing-sensitive lifecycle tests were written against.
+///
+/// Neither branch asserts the binary exists. A plain `cargo test` on a tree
+/// with no release build used to fail thirteen tests at once on a missing
+/// file, which reads like a defect in the code under test rather than a
+/// missing prerequisite. Building it from inside the test was the first fix
+/// and the wrong one: a nested Cargo waits on the target-directory lock the
+/// parent `cargo test` may still hold.
 pub fn release_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_frama-c-mcp"));
     let release = workspace_path("target/release/frama-c-mcp");
-    if release.exists() {
-        return release;
+
+    let modified = |path: &PathBuf| {
+        std::fs::metadata(path)
+            .and_then(|meta| meta.modified())
+            .ok()
+    };
+
+    // Only when release is strictly newer. Everything else, including equal
+    // timestamps and an absent or unreadable release build, falls to the binary
+    // Cargo just produced, which is the answer that cannot be stale.
+    match (modified(&release), modified(&built)) {
+        (Some(release_at), Some(built_at)) if release_at > built_at => release,
+        _ => built,
     }
-    PathBuf::from(env!("CARGO_BIN_EXE_frama-c-mcp"))
 }
 
 /// Conclusions and sandbox metadata for one test binary, kept out of the repo.

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -10166,4 +10166,47 @@ async fn naming_a_profile_does_not_turn_off_the_runtime_error_checks() {
         .await,
         false
     );
+
+    // A load without RTE says so in incomplete[], whichever of the three
+    // decided it. check resolves rte before reload_project sees it, and the
+    // gap list used to be handed the caller's unresolved value, so naming a
+    // profile that turns RTE off produced a load with no runtime-error
+    // obligations and no RTE_DISABLED gap to say so.
+    let gap_codes = |args: serde_json::Value| {
+        let client = &client;
+        async move {
+            let result = call_tool_json(client, "check", args).await.unwrap();
+            result["incomplete"]
+                .as_array()
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|item| item["code"].as_str().map(str::to_string))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        }
+    };
+
+    let via_profile =
+        gap_codes(json!({"function": "swap", "timeout": 1, "verify_profile": "no_rte"})).await;
+    assert!(
+        via_profile.iter().any(|code| code == "RTE_DISABLED"),
+        "a profile turned RTE off without saying so: {via_profile:?}"
+    );
+
+    let via_caller =
+        gap_codes(json!({"function": "swap", "timeout": 1, "rte": false})).await;
+    assert!(
+        via_caller.iter().any(|code| code == "RTE_DISABLED"),
+        "{via_caller:?}"
+    );
+
+    // And RTE on reports no such gap, so the assertion above is not vacuous.
+    let with_rte =
+        gap_codes(json!({"function": "swap", "timeout": 1, "verify_profile": "with_rte"})).await;
+    assert!(
+        !with_rte.iter().any(|code| code == "RTE_DISABLED"),
+        "{with_rte:?}"
+    );
 }

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -186,13 +186,7 @@ async fn spawn_mcp_client_inner(
     cwd: Option<&Path>,
     env: &[(&str, &str)],
 ) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
-    let binary = workspace_path("target/release/frama-c-mcp");
-    if !binary.exists() {
-        panic!(
-            "MCP binary missing: {}\nRun `cargo build --release` first.",
-            binary.display()
-        );
-    }
+    let binary = harness::release_binary();
     let frama_c = std::env::var("FRAMA_C_BIN").unwrap_or_else(|_| "frama-c".into());
 
     let mut cmd = Command::new(&binary);
@@ -9728,6 +9722,8 @@ async fn a_named_profile_decides_the_model_wp_proves_under() {
                     "model": "Typed+cast",
                     "provers": ["alt-ergo"],
                     "timeout_seconds": 10,
+                    "rte": false,
+                    "nostdinc": false,
                     "reproduce": "make verify-demo"
                 },
                 "incomplete": {
@@ -9787,7 +9783,7 @@ async fn a_named_profile_decides_the_model_wp_proves_under() {
     )
     .await
     .expect_err("incomplete profile is not evidence");
-    assert!(format!("{error:?}").contains("missing functions, model, provers, or timeout_seconds"));
+    assert!(format!("{error:?}").contains("missing functions, model, provers, timeout_seconds, rte, or nostdinc"));
 
     let sandbox = call_tool_json(&client, "create_sandbox", json!({
         "function": "swap",
@@ -9855,6 +9851,8 @@ async fn a_profile_refuses_a_project_and_a_function_set_that_are_not_its_own() {
                     "model": "Typed+cast",
                     "provers": ["alt-ergo"],
                     "timeout_seconds": 10,
+                    "rte": false,
+                    "nostdinc": false,
                     "reproduce": "make verify-swap"
                 }
             }
@@ -9917,6 +9915,8 @@ async fn a_conclusion_can_name_the_target_it_settles() {
                     "model": "Typed+cast",
                     "provers": ["alt-ergo"],
                     "timeout_seconds": 10,
+                    "rte": false,
+                    "nostdinc": false,
                     "reproduce": "make verify-swap"
                 },
 
@@ -9929,6 +9929,8 @@ async fn a_conclusion_can_name_the_target_it_settles() {
                     "model": "Typed+nocast",
                     "provers": ["alt-ergo"],
                     "timeout_seconds": 10,
+                    "rte": false,
+                    "nostdinc": false,
                     "reproduce": "make verify-swap-nocast"
                 }
             },
@@ -10032,4 +10034,136 @@ async fn a_conclusion_can_name_the_target_it_settles() {
     let text = format!("{listed:?}");
     assert!(text.contains("\"verify_profile\": String(\"swap\")"), "{text}");
     assert!(text.contains("make verify-swap"), "{text}");
+}
+
+/// The load settings a receipt is hashed over have to be visible in the load.
+///
+/// isystem_paths and nostdinc decide which headers the files were compiled
+/// against, so they are part of project_load_identity and therefore part of the
+/// proof receipt digest. The response echoed every other load setting and not
+/// these two, which left a caller unable to check what program it had actually
+/// loaded against the target it meant to load.
+#[tokio::test]
+async fn reload_echoes_the_header_settings_its_receipt_is_hashed_over() {
+    let c_file = tutorial_c("swap-frame.c");
+    let client = spawn_mcp_client(c_file.to_str().unwrap()).await;
+    let stubs = c_file.parent().unwrap().to_str().unwrap().to_string();
+
+    let plain = call_tool_json(
+        &client,
+        "reload_project",
+        json!({"files": [c_file.to_str().unwrap()]}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(plain["isystem_paths"], json!([]), "{plain:?}");
+    assert_eq!(plain["nostdinc"], false, "{plain:?}");
+
+    let with_headers = call_tool_json(
+        &client,
+        "reload_project",
+        json!({
+            "files": [c_file.to_str().unwrap()],
+            "isystem_paths": [stubs.clone()],
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(with_headers["isystem_paths"], json!([stubs]), "{with_headers:?}");
+    assert_eq!(with_headers["nostdinc"], false, "{with_headers:?}");
+}
+
+/// Naming a target must not quietly change what gets loaded.
+///
+/// check's RTE default is on. reload_project resolves an unset rte through the
+/// named profile and then to false, which is right for a load and wrong here: a
+/// profile silent on rte turned RTE off the moment a target was named, so the
+/// call README documents as the way to check a target parsed a program with no
+/// runtime-error obligations in it, and reported EVA and the parse against
+/// that. The profile still decides when it states a value, and the caller
+/// still decides over both.
+#[tokio::test]
+async fn naming_a_profile_does_not_turn_off_the_runtime_error_checks() {
+    let c_file = tutorial_c("swap-frame.c");
+    let client = spawn_mcp_client(c_file.to_str().unwrap()).await;
+
+    let complete = |rte: bool| {
+        json!({
+            "sources": [c_file.to_str().unwrap()],
+            "functions": ["swap"],
+            "model": "Typed+cast",
+            "provers": ["alt-ergo"],
+            "timeout_seconds": 10,
+            "rte": rte,
+            "nostdinc": false,
+            "reproduce": "make verify"
+        })
+    };
+
+    call_tool_json(
+        &client,
+        "reload_project",
+        json!({
+            "files": [c_file.to_str().unwrap()],
+            "verify_profiles": {
+                // Registered for loading only: it says nothing about rte, so it
+                // cannot be proof evidence and run_wp refuses it. What it must
+                // not do is quietly decide the load.
+                "silent": {
+                    "sources": [c_file.to_str().unwrap()],
+                    "functions": ["swap"],
+                    "model": "Typed+cast",
+                    "provers": ["alt-ergo"],
+                    "timeout_seconds": 10,
+                    "reproduce": "make verify-silent"
+                },
+                "no_rte": complete(false),
+                "with_rte": complete(true),
+            },
+            "verify_profiles_source": "make print-verify-profiles"
+        }),
+    )
+    .await
+    .unwrap();
+
+    let loaded_rte = |args: serde_json::Value| {
+        let client = &client;
+        async move {
+            let result = call_tool_json(client, "check", args).await.unwrap();
+            result["reload"]["rte"].clone()
+        }
+    };
+
+    // No profile named: check's own default, which is on.
+    assert_eq!(
+        loaded_rte(json!({"function": "swap", "timeout": 1})).await,
+        true
+    );
+
+    // A profile that says nothing about rte must not overrule that default.
+    assert_eq!(
+        loaded_rte(json!({"function": "swap", "timeout": 1, "verify_profile": "silent"})).await,
+        true,
+        "naming a target turned RTE off"
+    );
+
+    // One that does say so still decides, in both directions: that is the
+    // target's own setting and the run is labelled as its evidence.
+    assert_eq!(
+        loaded_rte(json!({"function": "swap", "timeout": 1, "verify_profile": "no_rte"})).await,
+        false
+    );
+    assert_eq!(
+        loaded_rte(json!({"function": "swap", "timeout": 1, "verify_profile": "with_rte"})).await,
+        true
+    );
+
+    // And the caller wins over both.
+    assert_eq!(
+        loaded_rte(json!({
+            "function": "swap", "timeout": 1, "verify_profile": "with_rte", "rte": false
+        }))
+        .await,
+        false
+    );
 }

--- a/tests/test-transport-poison-recovery.rs
+++ b/tests/test-transport-poison-recovery.rs
@@ -47,6 +47,8 @@ fn reload_params(files: Option<Vec<String>>) -> Parameters<ReloadProjectParams> 
         include_paths: None,
         defines: None,
         force_includes: None,
+        isystem_paths: None,
+        nostdinc: None,
         machdep: None,
         detail: None,
         compilation_database: None,

--- a/tests/unit/check-gaps.rs
+++ b/tests/unit/check-gaps.rs
@@ -4,14 +4,21 @@ use frama_c_mcp::error::FramaCError;
 
 use frama_c_mcp::mcp::server::*;
 use frama_c_mcp::mcp::server::analysis::{
+    goal_needs_failure_classification,
+    property_is_dead, render_sequent,
+    wp_backend_anomaly_left_goal_unjudged,
+};
+
+// The band this file was named after now has a module of its own in src/, for
+// the same reason this file came out of tests/unit/server.rs.
+use frama_c_mcp::mcp::server::checkgaps::{
     check_blocked_reason,
-    gap_guidance,
-    incomplete_guidance,
     check_incomplete_items,
     check_variants_summary,
-    goal_needs_failure_classification,
-    property_is_dead, render_sequent, WantedAnalyses,
-    wp_backend_anomaly_left_goal_unjudged,
+    gap_guidance,
+    incomplete_guidance,
+    check_next_call, incomplete_code, NextCallInputs,
+    WantedAnalyses,
 };
 use frama_c_mcp::mcp::server::selfcheck::{
     buggy_fixture_reason, fixed_fixture_reason,
@@ -1407,4 +1414,88 @@ fn variant_summary_will_not_call_an_unchecked_matrix_proved() {
     assert_eq!(partial["verdict"], "incomplete", "{partial:?}");
     assert_eq!(partial["ast_digest_unavailable_count"], 1);
     assert_eq!(partial["distinct_asts"], 1);
+}
+
+/// A crashed backend is read before the goal it left behind.
+///
+/// Extracted from check_payload as check_next_call, which is what made this
+/// testable at all: the ordering used to be a 67-line fallback chain inside a
+/// 296-line method, and breaking the first link failed nothing.
+///
+/// The order matters in both directions. A Why3 abort stamps goals FAILED with
+/// no prover having answered, so pointing the caller at such a goal sends them
+/// to rewrite an annotation that was never judged. But an abort that cost no
+/// goal its verdict must not displace a call targeting a goal still open,
+/// which is what anomaly_left_goals_unjudged gates.
+#[test]
+fn a_crashed_backend_outranks_the_goal_it_left_unjudged() {
+    let diagnosis = json!({
+        "next_action": {"tool": "run_wp", "args": {"model": "Typed+cast"}, "reason": "backend"}
+    });
+    let alarms = json!([{
+        "marker": "#p1",
+        "normalized_status": "unknown",
+        "kind": "mem_access",
+    }]);
+    let goals = json!([{"stable_goal_id": "g1", "normalized_status": "unknown"}]);
+
+    let next = |unjudged: bool| {
+        check_next_call(NextCallInputs {
+            backend_diagnosis: &diagnosis,
+            anomaly_left_goals_unjudged: unjudged,
+            eva_alarms: &alarms,
+            wp_goals: &goals,
+            incomplete: &[],
+            wanted: WantedAnalyses::BOTH,
+            function: None,
+        })
+    };
+
+    // The abort left something unjudged, so it is what the caller is sent at.
+    assert_eq!(next(true)["reason"], "backend", "{:?}", next(true));
+
+    // It cost no goal its verdict, so the open goal wins instead.
+    assert_ne!(next(false)["reason"], "backend", "{:?}", next(false));
+}
+
+/// With nothing to point at, the fallback says which sentence it means.
+///
+/// "Nothing to target" and "nothing wrong" are different, and a clean run is
+/// exactly when vacuity is worth raising: check runs no smoke tests, so an
+/// over-strong requires proves everything and silently excludes the branch it
+/// forbids.
+#[test]
+fn the_fallback_separates_a_clean_run_from_a_blocked_one() {
+    let empty = json!([]);
+    let next = |incomplete: &[serde_json::Value]| {
+        check_next_call(NextCallInputs {
+            backend_diagnosis: &json!({}),
+            anomaly_left_goals_unjudged: false,
+            eva_alarms: &empty,
+            wp_goals: &empty,
+            incomplete,
+            wanted: WantedAnalyses::BOTH,
+            function: None,
+        })
+    };
+
+    let clean = next(&[]);
+    assert_eq!(clean["tool"], "get_wp_goals", "{clean:?}");
+    assert!(clean["reason"].as_str().unwrap().contains("vacuity"), "{clean:?}");
+
+    let blocked = next(&[json!({"code": incomplete_code::WP_NOT_RUN, "reason": "x"})]);
+    assert!(!blocked["reason"].as_str().unwrap().contains("vacuity"), "{blocked:?}");
+
+    // An analysis the caller left out is answered by asking for it, not by
+    // reading the table nothing filled.
+    let skipped = check_next_call(NextCallInputs {
+        backend_diagnosis: &json!({}),
+        anomaly_left_goals_unjudged: false,
+        eva_alarms: &empty,
+        wp_goals: &empty,
+        incomplete: &[],
+        wanted: WantedAnalyses { eva: true, wp: false },
+        function: None,
+    });
+    assert_eq!(skipped["tool"], "check", "{skipped:?}");
 }

--- a/tests/unit/check-gaps.rs
+++ b/tests/unit/check-gaps.rs
@@ -17,7 +17,7 @@ use frama_c_mcp::mcp::server::checkgaps::{
     check_variants_summary,
     gap_guidance,
     incomplete_guidance,
-    check_next_call, incomplete_code, NextCallInputs,
+    check_next_call, incomplete_code, wp_goal_gaps, NextCallInputs,
     WantedAnalyses,
 };
 use frama_c_mcp::mcp::server::selfcheck::{
@@ -1498,4 +1498,53 @@ fn the_fallback_separates_a_clean_run_from_a_blocked_one() {
         function: None,
     });
     assert_eq!(skipped["tool"], "check", "{skipped:?}");
+}
+
+/// A proof that leaned on an impossible hypothesis is a gap, not a proof.
+///
+/// Frama-C spells this "valid_under_false_hypothesis" on the property while the
+/// goal's own status stays "valid". It is neither of the two states
+/// proved_goal_gap used to test for: property_is_dead matches only "_but_dead",
+/// and goal_is_valid_under_hypotheses matches "valid_under_hyp". A goal in this
+/// state answered both false and produced no gap, so check reported "proved"
+/// over a proof that holds over no execution, while get_wp_goals reported it
+/// through goal_needs_failure_classification. The two paths disagreed.
+#[test]
+fn a_vacuously_discharged_property_is_reported_rather_than_counted_as_proved() {
+    let vacuous = json!([{
+        "wpo": "w1",
+        "stable_goal_id": "g1",
+        "normalized_status": "valid",
+        "normalized_property_status": "valid_under_false_hypothesis",
+        "counts_as_progress": false,
+        "vacuous": true,
+        "vacuity_reason": "an earlier instance of the same property did not prove",
+    }]);
+    let mut items = Vec::new();
+    wp_goal_gaps(&mut items, &json!([]), &vacuous);
+    let codes: Vec<&str> = items.iter().filter_map(|i| i["code"].as_str()).collect();
+    assert!(
+        codes.contains(&"PROPERTY_VACUOUS"),
+        "a vacuous proof produced no gap: {codes:?}"
+    );
+
+    // Not filed as dead code, which is a different finding with different
+    // advice: dead code is unreachable, this statement is reachable.
+    assert!(!codes.contains(&"PROPERTY_DEAD"), "{codes:?}");
+
+    // And a genuinely valid goal still produces nothing, so the assertion above
+    // is not just "every goal reports something".
+    let mut clean = Vec::new();
+    wp_goal_gaps(
+        &mut clean,
+        &json!([]),
+        &json!([{
+            "wpo": "w2",
+            "stable_goal_id": "g2",
+            "normalized_status": "valid",
+            "normalized_property_status": "valid",
+            "counts_as_progress": true,
+        }]),
+    );
+    assert!(clean.is_empty(), "{clean:?}");
 }

--- a/tests/unit/project.rs
+++ b/tests/unit/project.rs
@@ -18,6 +18,13 @@ fn with_include_paths(paths: &[&str]) -> ProjectLoadOptions {
     }
 }
 
+fn with_isystem_paths(paths: &[&str]) -> ProjectLoadOptions {
+    ProjectLoadOptions {
+        isystem_paths: paths.iter().map(|p| p.to_string()).collect(),
+        ..Default::default()
+    }
+}
+
 fn with_force_includes(headers: &[&str]) -> ProjectLoadOptions {
     ProjectLoadOptions {
         force_includes: headers.iter().map(|h| h.to_string()).collect(),
@@ -34,6 +41,14 @@ fn plain_and_valued_defines_are_accepted() {
 fn ordinary_paths_and_headers_are_accepted() {
     assert!(validate_project_options(&with_include_paths(&["include", "../vendor/inc"])).is_ok());
     assert!(validate_project_options(&with_force_includes(&["builtins.h", "sys/types.h"])).is_ok());
+}
+
+#[test]
+fn system_include_paths_use_the_same_safe_grammar() {
+    let valid = with_isystem_paths(&["include", "../vendor/inc"]);
+    let injected = with_isystem_paths(&["$(touch pwned)"]);
+    assert!(validate_project_options(&valid).is_ok());
+    assert!(validate_project_options(&injected).is_err());
 }
 
 /// The log shape is verbatim Frama-C 33: tag and location on one line, text
@@ -301,11 +316,11 @@ fn an_unreadable_parse_log_is_not_a_clean_parse() {
     // that the analyzed program is the compiled one.
     let reload = json!({"ast_reload_health": {"parse_diagnostics": record}});
     let mut items = Vec::new();
-    analysis::ast_diagnostic_gaps(&mut items, &reload, &[]);
+    checkgaps::ast_diagnostic_gaps(&mut items, &reload, &[]);
     assert_eq!(items.len(), 1, "{items:?}");
     assert_eq!(
         items[0]["code"],
-        analysis::incomplete_code::AST_PARSE_DIAGNOSTICS_UNAVAILABLE
+        checkgaps::incomplete_code::AST_PARSE_DIAGNOSTICS_UNAVAILABLE
     );
     assert!(
         items[0]["detail"]
@@ -320,7 +335,7 @@ fn an_unreadable_parse_log_is_not_a_clean_parse() {
         "kernel:asm:clobber": {"count": 0, "count_unit": "sites"},
     }}}});
     let mut items = Vec::new();
-    analysis::ast_diagnostic_gaps(&mut items, &clean, &[]);
+    checkgaps::ast_diagnostic_gaps(&mut items, &clean, &[]);
     assert!(items.is_empty(), "{items:?}");
 }
 
@@ -801,4 +816,32 @@ fn a_header_is_read_off_the_phrase_not_off_the_first_quote() {
         quoted.message.contains("something new here"),
         "the message must carry what could not be classified: {quoted:?}"
     );
+}
+
+// Frama-C puts the location on the "User Error:" line and the reason on the
+// indented lines under it, so quoting one line names nothing. This is the
+// branch whose whole job is to say what it could not classify.
+#[test]
+fn an_unclassified_failure_quotes_the_reason_not_just_the_location() {
+    let output = "[kernel] Parsing src/syscall/sys.c (with preprocessing)\n\
+                  [kernel] src/syscall/sys.c:86: User Error: \n  \
+                  Cannot find field ru_maxrss in type struct rusage\n        \
+                  _Static_assert(__builtin_offsetof(struct rusage,ru_maxrss) ==\n";
+    let block = frama_c_mcp::mcp::server::project::classify_parse_failure(output);
+    assert_eq!(block.cause, "other");
+    assert!(block.message.contains("sys.c:86"), "{}", block.message);
+    assert!(
+        block.message.contains("Cannot find field ru_maxrss"),
+        "the reason must survive: {}",
+        block.message
+    );
+}
+
+// The next unindented line is a new message, not more of this one.
+#[test]
+fn an_unclassified_failure_stops_at_the_next_message() {
+    let output = "[kernel] a.c:1: User Error: \n  first reason\n[kernel] b.c:2: User Error: \n  second reason\n";
+    let block = frama_c_mcp::mcp::server::project::classify_parse_failure(output);
+    assert!(block.message.contains("first reason"), "{}", block.message);
+    assert!(!block.message.contains("second reason"), "{}", block.message);
 }

--- a/tests/unit/repo-guards.rs
+++ b/tests/unit/repo-guards.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 
 use frama_c_mcp::mcp::server::*;
 use frama_c_mcp::mcp::server::receipt::strip_generated_label;
-use frama_c_mcp::mcp::server::analysis::{
+use frama_c_mcp::mcp::server::checkgaps::{
     ast_diagnostic_gaps, incomplete_code, AST_WARNING_ALLOWLIST, CHECK_SCHEMA,
 };
 use frama_c_mcp::mcp::server::selfcheck;

--- a/tests/unit/server.rs
+++ b/tests/unit/server.rs
@@ -9,12 +9,13 @@ use frama_c_mcp::mcp::server::contracts::{result_unconstrained_findings, unconst
 use frama_c_mcp::mcp::server::eacsl::run_e_acsl_counterexample;
 use frama_c_mcp::mcp::server::wpclass::*;
 use frama_c_mcp::mcp::server::analysis::unproved_assumption_findings;
+use frama_c_mcp::mcp::server::checkgaps::{check_incomplete_items, WantedAnalyses};
 
 use frama_c_mcp::mcp::server::*;
 use frama_c_mcp::mcp::server::analysis::{
     append_to_error_message, assumed_callee_contract_findings,
-    check_incomplete_items, finish_verify_program_step_response, goal_status_matches, present_statuses, reject_unknown_status,
-    wp_timed_out, WantedAnalyses,
+    finish_verify_program_step_response, goal_status_matches, present_statuses, reject_unknown_status,
+    wp_timed_out,
     GOAL_STATUS_UNPROVED, VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES,
 };
 use frama_c_mcp::mcp::server::contracts::int_literal_before;
@@ -1515,6 +1516,7 @@ chmod +x "$out.e-acsl"
             force_includes: vec!["builtins.h".to_string()],
             machdep: Some("gcc_x86_64".to_string()),
             compilation_database: Some("compile-commands.json".to_string()),
+            ..Default::default()
         },
         None,
         &[],
@@ -1535,20 +1537,73 @@ chmod +x "$out.e-acsl"
     // the two copies is dropped, and one copy is exactly the failure this pins:
     // a project that needs a -D to parse needs the same -D to compile, so half
     // the flags means it analyzes and then fails to instrument.
-    let flags_follow = |flag: &str| {
-        payload["compile"]["command"].as_array().is_some_and(|command| {
-            command.windows(2).any(|pair| {
-                pair[0] == flag && pair[1] == "-Iinclude -DNDEBUG -include builtins.h"
+    let flags_after = |flag: &str| {
+        payload["compile"]["command"]
+            .as_array()
+            .and_then(|command| {
+                command
+                    .windows(2)
+                    .find(|pair| pair[0] == flag)
+                    .and_then(|pair| pair[1].as_str())
+                    .map(str::to_string)
             })
-        })
+            .unwrap_or_else(|| {
+                panic!("{flag} missing from {:?}", payload["compile"]["command"])
+            })
     };
     for flag in ["-E", "-e"] {
-        assert!(
-            flags_follow(flag),
-            "{flag} did not carry the preprocessor flags: {:?}",
-            payload["compile"]["command"]
+        assert_eq!(
+            flags_after(flag),
+            "-Iinclude -DNDEBUG -include builtins.h",
+            "{flag} did not carry the preprocessor flags"
         );
     }
+    // -nostdinc is the one flag that goes to the analyzer and not to the
+    // compiler behind it. Frama-C's modeled libc exists to be analyzed:
+    // dropping the real system headers from the gcc that builds the
+    // instrumented program leaves it without stdio, stdlib or the E-ACSL
+    // runtime headers, so a project that loads with nostdinc analyzes cleanly
+    // and then fails to build.
+    let with_nostdinc = run_e_acsl_counterexample(
+        "frama-c",
+        &[source.display().to_string()],
+        &ProjectLoadOptions {
+            include_paths: vec!["include".to_string()],
+            isystem_paths: vec!["/opt/frama-c/libc".to_string()],
+            nostdinc: true,
+            machdep: Some("gcc_x86_64".to_string()),
+            ..Default::default()
+        },
+        None,
+        &[],
+        5,
+        Some(tool.to_str().unwrap()),
+    )
+    .await;
+    let nostdinc_flags_after = |flag: &str| {
+        with_nostdinc["compile"]["command"]
+            .as_array()
+            .and_then(|command| {
+                command
+                    .windows(2)
+                    .find(|pair| pair[0] == flag)
+                    .and_then(|pair| pair[1].as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| {
+                panic!("{flag} missing from {:?}", with_nostdinc["compile"]["command"])
+            })
+    };
+    assert_eq!(
+        nostdinc_flags_after("-E"),
+        "-nostdinc -Iinclude -isystem /opt/frama-c/libc"
+    );
+    assert_eq!(
+        nostdinc_flags_after("-e"),
+        "-Iinclude -isystem /opt/frama-c/libc",
+        "-nostdinc reached the C compiler"
+    );
+
     assert!(payload["compile"]["command"]
         .as_array()
         .is_some_and(|command| command.iter().any(|arg| arg == "--mbits")

--- a/tests/unit/state.rs
+++ b/tests/unit/state.rs
@@ -1786,7 +1786,9 @@ fn a_profile_silent_on_rte_or_nostdinc_cannot_check_a_receipt() {
     for (rte, nostdinc) in [(None, Some(false)), (Some(false), None), (None, None)] {
         let err = profile_evidence_error("t", &profile(rte, nostdinc), "f", Some(&receipt))
             .unwrap_or_else(|| panic!("accepted a profile silent on one of them"));
-        assert!(err.contains("rte or nostdinc"), "{err}");
+        // Names both, because the guard fires when either is unset and
+        // "rte or nostdinc" reads as though only one of them were missing.
+        assert!(err.contains("must state both rte and nostdinc"), "{err}");
     }
 
     // Stating both gets past this check and on to the load comparison, which is

--- a/tests/unit/state.rs
+++ b/tests/unit/state.rs
@@ -1449,14 +1449,32 @@ fn profile_paths_are_not_normalized() {
             "defines": ["TARGET=1"],
             "force_includes": ["target.h"],
             "machdep": "gcc_x86_64",
+            "rte": false,
+            "isystem_paths": [],
+            "nostdinc": false,
             "provers": ["alt-ergo"],
             "timeout_seconds": 10
         }))
         .unwrap();
 
+        // Built through the function that writes it, so a field added to
+        // ProjectLoadOptions reaches these fixtures rather than making every
+        // one of them differ from the receipt for a reason no assertion names.
+        let target_load = || {
+            frama_c_mcp::mcp::server::receipt::project_load_identity(
+                &frama_c_mcp::mcp::server::ProjectLoadOptions {
+                    include_paths: vec!["include".into()],
+                    defines: vec!["TARGET=1".into()],
+                    force_includes: vec!["target.h".into()],
+                    machdep: Some("gcc_x86_64".into()),
+                    ..Default::default()
+                },
+            )
+        };
+
         let wrong_function = json!({
             "wp": {"functions": ["order_3"], "model": "Typed+cast"},
-            "subject": {"files": [{"path": "swap-frame.c", "sha256": "h"}, {"path": "support.c", "sha256": "h"}], "project_load": {"include_paths": ["include"], "defines": ["TARGET=1"], "force_includes": ["target.h"], "machdep": "gcc_x86_64", "compilation_database": null}}
+            "subject": {"files": [{"path": "swap-frame.c", "sha256": "h"}, {"path": "support.c", "sha256": "h"}], "project_load": target_load()}
         });
         assert!(
             profile_evidence_error("target", &profile, "swap", Some(&wrong_function))
@@ -1466,7 +1484,7 @@ fn profile_paths_are_not_normalized() {
 
         let wrong_source = json!({
             "wp": {"functions": ["swap"], "model": "Typed+cast"},
-            "subject": {"files": [{"path": "other.c", "sha256": "h"}, {"path": "support.c", "sha256": "h"}], "project_load": {"include_paths": ["include"], "defines": ["TARGET=1"], "force_includes": ["target.h"], "machdep": "gcc_x86_64", "compilation_database": null}}
+            "subject": {"files": [{"path": "other.c", "sha256": "h"}, {"path": "support.c", "sha256": "h"}], "project_load": target_load()}
         });
         assert!(
             profile_evidence_error("target", &profile, "swap", Some(&wrong_source))
@@ -1476,7 +1494,7 @@ fn profile_paths_are_not_normalized() {
 
         let matching_sources = json!({
             "wp": {"functions": ["swap"], "model": "Typed+cast"},
-            "subject": {"files": [{"path": "support.c", "sha256": "h"}, {"path": "swap-frame.c", "sha256": "h"}], "project_load": {"include_paths": ["include"], "defines": ["TARGET=1"], "force_includes": ["target.h"], "machdep": "gcc_x86_64", "compilation_database": null}}
+            "subject": {"files": [{"path": "support.c", "sha256": "h"}, {"path": "swap-frame.c", "sha256": "h"}], "project_load": target_load()}
         });
         assert_eq!(
             profile_evidence_error("target", &profile, "swap", Some(&matching_sources)),
@@ -1668,4 +1686,115 @@ fn a_sandbox_receipt_is_never_evidence_for_a_main_project_conclusion() {
             .expect("a sandbox receipt is not evidence about the main project");
         assert!(reason.contains("sandbox"), "unexpected refusal: {reason}");
     }
+}
+
+/// The quoted-object form, decoded where every other Value-typed parameter
+/// decodes it.
+///
+/// A client whose schema for verify_profiles carries no "type" may send the
+/// JSON text of the map rather than the map. Decoding that is unambiguous, so
+/// it is accepted; the alternative is such a caller failing on a payload that
+/// says exactly what it means. It used to be decoded a second time inside
+/// parse_verification_profiles, and the two copies disagreed on the empty
+/// string, so the test drives the boundary rather than the parser.
+fn profiles_param(raw: serde_json::Value) -> Result<serde_json::Value, String> {
+    let params: frama_c_mcp::mcp::types::ReloadProjectParams =
+        serde_json::from_value(json!({"verify_profiles": raw})).map_err(|e| e.to_string())?;
+    Ok(params.verify_profiles.unwrap_or(serde_json::Value::Null))
+}
+
+#[test]
+fn a_profile_map_sent_as_json_text_is_decoded() {
+    let decoded = profiles_param(json!(r#"{"align": {"sources": ["src/proved/align.h"]}}"#))
+        .expect("a stringified profile map decodes");
+    let profiles = parse_verification_profiles(&decoded).expect("and then parses");
+    assert!(profiles.contains_key("align"));
+
+    // The object form is untouched on the way through.
+    let direct = json!({"align": {"sources": ["src/proved/align.h"]}});
+    assert_eq!(profiles_param(direct.clone()).unwrap(), direct);
+}
+
+// An empty string means "unset", not "a malformed set".
+//
+// A behavior change, and a deliberate one: the whole tolerant-deserializer
+// family reads "" as absent because that is what a schema-less client sends for
+// a parameter it is not using, and verify_profiles used to be the one that
+// answered "not valid JSON" instead. Pinned so it stays a decision.
+#[test]
+fn an_empty_profiles_string_is_absent_rather_than_malformed() {
+    assert_eq!(profiles_param(json!("")).unwrap(), serde_json::Value::Null);
+    assert_eq!(profiles_param(json!("   ")).unwrap(), serde_json::Value::Null);
+
+    // Absent stays absent, and a real set still arrives.
+    assert_eq!(profiles_param(json!(null)).unwrap(), serde_json::Value::Null);
+}
+
+#[test]
+fn a_string_that_is_not_json_is_refused_at_the_boundary() {
+    let err = profiles_param(json!("not json at all")).unwrap_err();
+    assert!(err.contains("not valid JSON"), "{err}");
+}
+
+// The old message said only "must be an object", which gave a caller who sent
+// a string no way to tell that from a malformed object.
+#[test]
+fn a_wrong_type_names_what_arrived() {
+    let err = parse_verification_profiles(&json!([])).unwrap_err();
+    assert!(err.contains("an array"), "{err}");
+    let err = parse_verification_profiles(&json!(7)).unwrap_err();
+    assert!(err.contains("a number"), "{err}");
+}
+
+// Text that decodes to something other than a map is refused by what it decoded
+// to, since that is the value the parser is handed.
+#[test]
+fn json_text_of_a_non_object_is_refused_by_its_decoded_type() {
+    for (text, want) in [("[]", "an array"), ("true", "a boolean"), ("7", "a number")] {
+        let decoded = profiles_param(json!(text)).expect("valid JSON decodes");
+        let err = parse_verification_profiles(&decoded).unwrap_err();
+        assert!(err.contains(want), "{text}: {err}");
+    }
+
+    // One layer of quoting is unwrapped, not two: text that decodes to another
+    // string arrives at the parser as a string and is named as one.
+    let decoded = profiles_param(json!(r#""still text""#)).expect("valid JSON decodes");
+    let err = parse_verification_profiles(&decoded).unwrap_err();
+    assert!(err.contains("a string"), "{err}");
+}
+
+// run_wp refuses a profile that leaves rte or nostdinc unset, so the conclusion
+// path must refuse it too. Defaulting them to false here would check a receipt
+// against an invented load and pass for whichever setting happened to match.
+#[test]
+fn a_profile_silent_on_rte_or_nostdinc_cannot_check_a_receipt() {
+    let profile = |rte, nostdinc| crate::state::VerificationProfile {
+        functions: vec!["f".into()],
+        sources: vec!["a.c".into()],
+        model: Some("Typed".into()),
+        provers: vec!["alt-ergo".into()],
+        timeout_seconds: Some(10),
+        rte,
+        nostdinc,
+        ..Default::default()
+    };
+    let receipt = json!({
+        "wp": {"functions": ["f"], "model": "Typed"},
+        "subject": {"files": [{"path": "a.c", "sha256": "h"}], "project_load": {}}
+    });
+
+    for (rte, nostdinc) in [(None, Some(false)), (Some(false), None), (None, None)] {
+        let err = profile_evidence_error("t", &profile(rte, nostdinc), "f", Some(&receipt))
+            .unwrap_or_else(|| panic!("accepted a profile silent on one of them"));
+        assert!(err.contains("rte or nostdinc"), "{err}");
+    }
+
+    // Stating both gets past this check and on to the load comparison, which is
+    // a different refusal: the point is that silence is not one of the answers.
+    let stated = profile(Some(false), Some(false));
+    let err = profile_evidence_error("t", &stated, "f", Some(&receipt));
+    assert!(
+        err.as_deref().is_none_or(|e| !e.contains("rte or nostdinc")),
+        "{err:?}"
+    );
 }

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -2539,3 +2539,39 @@ fn a_timeout_under_a_valid_property_still_counts_as_a_timeout() {
     let valid = json!({"normalized_status": "valid", "raw_status": "VALID"});
     assert_eq!(run_measurement(std::slice::from_ref(&valid)).timed_out, 0);
 }
+
+// A profile that names no system include directories does not match a load
+// that carries some.
+//
+// isystem_paths is a Vec, so omission and "explicitly empty" are the same
+// value, and the evidence gate requires rte and nostdinc but not this list.
+// Treating an empty list as "unset" therefore let a profile match a load
+// carrying any -isystem at all, and run_wp would label that run as the
+// target's evidence under a load identity that is not the target's. The three
+// Vec fields beside it have always compared exactly; only the two Option flags
+// can say "unset".
+#[test]
+fn a_profile_that_names_no_system_includes_does_not_match_a_load_that_has_them() {
+    let profile = frama_c_mcp::state::VerificationProfile {
+        sources: vec!["src/target.c".into()],
+        rte: Some(false),
+        nostdinc: Some(false),
+        ..Default::default()
+    };
+    let files = ["src/target.c".to_string()];
+
+    assert!(profile_matches_loaded_project(
+        &profile,
+        &files,
+        &ProjectLoadOptions::default()
+    ));
+
+    let with_isystem = ProjectLoadOptions {
+        isystem_paths: vec!["/opt/frama-c/libc".into()],
+        ..Default::default()
+    };
+    assert!(
+        !profile_matches_loaded_project(&profile, &files, &with_isystem),
+        "an omitted isystem_paths matched a load that passes one"
+    );
+}

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -5,10 +5,40 @@ use frama_c_mcp::mcp::server::receipt::proof_receipt_goals;
 use frama_c_mcp::mcp::server::analysis::{profile_covers_exactly, profile_matches_loaded_project};
 use frama_c_mcp::mcp::server::wpcli::{run_wp_counter_examples, run_why3_dump};
 use frama_c_mcp::mcp::server::wpclass::*;
+use frama_c_mcp::mcp::server::WpRunResponse;
+
+/// One wp_run_response call, with the six fields no case here varies.
+///
+/// Eight literals repeated `params`, `functions`, `scope`, `rte_enabled`,
+/// `frama_c_protocol` and the host load identically; the next field added to
+/// WpRunResponse would have been eight edits.
+struct WpRun<'a> {
+    tasks: serde_json::Value,
+    report: Option<serde_json::Value>,
+    goals: Option<&'a [serde_json::Value]>,
+}
+
+fn wp_response(run: WpRun<'_>) -> serde_json::Value {
+    let params = RunWpParams::default();
+    wp_run_response(WpRunResponse {
+        tasks: run.tasks,
+        params: &params,
+        functions: vec![],
+        scope: "main",
+        rte_enabled: false,
+        frama_c_protocol: vec![],
+        proofread_report: run.report,
+        goals: run.goals,
+
+        // A quiet host, so nothing here turns on the machine it runs on.
+        host_load: HostLoad::Load(0.1),
+    })
+}
+
 
 use frama_c_mcp::mcp::server::*;
 use frama_c_mcp::mcp::server::receipt::{
-    eva_config_absent, incomplete_digest, proof_receipt_body, proof_receipt_with_hash, receipt_shape, schema_of,
+    eva_config_absent, incomplete_digest, project_load_identity, proof_receipt_body, proof_receipt_with_hash, receipt_shape, schema_of,
     ProofReceiptBody, RECEIPT_SCHEMA,
 };
 
@@ -650,7 +680,6 @@ fn classify_wp_failure_rte_report_points_to_precondition_or_assertion() {
 
 #[test]
 fn wp_run_response_preserves_top_level_proofread_report() {
-    let params = RunWpParams::default();
     let report = proofread_report(vec![json!({
         "id": "x",
         "severity": "high",
@@ -658,95 +687,38 @@ fn wp_run_response_preserves_top_level_proofread_report() {
         "file": "x.c",
         "line": 1
     })]);
-    let object_response = wp_run_response(
-        json!({"done": 0, "total": 1}),
-        &params,
-        vec![],
-        "main",
-        false,
-        vec![],
-        Some(report.clone()),
-    );
+    let object_response = wp_response(WpRun { tasks: json!({"done": 0, "total": 1}), report: Some(report.clone()), goals: None });
     assert_eq!(object_response["proofread_report"], report);
 
-    let array_response = wp_run_response(
-        json!([]),
-        &params,
-        vec![],
-        "main",
-        false,
-        vec![],
-        Some(report.clone()),
-    );
+    let array_response = wp_response(WpRun { tasks: json!([]), report: Some(report.clone()), goals: None });
     assert_eq!(array_response["proofread_report"], report);
 }
 
 #[test]
 fn wp_run_response_reports_task_failure_kind() {
-    let params = RunWpParams::default();
-    let timeout = wp_run_response(
-        json!({"status": "timeout"}),
-        &params,
-        vec![],
-        "main",
-        false,
-        vec![],
-        None,
-    );
+    let timeout = wp_response(WpRun { tasks: json!({"status": "timeout"}), report: None, goals: None });
     assert_eq!(timeout["failure_kind"], "mcp_timeout");
 
-    let rejected = wp_run_response(
-        json!(["rejected task"]),
-        &params,
-        vec![],
-        "main",
-        false,
-        vec![],
-        None,
-    );
+    let rejected = wp_response(WpRun { tasks: json!(["rejected task"]), report: None, goals: None });
     assert_eq!(rejected["failure_kind"], "request_rejected");
 
-    let missing_prover = wp_run_response(
-        json!({"message": "prover Alt-Ergo not found"}),
-        &params,
-        vec![],
-        "main",
-        false,
-        vec![],
-        None,
-    );
+    let missing_prover = wp_response(WpRun { tasks: json!({"message": "prover Alt-Ergo not found"}), report: None, goals: None });
     assert_eq!(missing_prover["failure_kind"], "missing_prover");
 
     // A crashed backend, as the payload actually carries it: a goal stamped
     // FAILED and no log text anywhere. This used to hand the goal a name
     // containing the anomaly text, which no WP run produces, so the branch it
     // exercised could never fire on a real one.
-    let why3_crash = wp_run_response(
-        json!({
+    let why3_crash = wp_response(WpRun { tasks: json!({
             "goals": [{
                 "stable_goal_id": "g1",
                 "name": "Post-condition",
                 "normalized_status": "failed"
             }]
-        }),
-        &params,
-        vec![],
-        "main",
-        false,
-        vec![],
-        None,
-    );
+        }), report: None, goals: None });
     assert_eq!(why3_crash["failure_kind"], "frama_c_internal");
 
-    let unproved = wp_run_response(
-        json!({"goals": [{"stable_goal_id": "g1", "normalized_status": "unknown"}]}),
-        &params,
-        vec![],
-        "main",
-        false,
-        vec![],
-        None,
-    );
+    let unproved = wp_response(WpRun { tasks: json!({"goals": [{"stable_goal_id": "g1", "normalized_status": "unknown"}]}), report: None, goals: None });
     assert_eq!(unproved["failure_kind"], "proof_obligation");
 }
 
@@ -1760,7 +1732,7 @@ fn goal_timeouts_are_not_reported_as_no_timeout_evidence() {
         ]
     });
 
-    let triage = wp_timeout_triage_from_tasks_and_report(&drained, Some(&report));
+    let triage = wp_timeout_triage_from_tasks_and_report(&drained, Some(&report), None, HostLoad::Load(0.1));
     assert_eq!(triage["kind"], "prover_timeout", "{triage:?}");
     assert_eq!(triage["evidence"][0]["value"], 2, "{triage:?}");
 
@@ -1779,7 +1751,7 @@ fn goal_timeouts_are_not_reported_as_no_timeout_evidence() {
 fn task_level_verdict_takes_precedence_over_goal_timeouts() {
     let cancelled = json!({"tasks": "the WP task was cancelled"});
     let report = json!({"findings": [{"category": "timeout", "trigger": "x"}]});
-    let triage = wp_timeout_triage_from_tasks_and_report(&cancelled, Some(&report));
+    let triage = wp_timeout_triage_from_tasks_and_report(&cancelled, Some(&report), None, HostLoad::Load(0.1));
     assert_eq!(triage["kind"], "cancelled_task", "{triage:?}");
 }
 
@@ -1788,9 +1760,9 @@ fn task_level_verdict_takes_precedence_over_goal_timeouts() {
 fn clean_run_still_reports_no_timeout_evidence() {
     let drained = json!({"todo": 0, "drained": true});
     let report = json!({"findings": [{"category": "unconstrained_assigns"}]});
-    let triage = wp_timeout_triage_from_tasks_and_report(&drained, Some(&report));
+    let triage = wp_timeout_triage_from_tasks_and_report(&drained, Some(&report), None, HostLoad::Load(0.1));
     assert_eq!(triage["kind"], "none", "{triage:?}");
-    let triage = wp_timeout_triage_from_tasks_and_report(&drained, None);
+    let triage = wp_timeout_triage_from_tasks_and_report(&drained, None, None, HostLoad::Load(0.1));
     assert_eq!(triage["kind"], "none", "{triage:?}");
 }
 
@@ -2231,4 +2203,339 @@ fn a_profile_only_labels_its_loaded_project() {
     assert!(profile_matches_loaded_project(&profile, &["src/target.c".into()], &options));
     assert!(!profile_matches_loaded_project(&profile, &["src/other.c".into()], &options));
     assert!(!profile_matches_loaded_project(&profile, &["src/target.c".into()], &ProjectLoadOptions::default()));
+}
+
+// A prover budget is wall clock, so on an oversubscribed host every goal
+// grinds to it whatever its difficulty. Reporting that run at high confidence
+// states a verdict about the code that the run cannot support.
+#[test]
+fn a_saturated_host_withdraws_the_timeout_verdict() {
+    let t = prover_timeout_triage(18, vec![], HostLoad::from_reading(Some(7.6)), None);
+    assert_eq!(t["confidence"], "low");
+    assert_eq!(t["retry_with_higher_prover_timeout"], false);
+    assert!(t["reason"].as_str().unwrap().contains("oversubscribed"));
+}
+
+// -wp-rte decides which obligations exist at all, so a load without it gives a
+// strictly smaller set. A target proved with it is not described by a load
+// without it, however well every other field lines up.
+#[test]
+fn a_load_without_rte_does_not_match_a_target_that_needs_it() {
+    let needs_rte = frama_c_mcp::state::VerificationProfile {
+        sources: vec!["src/target.c".into()],
+        rte: Some(true),
+        ..Default::default()
+    };
+    let files = ["src/target.c".to_string()];
+
+    let without = ProjectLoadOptions::default();
+    let with = ProjectLoadOptions { rte: true, ..Default::default() };
+
+    assert!(!profile_matches_loaded_project(&needs_rte, &files, &without));
+    assert!(profile_matches_loaded_project(&needs_rte, &files, &with));
+
+    // A profile that does not speak to RTE still matches either load. Only a
+    // profile that states it can be proof evidence, which the evidence gate in
+    // run_wp enforces separately.
+    let silent = frama_c_mcp::state::VerificationProfile {
+        sources: vec!["src/target.c".into()],
+        ..Default::default()
+    };
+    assert!(profile_matches_loaded_project(&silent, &files, &without));
+    assert!(profile_matches_loaded_project(&silent, &files, &with));
+}
+
+// WP's cache stores timeout verdicts as readily as valid ones, so a run can
+// report a failure it never attempted. That is a stronger disqualifier than a
+// loaded host: neither the goal nor the machine explains a replayed verdict,
+// because nothing was run. A cached *valid* goal is not the trap, since the
+// timed-out goals are what a timeout verdict is about.
+#[test]
+fn only_a_run_whose_timeouts_were_all_replayed_withdraws_the_verdict() {
+    let goal = |status: &str, from_cache: bool| {
+        json!({"stable_goal_id": "g", "status": status, "from_cache": from_cache})
+    };
+
+    for (case, goals, all_replayed, confidence) in [
+        (
+            "every timeout replayed",
+            vec![goal("valid", false), goal("timeout", true)],
+            true,
+            "low",
+        ),
+        ("the timeout was attempted", vec![goal("timeout", false)], false, "high"),
+        (
+            "only a valid goal was replayed",
+            vec![goal("valid", true), goal("timeout", false)],
+            false,
+            "high",
+        ),
+        ("nothing timed out", vec![goal("valid", true)], false, "high"),
+        ("no goals at all", vec![], false, "high"),
+    ] {
+        let m = run_measurement(&goals);
+        assert_eq!(m.every_timed_out_goal_was_replayed(), all_replayed, "{case}");
+
+        // A quiet host throughout, so the replay is the only thing that can
+        // withdraw the verdict.
+        let t = prover_timeout_triage(1, vec![], HostLoad::from_reading(Some(0.1)), Some(&m));
+        assert_eq!(t["confidence"], confidence, "{case}");
+        if all_replayed {
+            assert!(t["reason"].as_str().unwrap().contains("cache"), "{case}");
+        }
+    }
+}
+
+// The predicate is handed the whole fetchGoals table, which carries goals from
+// functions proved earlier in the session and goals left at NORESULT by
+// -wp-prop. Those are unproved and not cached, so scoping the question to every
+// unproved goal let a single one of them keep the verdict confident while every
+// timed-out goal in the run had in fact been replayed.
+#[test]
+fn goals_the_run_never_attempted_do_not_rescue_a_wholly_replayed_timeout() {
+    let goals = vec![
+        json!({"stable_goal_id": "earlier", "status": "valid", "from_cache": true}),
+        json!({"stable_goal_id": "excluded", "status": "NORESULT", "from_cache": false}),
+        json!({"stable_goal_id": "timed_out", "status": "timeout", "from_cache": true}),
+    ];
+    let m = run_measurement(&goals);
+
+    // The unproved counters still see the excluded goal, which is why they
+    // cannot be what the verdict rests on.
+    assert_eq!(m.unproved, 2);
+    assert_ne!(m.unproved_replayed, m.unproved);
+
+    assert_eq!(m.timed_out, 1);
+    assert_eq!(m.timed_out_replayed, 1);
+    assert!(m.every_timed_out_goal_was_replayed());
+
+    let t = prover_timeout_triage(1, vec![], HostLoad::from_reading(Some(0.1)), Some(&m));
+    assert_eq!(t["confidence"], "low", "{t:?}");
+    assert!(t["reason"].as_str().unwrap().contains("cache"), "{t:?}");
+}
+
+// Both causes are named when both apply. Reporting only the cache sends the
+// caller to re-run with cache "None" on the machine that will grind to the
+// budget again.
+#[test]
+fn a_replayed_run_on_a_loaded_host_names_both_causes() {
+    let m = run_measurement(&[json!({"status": "timeout", "from_cache": true})]);
+    let t = prover_timeout_triage(1, vec![], HostLoad::from_reading(Some(9.0)), Some(&m));
+    let reason = t["reason"].as_str().unwrap();
+    assert_eq!(t["confidence"], "low");
+    assert!(reason.contains("cache"), "{reason}");
+    assert!(reason.contains("oversubscribed"), "{reason}");
+}
+
+// An absent reading is the one case where the host cannot be ruled out, so it
+// is said rather than defaulted to a quiet machine.
+#[test]
+fn an_unavailable_load_is_reported_rather_than_assumed_quiet() {
+    let t = prover_timeout_triage(1, vec![], HostLoad::Unavailable, None);
+    let ev = t["evidence"].as_array().unwrap();
+    let load = ev.iter().find(|e| e["field"] == "host_load").unwrap();
+    assert_eq!(load["value"], "unavailable");
+    assert_eq!(t["confidence"], "low");
+    assert!(t["reason"].as_str().unwrap().contains("could not be read"));
+}
+
+// The threshold is "above", not "at": one runnable thread per CPU is where
+// saturation starts. The low reading is host-wide, so load 4 on a 64-core box
+// stays quiet even under a one-CPU cgroup quota.
+#[test]
+fn the_saturation_threshold_excludes_its_own_boundary() {
+    for (load, confidence) in [(4.0 / 64.0, "high"), (1.0, "high"), (1.0001, "low")] {
+        let t = prover_timeout_triage(1, vec![], HostLoad::from_reading(Some(load)), None);
+        assert_eq!(t["confidence"], confidence, "load {load}");
+        assert_eq!(t["retry_with_higher_prover_timeout"], false, "load {load}");
+    }
+}
+
+// serde renders a non-finite float as JSON null, so a NaN reaching the evidence
+// would be invisible, and it compares false against the threshold on the way
+// past. The verdict must not depend on the reader having filtered them.
+#[test]
+fn a_non_finite_reading_never_reads_as_a_quiet_host() {
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -1.0] {
+        let t = prover_timeout_triage(1, vec![], HostLoad::from_reading(Some(bad)), None);
+        let ev = t["evidence"].as_array().unwrap();
+        let load = ev.iter().find(|e| e["field"] == "host_load").unwrap();
+        assert!(!load["value"].is_null(), "{bad} serialized to null");
+
+        // Distinct from "unavailable": a reading that arrived and was refused
+        // is not a reading that never arrived, and only one of the two means
+        // the machine has a load average worth looking at.
+        assert_eq!(load["value"], "unreadable", "{bad}");
+        assert_eq!(HostLoad::from_reading(Some(bad)), HostLoad::Unreadable, "{bad}");
+        assert_eq!(HostLoad::from_reading(Some(bad)).per_cpu(), None, "{bad}");
+        assert_ne!(t["confidence"], "high", "{bad} passed as a quiet host");
+    }
+}
+
+// The triage goes into the proof receipt's reported block, and that block is
+// hashed. A reading in it would give two runs of the same proof on the same
+// machine different receipt digests, which is the one property a receipt
+// exists to carry. Rounding does not save it, so the payload carries a
+// category and the reading is reported outside the receipt.
+#[test]
+fn the_timeout_verdict_does_not_move_with_the_load_reading() {
+    let quiet = prover_timeout_triage(3, vec![], HostLoad::from_reading(Some(0.11)), None);
+    let quieter = prover_timeout_triage(3, vec![], HostLoad::from_reading(Some(0.87)), None);
+    assert_eq!(quiet, quieter, "the reading reached the hashed payload");
+
+    let busy = prover_timeout_triage(3, vec![], HostLoad::from_reading(Some(4.0)), None);
+    assert_ne!(quiet, busy, "the verdict must still move when the category does");
+
+    // Nothing anywhere in the payload is a number that came off the host.
+    let rendered = quiet.to_string();
+    assert!(!rendered.contains("0.11"), "{rendered}");
+}
+
+// The reading itself, on whatever machine the suite runs on. It may be any
+// value, but it may not be one the evidence cannot render.
+#[test]
+fn the_host_reading_is_usable_or_absent() {
+    // Whatever the machine reports, it lands in a variant the payload can
+    // render, and a Load carries a number the threshold can be compared with.
+    match host_load() {
+        HostLoad::Load(l) => assert!(l.is_finite() && l >= 0.0, "unusable reading {l}"),
+        HostLoad::Unavailable | HostLoad::Unreadable => {}
+    }
+    assert!(
+        ["quiet", "saturated", "unavailable", "unreadable"].contains(&host_load().category())
+    );
+}
+
+// The flags the build passes must reach the preprocessor, and in the order the
+// preprocessor searches: -nostdinc removes the default directories, the -I set
+// answers first, and -isystem is where the modeled libc sits so it is found
+// only where the project's own headers do not answer.
+#[test]
+fn the_load_flags_carry_nostdinc_and_isystem_in_search_order() {
+    let options = ProjectLoadOptions {
+        include_paths: vec!["stubs".into(), "src".into()],
+        isystem_paths: vec!["/opt/frama-c/libc".into()],
+        nostdinc: true,
+        force_includes: vec!["prelude.h".into()],
+        ..Default::default()
+    };
+    let args = frama_c_mcp::mcp::server::cpp_extra_args(&options).expect("flags");
+    assert_eq!(
+        args,
+        "-nostdinc -Istubs -Isrc -isystem /opt/frama-c/libc -include prelude.h"
+    );
+
+    // Off by default, so a caller that never heard of it is unaffected.
+    let plain = ProjectLoadOptions { include_paths: vec!["src".into()], ..Default::default() };
+    assert_eq!(frama_c_mcp::mcp::server::cpp_extra_args(&plain).unwrap(), "-Isrc");
+}
+
+#[test]
+fn receipt_load_identity_includes_all_obligation_shaping_options() {
+    let identity = project_load_identity(&ProjectLoadOptions {
+        rte: true,
+        isystem_paths: vec!["modeled-libc".into()],
+        nostdinc: true,
+        ..Default::default()
+    });
+    assert_eq!(identity["rte"], true);
+    assert_eq!(identity["isystem_paths"], json!(["modeled-libc"]));
+    assert_eq!(identity["nostdinc"], true);
+}
+
+// Without this a load against the real system headers passes for a load
+// against the modeled libc, which is a different program to prove.
+#[test]
+fn a_load_that_kept_the_system_headers_does_not_match_a_target_that_dropped_them() {
+    let profile = frama_c_mcp::state::VerificationProfile {
+        sources: vec!["src/target.c".into()],
+        nostdinc: Some(true),
+        isystem_paths: vec!["/opt/frama-c/libc".into()],
+        ..Default::default()
+    };
+    let files = ["src/target.c".to_string()];
+
+    let matching = ProjectLoadOptions {
+        nostdinc: true,
+        isystem_paths: vec!["/opt/frama-c/libc".into()],
+        ..Default::default()
+    };
+    assert!(profile_matches_loaded_project(&profile, &files, &matching));
+
+    let kept_system_headers = ProjectLoadOptions {
+        isystem_paths: vec!["/opt/frama-c/libc".into()],
+        ..Default::default()
+    };
+    assert!(!profile_matches_loaded_project(&profile, &files, &kept_system_headers));
+
+    let wrong_libc = ProjectLoadOptions {
+        nostdinc: true,
+        isystem_paths: vec!["/some/other/libc".into()],
+        ..Default::default()
+    };
+    assert!(!profile_matches_loaded_project(&profile, &files, &wrong_libc));
+}
+
+
+// drain_wp_tasks returns whatever Frama-C sent whenever it cannot count the
+// queue, and that payload need not be an object. A response missing the counts
+// on that path reads as a run with nothing replayed, which is the confident
+// direction.
+#[test]
+fn the_replay_counts_survive_a_task_payload_that_is_not_an_object() {
+    let goals = vec![json!({"status": "timeout", "from_cache": true})];
+
+    for tasks in [json!(["a bare list"]), json!({"done": 0, "total": 1})] {
+        let response = wp_response(WpRun {
+            tasks: tasks.clone(),
+            report: None,
+            goals: Some(goals.as_slice()),
+        });
+        assert_eq!(response["measurement"]["timed_out_replayed"], 1, "{tasks}");
+        assert_eq!(
+            response["measurement"]["every_timed_out_goal_was_replayed"], true,
+            "{tasks}"
+        );
+
+        // The reading lives here, outside the triage that the receipt hashes.
+        assert_eq!(response["host_load"]["category"], "quiet", "{tasks}");
+    }
+}
+
+// A timed-out goal counts as timed out even when the property it hangs off
+// consolidated to valid.
+//
+// The two questions come apart, which is what src/mcp/status.rs exists to keep
+// straight: own_status is what WP decided about this goal, consolidated_status
+// is what the property decided. run_measurement asked the second for a question
+// about the first, beside a line asking the first for whether the goal was
+// proved, so one loop asked two different questions about one row. Reading the
+// consolidated verdict here hides a replayed timeout behind a valid property,
+// which is the direction that keeps the run's verdict confident.
+#[test]
+fn a_timeout_under_a_valid_property_still_counts_as_a_timeout() {
+    let goal = json!({
+        "normalized_property_status": "valid",
+        "raw_status": "TIMEOUT",
+        "status": "TIMEOUT",
+        "from_cache": true,
+    });
+    let m = run_measurement(std::slice::from_ref(&goal));
+    assert_eq!(m.timed_out, 1, "consolidated verdict masked the goal's own");
+    assert_eq!(m.timed_out_replayed, 1);
+    assert!(m.every_timed_out_goal_was_replayed());
+
+    // And a goal straight off the wire, which carries "status" alone.
+    let raw = json!({"status": "TIMEOUT", "from_cache": false});
+    let m = run_measurement(std::slice::from_ref(&raw));
+    assert_eq!(m.timed_out, 1, "an unenriched goal was not counted");
+    assert_eq!(m.timed_out_replayed, 0);
+
+    // The enriched spelling, where normalized_status leads.
+    let enriched = json!({"normalized_status": "timeout", "raw_status": "TIMEOUT"});
+    assert_eq!(run_measurement(std::slice::from_ref(&enriched)).timed_out, 1);
+
+    // A goal that really is valid is not swept in by any of the three.
+    let valid = json!({"normalized_status": "valid", "raw_status": "VALID"});
+    assert_eq!(run_measurement(std::slice::from_ref(&valid)).timed_out, 0);
 }


### PR DESCRIPTION
Two things can make a run say less than its payload appears to, and neither was visible in it. A prover budget is wall clock, so on an oversubscribed host every goal grinds to it whatever its difficulty, and a timeout stops saying anything about the goal. And WP's cache defaults to update, so it replays timeout verdicts as readily as valid ones: a run whose failures all came back from the cache attempted nothing and looked identical to one that did.

run_wp now reads the host load before scheduling any proof, counts how many of its timed-out goals were replayed, and withdraws the confident verdict for either, naming both causes when both apply. The reading is taken before rather than after because a timeout-heavy run drives the one-minute average toward saturation on its own, and a reading taken at response assembly is mostly this server's own provers.

The load reaches the payload as a category and never as a number. run_wp hashes the timeout triage into the proof receipt, so a continuous environment-dependent float there would give two byte-identical runs on the same machine different digests, which is the one property a receipt exists to carry. Rounding does not save it, since 0.42 and 0.55 differ however few decimals they are printed to. The reading is reported beside the response, where nothing hashes it.

Verification profiles gain isystem_paths, nostdinc and rte, and all three join the load identity a receipt is hashed over, because each decides which declarations a file is compiled against or which obligations exist at all. A profile a run or a conclusion will name is refused without rte and nostdinc: otherwise a receipt is checked against an invented default and passes for whichever setting happened to match it. check resolves rte itself rather than leaving it to reload_project, whose fallback of false is right for a load and wrong here, since naming a target used to turn RTE off and quietly shrink the obligation set check reports against.

-nostdinc reaches Frama-C's preprocessor and not the C compiler behind E-ACSL. The modeled libc exists to be analysed rather than compiled, so dropping the real system headers from the gcc that builds the instrumented program leaves it without stdio, and a project that loads cleanly then fails to build.

run_measurement asks the goal's own verdict for whether it timed out. It asked the consolidated one, which is the verdict of the property the goal hangs off, on the line after asking the goal's own verdict for whether it was proved. A timeout under a property that consolidated valid answered "not timed out", which is how a replayed timeout hides behind a confident verdict.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Withholds WP timeout verdicts when the run didn't measure the goal, and closes three gaps a verdict could pass through.

**Host load and cache**
- `run_wp` reads host load before scheduling proofs and reports it as a category beside the response, not in the receipt.
- Timed-out goals replayed from the cache are counted and, with a saturated host, withdraw the confident verdict, naming the cause.
- `run_measurement` now reads the goal's own verdict for timeout instead of the consolidated property verdict.

**Profiles and receipts**
- Verification profiles gain `isystem_paths`, `nostdinc`, and `rte`, all hashed into the proof receipt load identity; a profile naming no `isystem_paths` matches only a load passing none.
- A profile named in a run or conclusion must state `rte` and `nostdinc`; otherwise it is refused.
- `check` resolves `rte` itself rather than `reload_project`'s fallback, reports `RTE_DISABLED` when the profile turned RTE off, and reports `PROPERTY_VACUOUS` for goals proved only under an impossible hypothesis.
- `-nostdinc` goes to Frama-C's preprocessor only; the E-ACSL compiler keeps system headers.
- The gap logic moved from `analysis.rs` into `checkgaps.rs` unchanged, and the test harness now picks the fresher of the release build and Cargo's build.

<sup>Written for commit 8cb6a8cb4277900a98ad0c49ccd3af140ea9a348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/frama-c-mcp/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

