### PR TITLE
Refuse profiled run proved less than its target

### DIFF
--- a/.ci/check-shell-formatting.sh
+++ b/.ci/check-shell-formatting.sh
@@ -34,8 +34,8 @@
 # restoration.
 set -euo pipefail
 
-curl -sSfL -o /tmp/shfmt https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
-echo "fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1  /tmp/shfmt" | sha256sum -c -
+curl -sSfL -o /tmp/shfmt https://github.com/mvdan/sh/releases/download/v3.14.0/shfmt_v3.14.0_linux_amd64
+echo "fe42021c7272ef2d67ea36cbc3031683c625d0badec733ef3a57b567246a0b66  /tmp/shfmt" | sha256sum -c -
 chmod +x /tmp/shfmt
 
 git ls-files -z '*.sh' '*.hook' | xargs -0 /tmp/shfmt -d

--- a/README.md
+++ b/README.md
@@ -378,7 +378,28 @@ function set there is nothing for the coverage check to compare against, and
 `rte` and `nostdinc` each decide which obligations exist at all, so a run
 missing either discharges a different set than the target's own command does.
 A profile written before those two were required still loads; it is refused only
-where it would have become evidence, and stating them restores it. Emit the JSON from the build system that defines the targets
+where it would have become evidence, and stating them restores it.
+
+Two further fields are optional, and say what this server cannot otherwise
+know. `min_goals` is the floor on obligations the target requires WP to
+*generate*, and a run that generates fewer is refused: "N of N discharged" is
+not evidence on its own, since an emptied function body or a dropped contract
+discharges 0 of 0 and reports success. Counted over the target's own
+obligations, not over the goal table, which also holds goals from functions
+proved earlier in the session; otherwise an unrelated function's leftovers
+would clear the floor. A floor of `0` is refused as well, because omitting the
+field already says the target declares none. The same floor is applied to a
+receipt handed to `store_function_conclusion` under the profile's name, since a
+receipt arrives there from the caller rather than from the run that made it,
+but only to one whose `wp.functions` covers the profile's whole function set:
+a receipt from `check {function: "a"}` is scoped to `a`, so asking a
+three-function target's floor of it would refuse evidence that is correct.
+`build_gates` names checks the target's own command runs that this server does
+not, such as a separate script over the same sources; they come back under
+`declared_build_gates_not_run_here`. That list is the profile author's
+declaration and nothing here can verify it, so an empty one means none were
+declared rather than that none exist: it bounds a verdict downward, never
+upward. Emit the JSON from the build system that defines the targets
 rather than writing it by hand, so it cannot drift from the command that
 decides. An unknown key is refused rather than ignored. A profile
 whose model key is misspelled as `models` would otherwise register with no
@@ -387,11 +408,20 @@ report it as that target's evidence, which is the failure profiles exist to
 prevent. Naming a profile nobody registered is refused too, rather than
 falling back to the default.
 
-Passing `model`, `prover`, `provers` or `timeout` alongside `verify_profile` is
-refused rather than allowed to win. A run labelled as a target's evidence has
-to be the target's settings, and letting an override through produced exactly
-the mislabelling profiles exist to prevent: proving under one model while the
-response named another. Omit `verify_profile` to deviate on purpose.
+Passing `model`, `prover`, `provers`, `timeout`, `prop` or `retry_unproved`
+alongside `verify_profile` is refused rather than allowed to win. A run
+labelled as a target's evidence has to be the target's settings, and letting
+an override through produced exactly the mislabelling profiles exist to
+prevent: proving under one model while the response named another. `prop` is refused for the same reason and before the
+run rather than after it: a filtered run attempts the obligations the filter
+selects and leaves the rest, so its goal count and its summary agree with each
+other while describing a subset, and nothing downstream can tell that from a
+whole run. `retry_unproved` is the timeout's version of the same thing: it
+re-proves at double the profile's timeout and the flipped goals replace the
+reported set, receipt included, while the receipt records the declared timeout.
+Omit `verify_profile` to deviate on purpose. Through `check`, which forwards
+both, these refusals and the goal floor arrive as an error inside the `wp`
+field rather than as a failed call, since `check` reports each stage it ran.
 Evidence profiles must declare all five settings that decide what gets proved
 and over what: `model`, non-empty `provers`, `timeout_seconds`, `rte` and
 `nostdinc`; an incomplete profile may be registered for loading, but cannot
@@ -430,6 +460,19 @@ smoke tests.
 `self_check` reports `tool_surface`: the tool count, the byte size of the
 `tools/list` result that is resent on every agent turn, and the three heaviest
 tools. Computed from the running server, so it cannot be quoted stale.
+
+It also reports `build_commit`, the commit the running binary was built from,
+with `-dirty` appended when that build had uncommitted changes to tracked
+files, or when git could not say: "do not compare this sha to a tree" is what a
+reader must do with either answer. `version` reads `0.1.0` and always has, so
+it cannot tell an installed binary from the source sitting beside it: a caller
+comparing this server's behaviour against the code they are reading needs to
+know when the two are not the same thing, and this is the field that says so. Compare it with `git rev-parse HEAD`, which is the
+full object id: the abbreviation that `--short` picks grows with the object
+database, so it is not a function of the commit alone. A build
+with no git available, or one made from a copy of these sources vendored into
+another repository, reports `unknown` rather than guessing: a confident wrong
+sha is worse than none, because it is the value a caller compares against.
 
 It parses the `frama-c -version` banner rather than only checking that the
 command exited zero. `frama_c.major`, `frama_c.minor`, `frama_c.supported`

--- a/ast-utils/scripts/cppo-frama-c.sh
+++ b/ast-utils/scripts/cppo-frama-c.sh
@@ -4,10 +4,10 @@
 # plug-in calls, so the sources carry "#if FRAMAC_MAJOR >= 33" guards and this
 # decides which arm survives.
 #
-# The version arrives as a file rather than being looked up here, and the
-# reason is in src/dune next to the rule that writes it: an action dune cannot
-# see the inputs of gets its result replayed from cache, so a lookup inside
-# this script would pin the arm to whichever switch built the tree first.
+# The version arrives as a file rather than being looked up here, and the reason
+# is in src/dune next to the rule that writes it: an action dune cannot see the
+# inputs of gets its result replayed from cache, so a lookup inside this script
+# would pin the arm to whichever switch built the tree first.
 #
 # Only the major is read, so a "33.0~beta" suffix cannot break parsing.
 set -eu

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,197 @@
+//! Stamp the commit this binary was built from.
+//!
+//! CARGO_PKG_VERSION is the only identity the server had, and it has read
+//! 0.1.0 for the whole project's life, so an installed binary and a freshly
+//! built one describe themselves identically. That gap is expensive in
+//! practice: a caller comparing behaviour against the source cannot tell that
+//! the server answering them predates the code they are reading, and every
+//! conclusion drawn that way is about a binary nobody has.
+//!
+//! Best effort by design. A build from a tarball has no git, and that is not a
+//! reason to fail the build; it is a reason to say "unknown" and let the reader
+//! know the answer is unavailable rather than reassuring.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    // Asked first, because it is the one answer that refuses the whole job: a
+    // copy of these sources vendored into another repository would otherwise
+    // report that repository's HEAD as this server's build identity, which is
+    // worse than unknown, since a confident wrong sha is the value a caller
+    // compares against their own git rev-parse.
+    //
+    // Asked as a question about this directory rather than as a comparison of
+    // two paths. --show-prefix prints the path from the worktree top down to
+    // here, so empty output means this is the top, and git answers it having
+    // already resolved whatever symlinks or "." components the path was
+    // reached through. Comparing --show-toplevel against CARGO_MANIFEST_DIR as
+    // strings did not: git resolves symlinks and cargo does not, so a
+    // symlinked checkout compared unequal and stamped itself unknown, which is
+    // this guard turning the feature off rather than protecting it.
+    //
+    // Read through command() rather than git(), because git() maps empty
+    // output to None and empty is the answer being looked for.
+    let in_own_checkout = command(&manifest, &["rev-parse", "--show-prefix"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .is_some_and(|out| out.stdout.iter().all(u8::is_ascii_whitespace));
+    if !in_own_checkout {
+        println!("cargo:rustc-env=BUILD_COMMIT=unknown");
+        return;
+    }
+
+    // Naming any rerun-if-changed path turns off cargo's default "re-run when
+    // any file in the package changed", so both halves have to be listed here
+    // or the stamp goes stale in one of two ways: the git metadata alone misses
+    // a source edit, which is the dirty bit, and the sources alone miss a
+    // commit, which is the sha.
+    //
+    // A missing tracked path is named anyway. Cargo re-runs a build script on
+    // every build while a watched path does not exist, and that is the right
+    // signal for a tracked file: missing from the working tree means the tree
+    // is dirty, the cost is a few git calls and a relink, and it stops the
+    // moment the file comes back. It is the wrong signal for a ref file, whose
+    // absence is normal, and watched_paths probes those for that reason. Dropping the path instead was a one-way door, since
+    // restoring the file did not re-run this script and the stamp stayed
+    // "-dirty" over a tree that had become clean.
+    //
+    // Substituting the nearest existing ancestor, which is what this did
+    // first, is the worst of the three. Cargo prices a directory as a
+    // recursive walk, so a deleted top-level file resolves to the manifest
+    // root and watches target/ with it: measured at 9.6 GB and 131,902 files
+    // here, dirty on every no-op build afterwards, which is the whole-tree
+    // watch the doc below records as having been removed once already.
+    for path in watched_paths(&manifest).unwrap_or_default() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+
+    println!("cargo:rustc-env=BUILD_COMMIT={}", build_commit(&manifest));
+}
+
+/// Everything whose change can move the stamp.
+///
+/// The tracked files, from git, and not the directory listing. Reading the
+/// directory watched whatever happened to be sitting in it: measured at 12,483
+/// files and 220 MB against git's 193, the difference being ignored output such
+/// as externals, ast-utils/_build and the .frama-c cache that every WP run
+/// writes. None of it can move the stamp, because the dirty bit comes from
+/// git diff against HEAD, which does not see an ignored file. What it did do is
+/// re-run this script and relink the crate after every gate, once costing a
+/// full release rebuild in the middle of a gate run.
+///
+/// None when git cannot enumerate the tracked files. Watching the metadata
+/// alone would be worse than watching nothing: naming any path at all turns
+/// cargo's default package scan off, so the script would stop re-running on a
+/// source edit and the dirty bit would freeze. With no directives cargo keeps
+/// that default, which is the conservative answer.
+fn watched_paths(manifest: &Path) -> Option<Vec<PathBuf>> {
+    let mut paths: Vec<PathBuf> = git(manifest, &["ls-files"])?
+        .lines()
+        .map(|line| manifest.join(line))
+        .collect();
+
+    // The git directory is a file in a worktree and in a submodule, and the ref
+    // that HEAD points at lives under the common directory rather than the
+    // per-worktree one. Asking git for both is the only way to name them.
+    if let Some(git_dir) = git(manifest, &["rev-parse", "--absolute-git-dir"]) {
+        // HEAD and the index are per-worktree; a detached HEAD moves HEAD
+        // itself and needs nothing further.
+        paths.push(Path::new(&git_dir).join("HEAD"));
+        paths.push(Path::new(&git_dir).join("index"));
+    }
+    // --path-format wants git 2.31. On an older one the whole query fails, and
+    // the answer without it is a path relative to the current directory, which
+    // is the manifest dir here, so joining it gives the same result. Without
+    // the fallback an old git watched no branch ref at all, and switching
+    // branches or committing left the stamp naming the previous commit.
+    let common_dir = git(
+        manifest,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )
+    .map(PathBuf::from)
+    .or_else(|| git(manifest, &["rev-parse", "--git-common-dir"]).map(|dir| manifest.join(dir)));
+    if let Some(common_dir) = common_dir {
+        // These two are probed, and the tracked files above are not, because
+        // absence means opposite things. A tracked file missing from the
+        // working tree is a dirty tree, so naming it and letting cargo re-run
+        // until it returns is the right signal. A missing ref file is the
+        // normal state of a healthy repository: packed-refs does not exist
+        // until refs are packed, and the loose ref does not exist once they
+        // are. Naming either unconditionally re-runs this script and relinks
+        // the server on every build, forever, which is the cost this whole
+        // list was rewritten to avoid.
+        //
+        // One of the two always exists, so the branch HEAD points at is
+        // watched either way: pack the refs and the loose file goes but
+        // packed-refs appears, unpack them and the reverse.
+        let head_ref = git(manifest, &["symbolic-ref", "--quiet", "HEAD"]);
+        let refs = [Some(common_dir.join("packed-refs")), head_ref.map(|r| common_dir.join(r))];
+        paths.extend(refs.into_iter().flatten().filter(|path| path.exists()));
+    }
+    Some(paths)
+}
+
+fn build_commit(manifest: &Path) -> String {
+    // The full object id, not --short. Git picks the abbreviation length from
+    // the object database and lengthens it as the database grows, so two
+    // builds of the same commit can stamp different strings and a caller
+    // comparing them would read a difference that is not one. The full id is
+    // the only spelling that is a function of the commit alone.
+    let Some(commit) = git(manifest, &["rev-parse", "HEAD"]) else {
+        return "unknown".to_string();
+    };
+
+    // A dirty tree is the case this exists for: it is what an installed binary
+    // built from uncommitted work looks like, and the commit alone would name a
+    // tree it does not match.
+    //
+    // Tracked changes only, and by exit code. git status walks every untracked
+    // file, so a stray scratch directory would stamp a release binary dirty,
+    // and it rewrites the index it just walked, which is one of the paths this
+    // script watches. A git that cannot answer at all is reported dirty rather
+    // than as a third state: "-dirty" already means "do not compare this sha to
+    // a tree", which is what a reader must do with a tree nobody could read,
+    // and it understates confidence rather than overstating it.
+    //
+    // "diff", not "diff-index". Both compare the working tree against HEAD, and
+    // only the first falls back to reading the file when the index says a path
+    // is stat-dirty. GIT_OPTIONAL_LOCKS=0 is what makes that difference matter:
+    // git may not refresh the index it just found stale, so "diff-index"
+    // reports every touched-but-unchanged file as a difference, and a clean
+    // checkout stamps "-dirty" after anything that rewrites a source with the
+    // same bytes.
+    let clean = command(manifest, &["diff", "--quiet", "HEAD", "--"])
+        .status()
+        .ok()
+        .and_then(|status| status.code())
+        == Some(0);
+    if clean {
+        commit
+    } else {
+        format!("{commit}-dirty")
+    }
+}
+
+fn git(dir: &Path, args: &[&str]) -> Option<String> {
+    let out = command(dir, args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!text.is_empty()).then_some(text)
+}
+
+fn command(dir: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new("git");
+
+    // Without this, a read-only query takes index.lock to refresh stat data,
+    // which fails outright when a concurrent cargo or git holds it and degrades
+    // the stamp nondeterministically.
+    command.env("GIT_OPTIONAL_LOCKS", "0");
+    command.args(args).current_dir(dir);
+    command
+}

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -351,7 +351,21 @@ last two are there for different reasons. `rte` decides whether runtime-error
 obligations exist at all, so a receipt made without it covers a strictly
 smaller set than the target's own command does. `nostdinc` decides which
 declarations the file is compiled against, so a receipt made without it is
-about a different program rather than a smaller part of the same one. Because the tool is
+about a different program rather than a smaller part of the same one.
+
+A profile may also carry `min_goals`, the floor on obligations the target
+requires WP to generate. A profiled run that generates fewer is refused
+outright, because "N of N discharged" is not evidence on its own: an emptied
+body or a dropped contract discharges 0 of 0 and every other check on the path
+passes it. It counts the goals belonging to the functions the call named, not
+the whole goal table, which still holds whatever an earlier run left in it.
+`prop` and `retry_unproved` are refused alongside the proof settings for the
+same family of reason, and before the run rather than after: a filtered run
+attempts a subset while its goal count and summary agree with each other, and a
+retry discharges some goals at double the declared timeout while the receipt
+records the declared one, so nothing downstream can tell either from a whole
+run at the target's settings. `proof_coverage` names the same thing
+after the fact as `proved_under_a_goal_filter`. Because the tool is
 incremental, the comparison is against the conclusion as it will stand, so a
 later call that replaces the receipt is rechecked against the name already
 stored.

--- a/scripts/check-artifacts.sh
+++ b/scripts/check-artifacts.sh
@@ -15,6 +15,10 @@ import sys
 roots = [
     Path("README.md"),
     Path("Cargo.toml"),
+
+    # Scanned like any other source. The build script was simply never listed,
+    # so nothing read it for CJK, translator output or a misspelled Frama-C.
+    Path("build.rs"),
     Path("docs"),
     Path("src"),
     Path("tests"),
@@ -128,7 +132,7 @@ def is_published(rel_path):
 # `roots` covers is watched here for free, so a new root only has to be named
 # once; below it are the build inputs that sit outside `roots` because the
 # scans above have no reason to read them.
-build_roots = [str(r) for r in roots] + ["Cargo.lock", "build.rs", ".cargo"]
+build_roots = [str(r) for r in roots] + ["Cargo.lock", ".cargo"]
 
 # Narrowed by what the file is, since `roots` deliberately reaches into docs/
 # and the markdown at the top, where an untracked draft is ordinary work in

--- a/scripts/check-stdio-refusal.sh
+++ b/scripts/check-stdio-refusal.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 # Fail when the stdio suite hit a connect refusal that nothing diagnosed.
 #
-# The window between bind and listen is the known flake, and connect_when_listening
-# retries it. Its deadline says so in words, "frama-c never listened on <path>
-# within <timeout>: Connection refused", with both halves on one line, so the
-# qualifier is what separates the covered race from everything else. A refusal
-# without it came from a path the retry does not reach, and has to go red rather
-# than pass quietly as one more green run.
+# The window between bind and listen is the known flake, and
+# connect_when_listening retries it. Its deadline says so in words, "frama-c
+# never listened on <path> within <timeout>: Connection refused", with both
+# halves on one line, so the qualifier is what separates the covered race from
+# everything else. A refusal without it came from a path the retry does not
+# reach, and has to go red rather than pass quietly as one more green run.
 #
-# The recovered count is the other half. A race the retry absorbs leaves no trace
-# in any tool result or exit status, so a suite drifting back toward the flake
-# looks exactly like a healthy one until the deadline is finally exceeded. That
-# needs RUST_LOG to admit warn; see the stdio step in .github/workflows/ci.yml.
+# The recovered count is the other half. A race the retry absorbs leaves no
+# trace in any tool result or exit status, so a suite drifting back toward the
+# flake looks exactly like a healthy one until the deadline is finally exceeded.
+# That needs RUST_LOG to admit warn; see the stdio step in
+# .github/workflows/ci.yml.
 #
 # The log path arrives in the environment rather than as an argument because
 # tests/unit/repo-guards.rs keys a gate on the whole command string, and CI and

--- a/scripts/run-gates.sh
+++ b/scripts/run-gates.sh
@@ -56,8 +56,8 @@ run()
         # A gate can fail without printing any of those. The three shell gates
         # refuse a Frama-C whose proved-goal counts they were not measured
         # under, which is what a 32.1 switch gets, and the refusal says so in
-        # prose. Printing nothing there reports a bare rc=1 and sends the
-        # reader to a log to learn something the runner already had.
+        # prose. Printing nothing there reports a bare rc=1 and sends the reader
+        # to a log to learn something the runner already had.
         if [ -z "$detail" ]; then
             detail=$(tail -3 "$log")
         fi
@@ -97,13 +97,14 @@ want abs-int && run abs-int scripts/check-abs-int-fixtures.sh
 want wp-model && run wp-model scripts/check-wp-model-fixtures.sh
 want artifacts && run artifacts scripts/check-artifacts.sh
 want corpus && run corpus scripts/check-tutorial-corpus.sh
+
 # No --test-threads=1, unlike every other Frama-C gate here. Each of this
 # suite's 89 tests spawns its own server, its own frama-c and its own state
 # directory, so nothing is shared to serialise. Measured cold on 8 cores:
 # 1160.81s serial against 218.42s at libtest's default, both 89/89. The default
 # is available parallelism rather than a pinned number, so a 4-core runner gets
-# 4 and this does not oversubscribe whatever machine it lands on.
-# RUST_LOG matches the stdio step in .github/workflows/ci.yml: without it the
+# 4 and this does not oversubscribe whatever machine it lands on. RUST_LOG
+# matches the stdio step in .github/workflows/ci.yml: without it the
 # recovered-race warn the check below counts is filtered out before the log.
 want stdio && run stdio env RUST_LOG=frama_c_mcp=warn cargo test --test test-mcp-stdio --release
 # Keyed on the same "want stdio", so the suite cannot be run without its check.

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -1097,12 +1097,7 @@ pub fn unproved_assumption_findings(
         if !(is_assert || is_postcondition) {
             continue;
         }
-        let owner = goal
-            .get("fct")
-            .or_else(|| goal.get("scope"))
-            .or_else(|| goal.get("function_marker"))
-            .and_then(|value| value.as_str())
-            .unwrap_or("");
+        let owner = crate::mcp::server::wpclass::goal_scope_key(goal);
 
         // Keyed on the goal's identity, not on its name. Frama-C names a goal
         // "Assertion" or "Post-condition" with no location in it, so a name is
@@ -1617,6 +1612,91 @@ fn enrich_vcs_with_goals(
     }
 }
 
+/// A profile as it stood when the run was configured.
+///
+/// The echo goes in the response; the floor is checked after the run. Both are
+/// taken from one snapshot because the registry is replaceable: reload_project
+/// swaps it before waiting on main_wp_lock, so re-reading the profile after the
+/// proof would judge this run by a target it was never configured for.
+pub struct AppliedProfile {
+    /// The name this run was configured under.
+    ///
+    /// Carried rather than read back from params at the check. The pair was
+    /// destructured from two Options that cannot disagree, which invited a
+    /// reader to work out a half-state that does not exist:
+    /// apply_verify_profile returns None exactly when verify_profile is None,
+    /// and never clears it.
+    pub name: String,
+    pub echo: serde_json::Value,
+    pub min_goals: Option<u32>,
+}
+
+/// The refusal for a run that generated fewer obligations than its target
+/// requires, or None when it cleared the floor.
+///
+/// "N of N discharged" is not evidence on its own: an emptied function body or
+/// a dropped contract discharges 0 of 0 and reports success, and every other
+/// check on this path would pass it. A build system carrying such a floor is
+/// carrying the only check that catches that, so a profile that states one is
+/// stating something the server cannot otherwise know.
+///
+/// Refused rather than reported: a caller who asked for this target's evidence
+/// and got a thinner program has no use for the verdict. Split out of run_wp so
+/// the rule is testable without a live Frama-C, and because run_wp was at the
+/// repo's function-length ceiling.
+///
+/// No floor means the target declares none, which is not a floor of zero.
+///
+/// Counted over the target's own obligations rather than over the whole goal
+/// table, which is what fetchGoals returns: it carries goals from functions
+/// proved earlier in the session and goals left at NORESULT by -wp-prop. So
+/// run_wp on one function followed by a profiled run on another would have let
+/// the first function's goals clear the second's floor, which is the emptied
+/// body this check exists to catch. check reloads first and never saw it; a
+/// direct run_wp in a CEGIS loop is where the stale goals live.
+pub fn goal_floor_shortfall(
+    name: &str,
+    min_goals: Option<u32>,
+    goals: &[serde_json::Value],
+    functions: &[String],
+) -> Option<String> {
+    let min_goals = min_goals?;
+    let generated = goals_owned_by(goals, functions);
+    if generated >= min_goals as usize {
+        return None;
+    }
+    Some(format!(
+        "verify_profile \"{name}\" requires at least {min_goals} obligations and this run \
+         generated {generated} for {functions:?}, so it is not that target's evidence however \
+         many discharged. A dropped contract or an emptied body proves 0 of 0. WP did run: the \
+         goals are in Frama-C's table and reading them back through get_wp_goals or check \
+         reports the verdict this refusal is about, and any RTE guards this call generated are \
+         still in the AST."
+    ))
+}
+
+/// How many of these goals belong to the functions a run was asked about.
+///
+/// A goal names its function in "fct", which is a name rather than one of the
+/// reallocated "#F" markers, and a goal that names no function is not counted.
+///
+/// Counting the unnamed was the first answer here, on the argument that a false
+/// refusal is worse than nothing if Frama-C ever stops emitting the field. It
+/// is not: the input is the whole fetchGoals table, so an unowned or
+/// marker-scoped entry left there by an earlier run counts once for every
+/// profiled target afterwards, and one such entry can carry an emptied target
+/// over its floor. That is the case this check exists for, so the direction to
+/// fail in is the loud one. If the field ever does disappear, every profiled
+/// run refuses at once and says which functions it counted, which is a bug
+/// report rather than a silent pass.
+pub fn goals_owned_by(goals: &[serde_json::Value], functions: &[String]) -> usize {
+    goals
+        .iter()
+        .filter_map(crate::mcp::server::wpclass::goal_owner_name)
+        .filter(|owner| functions.iter().any(|wanted| wanted == owner))
+        .count()
+}
+
 /// Whether a call names the same functions the profile declares.
 ///
 /// Lifted out of apply_verify_profile to be testable independently of a live
@@ -1640,10 +1720,10 @@ pub fn profile_matches_loaded_project(
     // a database-backed load is not described by the profile whatever the
     // fields below say. Refusing it is the only honest answer: the alternative
     // is calling a run evidence about a target while the flags it actually ran
-    // under came from somewhere the profile does not reach.
-    // Destructured exhaustively, for the reason given on ProjectLoadOptions.
-    // The profile side stays field by field on purpose: its Option fields mean
-    // "unset, do not constrain", which no derived equality can express.
+    // under came from somewhere the profile does not reach. Destructured
+    // exhaustively, for the reason given on ProjectLoadOptions. The profile
+    // side stays field by field on purpose: its Option fields mean "unset, do
+    // not constrain", which no derived equality can express.
     let ProjectLoadOptions {
         include_paths,
         defines,
@@ -2221,7 +2301,9 @@ impl FramaCMcpServer {
                 verify_profiles: None,
                 verify_profiles_source: None,
                 verify_profile: params.verify_profile.clone(),
-                // Resolved above, so a named profile cannot silently turn it off.
+
+                // Resolved above, so a named profile cannot silently turn it
+                // off.
                 rte: Some(rte),
 
                 // check's own detail governs goals and alarms; the function
@@ -2312,6 +2394,7 @@ impl FramaCMcpServer {
         };
 
         let mut incomplete = check_incomplete_items(
+
             // The value this call actually loaded under, which is the caller's
             // only when the caller gave one. A profile stating rte:false loads
             // without RTE, and passing the caller's None here reported no
@@ -3021,7 +3104,7 @@ impl FramaCMcpServer {
     async fn apply_verify_profile(
         &self,
         params: &mut RunWpParams,
-    ) -> Result<Option<serde_json::Value>, McpError> {
+    ) -> Result<Option<AppliedProfile>, McpError> {
         let Some(name) = params.verify_profile.clone() else {
             return Ok(None);
         };
@@ -3051,12 +3134,32 @@ impl FramaCMcpServer {
             || params.timeout.is_some()
             || params.prover.is_some()
             || params.provers.is_some()
+
+            // prop belongs with them. A filtered run attempts the obligations
+            // the filter selects and leaves the rest, so its goal count and its
+            // summary agree with each other while describing a subset, and
+            // nothing downstream can tell that from a whole run. Refused here
+            // rather than after it, because the run is the expensive part and
+            // the answer does not depend on it. proof_coverage names the same
+            // thing after the fact as proved_under_a_goal_filter.
+            || params.prop.is_some()
+
+            // And so does retry_unproved, for the timeout's version of the same
+            // argument. The retry re-proves at double the profile's timeout and
+            // the flipped goals replace the reported set everywhere downstream,
+            // including the receipt; the session timeout is restored before the
+            // receipt is taken and the receipt reads the live config, so the
+            // receipt would record the declared timeout while some goals were
+            // discharged at twice it. That is the mislabelling this list exists
+            // to prevent, arriving through a parameter that does not look like
+            // a proof setting.
+            || params.retry_unproved == Some(true)
         {
             return Err(McpError::invalid_params(
                 format!(
                     "verify_profile \"{name}\" is proof evidence and cannot be combined with \
-                     model, prover, provers, or timeout overrides. Drop verify_profile to deviate \
-                     from its proof settings."
+                     model, prover, provers, timeout, prop, or retry_unproved overrides. Drop \
+                     verify_profile to deviate from its proof settings."
                 ),
                 None,
             ));
@@ -3098,16 +3201,79 @@ impl FramaCMcpServer {
         if !profile.provers.is_empty() {
             params.prover = Some(profile.provers.join(","));
         }
-        Ok(Some(json!({
-            "name": name,
-            "model": profile.model,
-            "provers": profile.provers,
-            "timeout_seconds": profile.timeout_seconds,
-            "rte": profile.rte,
-            "nostdinc": profile.nostdinc,
-            "isystem_paths": profile.isystem_paths,
-            "reproduce": profile.reproduce,
-        })))
+        Ok(Some(AppliedProfile {
+            name: name.clone(),
+
+            // Carried from the snapshot this function validated, not looked up
+            // again after the run. reload_project replaces the registry before
+            // it waits on main_wp_lock, so a concurrent call can swap the
+            // profile mid-proof and the floor checked at the end would belong
+            // to a target this run was never configured for.
+            min_goals: profile.min_goals,
+            echo: json!({
+                "name": name,
+                "model": profile.model,
+                "provers": profile.provers,
+                "timeout_seconds": profile.timeout_seconds,
+                "rte": profile.rte,
+                "nostdinc": profile.nostdinc,
+                "isystem_paths": profile.isystem_paths,
+                "min_goals": profile.min_goals,
+
+                // Repeated because they did not happen. A profile can say what
+                // Frama-C was invoked with; it cannot run a separate script
+                // over the same sources, and a verdict that stayed silent about
+                // them would read as the build's verdict rather than WP's.
+                //
+                // "declared" is load-bearing in the name. The list is whatever
+                // the profile author wrote, so it can be stale or short, and an
+                // old profile carrying none is indistinguishable from a target
+                // that has none. It bounds this verdict downward and never
+                // upward: reading an empty list as "nothing else is checked" is
+                // the one conclusion it does not support.
+                "declared_build_gates_not_run_here": profile.build_gates,
+                "reproduce": profile.reproduce,
+            }),
+        }))
+    }
+
+    /// The isolated per-prover retry, when this call asked for one.
+    ///
+    /// The plural "provers" argument is what selects the isolated CLI retry
+    /// path; a singular "prover" and the environment defaults configure the
+    /// live instance instead. requested_provers already holds the trimmed and
+    /// validated list whenever "provers" was given.
+    ///
+    /// Never a profiled run. apply_verify_profile refuses a plural "provers"
+    /// beside a profile and never sets one itself, so profile_applied is None
+    /// on every path that reaches here, and there is no profile key to graft
+    /// onto this exit's response.
+    ///
+    /// Split out of run_wp because it is a whole alternative answer rather than
+    /// a step in the one below it: nothing after it runs, and it takes the
+    /// project lock for itself.
+    async fn run_isolated_wp_retries_for_main(
+        &self,
+        params: &RunWpParams,
+        provers: &[String],
+    ) -> Result<CallToolResult, McpError> {
+        let (files, project_options) = {
+            let main_state = self.main_frama_c_state.lock().await;
+            let state = main_state.as_ref().ok_or_else(no_project_loaded_err)?;
+            (state.files.clone(), state.project_options.clone())
+        };
+        let functions = params.functions.clone().unwrap_or_default();
+        self.run_isolated_wp_retries(IsolatedWpRetry {
+            files,
+            project_options,
+            rte_enabled: true,
+            functions: functions.clone(),
+            reported_functions: functions,
+            provers: provers.to_vec(),
+            params,
+            scope: "main",
+        })
+        .await
     }
 
     #[tool(
@@ -3167,37 +3333,13 @@ impl FramaCMcpServer {
         }
         let requested_provers = effective_wp_provers(&params)?;
 
-        // The plural `provers` argument is what selects the isolated CLI retry
-        // path; a singular `prover` and the environment defaults configure the
-        // live instance instead. requested_provers already holds the trimmed
-        // and validated list whenever `provers` was given.
-        //
-        // Never a profiled run. apply_verify_profile refuses a plural "provers"
-        // beside a profile and never sets one itself, so profile_applied is
-        // None on every path that reaches here, and there is no profile key to
-        // graft onto this exit's response.
+        // The guard stays here, where a reader of run_wp can see that this is a
+        // whole alternative answer rather than a step.
         if let Some(provers) = requested_provers
             .as_ref()
             .filter(|_| params.provers.is_some())
         {
-            let (files, project_options) = {
-                let main_state = self.main_frama_c_state.lock().await;
-                let state = main_state.as_ref().ok_or_else(no_project_loaded_err)?;
-                (state.files.clone(), state.project_options.clone())
-            };
-            let functions = params.functions.clone().unwrap_or_default();
-            return self
-                .run_isolated_wp_retries(IsolatedWpRetry {
-                    files,
-                    project_options,
-                    rte_enabled: true,
-                    functions: functions.clone(),
-                    reported_functions: functions,
-                    provers: provers.clone(),
-                    params: &params,
-                    scope: "main",
-                })
-                .await;
+            return self.run_isolated_wp_retries_for_main(&params, provers).await;
         }
 
         // Held across the whole transaction below: config, target resolution,
@@ -3266,11 +3408,18 @@ impl FramaCMcpServer {
         // Every run regenerates, which is safe to repeat: measured on 33.0,
         // three successive runs over the same function give the same eight
         // goals with the same eight stable ids, so nothing is duplicated.
-        let rte_guarded = if rte_enabled {
-            Vec::new()
-        } else {
-            self.generate_rte_guards(&client, &targets).await?
-        };
+        //
+        // Unconditional, and that is what dropping kernel -rte at load made it.
+        // The branch here used to skip generation for an rte=true load because
+        // the kernel had already put its own assertions into the AST, and those
+        // are a different, larger set: WP's generator emits no
+        // pointer_alignment. With the kernel out of it nothing else generates
+        // these, so an rte=true load that skipped this step proved no
+        // runtime-error obligations at all. Inverting the branch moved the hole
+        // rather than closing it, to rte=false, where the obligations are
+        // generated in place precisely so that asking for them does not cost a
+        // reload that would discard this session's injected annotations.
+        let rte_guarded = self.generate_rte_guards(&client, &targets).await?;
 
         // A named target gets its own marker; "everything" asks for everything,
         // so global obligations like lemmas are scheduled too.
@@ -3344,9 +3493,28 @@ impl FramaCMcpServer {
                 wp_goals,
             )
             .await?;
+
+        // The floor on obligations generated, checked here because this is
+        // where the count first exists, against the floor captured before the
+        // run. Ahead of the proofread report rather than after it: that report
+        // costs a Frama-C round trip per target function and this path throws
+        // it away, which is the argument the profile already makes for refusing
+        // prop before the run instead of after.
+        if let Some(applied) = profile_applied.as_ref() {
+            if let Some(message) = goal_floor_shortfall(
+                &applied.name,
+                applied.min_goals,
+                &wp_goals,
+                &function_names,
+            ) {
+                return Err(McpError::invalid_params(message, None));
+            }
+        }
+
         let mut proofread_report =
             main_proofread_report(&client, &wp_goals, &function_names, report_function).await;
         proofread_drop_stale_retry_advice(&mut proofread_report, &timeout_retry);
+
         {
             let mut state = self.state.write().await;
             state.set_wp_completed();
@@ -3399,7 +3567,7 @@ impl FramaCMcpServer {
         // warns about.
         if let Some(profile) = profile_applied {
             if let Some(object) = response.as_object_mut() {
-                object.insert("verify_profile".to_string(), profile);
+                object.insert("verify_profile".to_string(), profile.echo);
             }
         }
         Ok(json_result(response))

--- a/src/mcp/checkgaps.rs
+++ b/src/mcp/checkgaps.rs
@@ -13,8 +13,8 @@
 
 use super::*;
 
-// The band this came out of. The dependency runs one way at the item level,
-// but analysis.rs also calls back into here, so both carry a glob rather than a
+// The band this came out of. The dependency runs one way at the item level, but
+// analysis.rs also calls back into here, so both carry a glob rather than a
 // list that goes stale on the next move.
 use super::analysis::*;
 
@@ -40,18 +40,18 @@ pub struct NextCallInputs<'a> {
 }
 
 pub fn check_next_call(inputs: NextCallInputs<'_>) -> serde_json::Value {
-    // Ordered after "incomplete" so the fallback can name the gaps it
-    // found. Not every gap has an alarm or a goal to point at: an axiom
-    // leaves every one of them valid, and a fallback that cannot name it
-    // reads as all clear next to a verdict of incomplete.
+    // Ordered after "incomplete" so the fallback can name the gaps it found.
+    // Not every gap has an alarm or a goal to point at: an axiom leaves every
+    // one of them valid, and a fallback that cannot name it reads as all clear
+    // next to a verdict of incomplete.
     //
-    // The backend diagnosis comes first for the same reason a timeout is
-    // read before a goal's text: reading a VC no prover ever received sends
-    // the caller to rewrite an annotation that was never judged.
+    // The backend diagnosis comes first for the same reason a timeout is read
+    // before a goal's text: reading a VC no prover ever received sends the
+    // caller to rewrite an annotation that was never judged.
     //
-    // Gated on the same condition as the incomplete entry above: an abort
-    // that cost no goal its verdict should not displace the call that
-    // targets a goal which is still open.
+    // Gated on the same condition as the incomplete entry above: an abort that
+    // cost no goal its verdict should not displace the call that targets a goal
+    // which is still open.
     let NextCallInputs {
         backend_diagnosis,
         anomaly_left_goals_unjudged,
@@ -70,29 +70,29 @@ pub fn check_next_call(inputs: NextCallInputs<'_>) -> serde_json::Value {
         .or_else(|| first_alarm_next_call(eva_alarms))
         .or_else(|| first_wp_goal_next_call(wp_goals, function))
         .unwrap_or_else(|| {
-            // An analysis the caller left out is answered by asking for it,
-            // not by reading the table it never filled. Pointing at
-            // get_wp_goals after a run that skipped WP sends the caller to
-            // a list that is empty because nothing produced it.
+            // An analysis the caller left out is answered by asking for it, not
+            // by reading the table it never filled. Pointing at get_wp_goals
+            // after a run that skipped WP sends the caller to a list that is
+            // empty because nothing produced it.
             let (tool, args) = if wanted.eva && wanted.wp {
                 ("get_wp_goals", json!({"want": ["counts"]}))
             } else {
                 ("check", json!({"want": ["eva", "wp"]}))
             };
 
-            // A clean run is exactly when vacuity is worth testing, and
-            // exactly when nothing else prompts for it. check runs no smoke
-            // tests, so it cannot see a contract that proves by excluding
-            // its own branch: the goals are valid, the verdict is proved,
-            // and an over-strong requires has quietly removed the case the
-            // function exists to handle.
+            // A clean run is exactly when vacuity is worth testing, and exactly
+            // when nothing else prompts for it. check runs no smoke tests, so
+            // it cannot see a contract that proves by excluding its own branch:
+            // the goals are valid, the verdict is proved, and an over-strong
+            // requires has quietly removed the case the function exists to
+            // handle.
             //
-            // Carried in the reason rather than by redirecting the call.
-            // Two stronger versions were tried and both were wrong: as an
+            // Carried in the reason rather than by redirecting the call. Two
+            // stronger versions were tried and both were wrong: as an
             // incomplete[] code it gated the verdict, so "proved" became
             // unreachable and the abs-int canary went red; as a replacement
-            // tool it broke the recommendation this payload has always made
-            // on a clean run.
+            // tool it broke the recommendation this payload has always made on
+            // a clean run.
             let reason = if incomplete.is_empty() {
                 "Every goal is valid, which says the code matches the contract, not that \
                  the contract was worth matching. check runs no vacuity tests: run_wp \
@@ -256,6 +256,7 @@ impl WantedAnalyses {
 fn unrequested_analysis_gaps(
     incomplete: &mut Vec<serde_json::Value>,
     rte: Option<bool>,
+    wp: &serde_json::Value,
     wanted: WantedAnalyses,
 ) {
     // An analysis nobody asked for is still an analysis that did not run, and
@@ -275,9 +276,24 @@ fn unrequested_analysis_gaps(
         }));
     }
     if rte == Some(false) {
+        // Which half of the check the gap is about depends on what WP did.
+        // run_wp generates WP's own RTE guards for every main-instance run,
+        // so its goals cover runtime errors whatever the load said, while EVA
+        // ran before them and its alarms do not. Saying both were excluded was
+        // true while the kernel's -rte at load was the only source of these
+        // annotations, and it now tells a caller to discard a WP verdict that
+        // is sound. Read off the run rather than off the load flag, because
+        // the run is what decided it.
+        let wp_covered_runtime_errors = wanted.wp
+            && wp.pointer("/effective_wp_config/rte").and_then(serde_json::Value::as_bool)
+                == Some(true);
         incomplete.push(json!({
             "code": incomplete_code::RTE_DISABLED,
-            "reason": "check ran without RTE annotations, so absence of alarms/goals excludes implicit runtime-error checks.",
+            "reason": if wp_covered_runtime_errors {
+                "check loaded without RTE annotations, so EVA's alarms exclude implicit runtime-error checks. WP generated its own RTE obligations in place for this run, so the goals do cover them."
+            } else {
+                "check ran without RTE annotations, so absence of alarms/goals excludes implicit runtime-error checks."
+            },
         }));
     }
 }
@@ -489,13 +505,15 @@ fn proved_goal_gap(goal: &serde_json::Value, status: &str) -> Option<serde_json:
             "property_status": field("normalized_property_status"),
         }));
     }
+
     // Before the hypotheses test, and separate from the dead test above it.
     // "valid_under_false_hypothesis" is a proof leaning on a hypothesis that
     // cannot hold, which is neither unreachable code nor a conditional proof:
-    // property_is_dead matches only "_but_dead", and goal_is_valid_under_hypotheses
-    // matches "valid_under_hyp", so a goal in this state answered both tests
-    // false and produced no gap at all. check then read "proved" over a proof
-    // that holds over no execution. get_wp_goals already reported it, through
+    // property_is_dead matches only "_but_dead", and
+    // goal_is_valid_under_hypotheses matches "valid_under_hyp", so a goal in
+    // this state answered both tests false and produced no gap at all. check
+    // then read "proved" over a proof that holds over no execution.
+    // get_wp_goals already reported it, through
     // goal_needs_failure_classification, so the two paths disagreed.
     if status_is_vacuous(
         goal.get("normalized_property_status")
@@ -854,7 +872,7 @@ pub fn check_incomplete_items(
 ) -> Vec<serde_json::Value> {
     let mut incomplete = Vec::new();
     ast_diagnostic_gaps(&mut incomplete, reload, AST_WARNING_ALLOWLIST);
-    unrequested_analysis_gaps(&mut incomplete, rte, wanted);
+    unrequested_analysis_gaps(&mut incomplete, rte, wp, wanted);
     step_failure_gaps(
         &mut incomplete,
         reload,

--- a/src/mcp/conclusions.rs
+++ b/src/mcp/conclusions.rs
@@ -2,14 +2,15 @@ use super::*;
 
 /// Why a receipt is not evidence about the target a conclusion names, or None.
 ///
-/// Five questions, and deliberately not seven. The target and receipt have to
+/// Six questions, and deliberately not eight. The target and receipt have to
 /// prove this function; the run has to have been made under the model and load
-/// settings the target declares; and it has to have been made over the sources
-/// the target names. A
-/// receipt records provers and timeout as "effective" and Frama-C leaves those
-/// null whenever it does not report them back, so comparing them would refuse
-/// runs that were correct. Model and sources are on every receipt this server
-/// writes.
+/// settings the target declares; it has to have been made over the sources
+/// the target names; and it has to clear the target's goal floor, because a
+/// receipt arrives here from the caller rather than from the run that made it.
+/// A receipt records provers and timeout as "effective" and Frama-C leaves
+/// those null whenever it does not report them back, so comparing them would
+/// refuse runs that were correct. Model and sources are on every receipt this
+/// server writes.
 ///
 /// Absent halves are skipped rather than refused. A conclusion can be stored
 /// before any proof exists, and a check that treated a missing receipt as a
@@ -102,6 +103,64 @@ pub fn profile_evidence_error(
             return Some(format!(
                 "verify_profile \"{name}\" declares different project load settings than this receipt, so it is not evidence about that target"
             ));
+        }
+
+        // The goal floor again, because run_wp is not the only way in. A
+        // conclusion takes a caller-supplied receipt, so a run made without the
+        // profile over a gutted target could be stored under the profile's name
+        // and the floor would never have run. The conclusion is durable and
+        // names the target, which makes this the more expensive miss of the
+        // two.
+        //
+        // Asked only of a receipt that covers the whole target, and counted by
+        // the same rule run_wp uses.
+        //
+        // The first half is a false refusal this check caused on its own. The
+        // floor is a claim about the target, and a receipt need not be: check
+        // {function: "a"} builds one from the goals scoped to a, so an honest
+        // receipt for one function of a three function profile records a
+        // fraction of the floor and was refused for it. Worse, proof_coverage
+        // runs this against every stored conclusion, so adding min_goals to a
+        // profile retroactively flipped conclusions already stored that way to
+        // a mismatch and dropped them from its denominator.
+        //
+        // The second half is the other direction. Counting the whole array let
+        // an emptied target clear its floor on its neighbours' obligations,
+        // because a whole-project run's receipt carries every function's goals,
+        // so the two doors enforced different floors and the durable one was
+        // the looser. Receipt goals record "fct" for this.
+        //
+        // A receipt written before that field carries none, and falls back to
+        // the array length rather than counting zero and refusing evidence that
+        // was correct when it was stored. receipt_goals_record_owner asks for
+        // the key rather than for a usable name, because a goal WP owns
+        // globally carries the key with a null in it and is not an old receipt.
+        let covers_whole_target = receipt
+            .pointer("/wp/functions")
+            .and_then(|functions| functions.as_array())
+            .is_some_and(|proved| {
+                profile.functions.iter().all(|declared| {
+                    proved.iter().any(|f| f.as_str() == Some(declared.as_str()))
+                })
+            });
+        if let Some(min_goals) = profile.min_goals.filter(|_| covers_whole_target) {
+            let goals = receipt
+                .get("goals")
+                .and_then(serde_json::Value::as_array)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let recorded = if super::receipt::receipt_goals_record_owner(goals) {
+                super::analysis::goals_owned_by(goals, &profile.functions)
+            } else {
+                goals.len()
+            };
+            if recorded < min_goals as usize {
+                return Some(format!(
+                    "verify_profile \"{name}\" requires at least {min_goals} obligations and \
+                     this receipt records {recorded}, so it is not evidence about that target \
+                     however many discharged"
+                ));
+            }
         }
     }
     None

--- a/src/mcp/coverage.rs
+++ b/src/mcp/coverage.rs
@@ -632,6 +632,7 @@ pub fn proof_coverage_report(
             "A source file a receipt named but that cannot be read now is counted under unchecked_sources rather than judged, so evidence from a deleted sandbox is reported as unverifiable rather than as unchanged.",
             "Functions this project declares without defining are listed under scope.declared_not_defined and are outside both denominators.",
             "WP only. EVA alarms are not read here, so a complete verdict is a statement about proof obligations rather than about every analysis this server can run.",
+            "A target's own command may run checks this server does not, such as a floor on obligations generated or a separate script over the same sources. A profile declares them under build_gates and coverage does not run them, so complete here is not the build's verdict. The list is the profile author's declaration rather than anything this server can verify, so an empty one means none were declared, not that none exist.",
             "Whether a covered function declares an assigns clause is not checked, because the conclusion's specs are supplied by the caller and may be absent for a function that has one.",
         ],
     })

--- a/src/mcp/eacsl.rs
+++ b/src/mcp/eacsl.rs
@@ -117,6 +117,21 @@ fn compile_args(
     driver: Option<&str>,
     output_exec: &Path,
 ) -> Result<Vec<String>, serde_json::Value> {
+    // Exhaustive so a field added later is a compile error here. The two named
+    // below are decisions this function makes; the rest reach both -E and -e
+    // through cpp_extra_args, which is given the whole struct and so carries a
+    // new one without being told.
+    let ProjectLoadOptions {
+        machdep,
+        compilation_database,
+        include_paths: _,
+        defines: _,
+        force_includes: _,
+        isystem_paths: _,
+        nostdinc: _,
+        rte: _,
+    } = project_options;
+
     let mut args = vec![
         "-c".to_string(),
         "-q".to_string(),
@@ -151,7 +166,7 @@ fn compile_args(
         args.push("-e".to_string());
         args.push(compile_flags);
     }
-    if let Some(machdep) = &project_options.machdep {
+    if let Some(machdep) = machdep {
         match machdep.as_str() {
             "gcc_x86_64" => {
                 args.push("--mbits".to_string());
@@ -172,7 +187,7 @@ fn compile_args(
         args.push("-F".to_string());
         args.push(format!("-machdep {machdep}"));
     }
-    if let Some(compilation_database) = &project_options.compilation_database {
+    if let Some(compilation_database) = compilation_database {
         args.push("-F".to_string());
         args.push(format!("-compilation-db={compilation_database}"));
     }

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -1527,23 +1527,44 @@ fn parse_surface_next_action(blocked_by: &[serde_json::Value]) -> serde_json::Va
 }
 
 pub fn validate_project_options(options: &ProjectLoadOptions) -> Result<(), McpError> {
+    // Exhaustive so a field added later cannot slip past validation unnoticed:
+    // the decision "does this one need a grammar" is made here or nowhere.
+    //
+    // Bound rather than elided, and every binding is used below. Destructuring
+    // all eight to "_" and then reading them back through options. was the
+    // decorative form: the compiler's only demand on a new field would have
+    // been that someone type its name beside the others, which is the same
+    // amount of thought as ignoring it.
+    let ProjectLoadOptions {
+        include_paths,
+        defines,
+        force_includes,
+        isystem_paths,
+        machdep,
+        compilation_database,
+
+        // Booleans, with no spelling to get wrong.
+        rte: _,
+        nostdinc: _,
+    } = options;
+
     validate_cpp_entries(
-        &options.include_paths,
+        include_paths,
         "include_paths entries must be non-empty directories of [A-Za-z0-9_./+-] \
          without a leading dash (write \"include\", not \"-Iinclude\")",
     )?;
     validate_cpp_entries(
-        &options.defines,
+        defines,
         "defines entries must be non-empty NAME or NAME=VALUE of [A-Za-z0-9_=./+-] \
          without a leading dash (write \"_Atomic=\", not \"-D_Atomic=\")",
     )?;
     validate_cpp_entries(
-        &options.force_includes,
+        force_includes,
         "force_includes entries must be non-empty header names of [A-Za-z0-9_./+-] \
          without a leading dash (write \"builtins.h\", not \"-include builtins.h\")",
     )?;
     validate_cpp_entries(
-        &options.isystem_paths,
+        isystem_paths,
         "isystem_paths entries must be non-empty directories of [A-Za-z0-9_./+-] \
          without a leading dash (write \"include\", not \"-isystem include\")",
     )?;
@@ -1555,7 +1576,7 @@ pub fn validate_project_options(options: &ProjectLoadOptions) -> Result<(), McpE
     //
     // Frama-C decides whether a non-name machdep argument is YAML from its
     // contents, so do not infer that from a filename suffix.
-    if let Some(machdep) = options.machdep.as_deref() {
+    if let Some(machdep) = machdep.as_deref() {
         if machdep.is_empty() || machdep.starts_with('-') {
             return Err(McpError::invalid_params(
                 "machdep must be a non-empty predefined name or YAML machdep file path without a \
@@ -1564,7 +1585,7 @@ pub fn validate_project_options(options: &ProjectLoadOptions) -> Result<(), McpE
             ));
         }
     }
-    if let Some(compilation_database) = options.compilation_database.as_deref() {
+    if let Some(compilation_database) = compilation_database.as_deref() {
         if compilation_database.is_empty() || compilation_database.starts_with('-') {
             return Err(McpError::invalid_params(
                 "compilation_database must be a non-empty path without a leading dash \

--- a/src/mcp/receipt.rs
+++ b/src/mcp/receipt.rs
@@ -109,8 +109,7 @@ pub fn proof_receipt_goals(
                 // The receipt spells the normalized verdict under "status",
                 // which is why a receipt reader is right to read that name
                 // directly and must not be routed through the goal accessors.
-                "status": own_status(&goal).map(|status| json!(status))
-                    .unwrap_or_else(|| json!(null)),
+                "status": own_status(&goal),
 
                 // Part of the receipt's identity on purpose: two runs whose
                 // receipts match are supposed to be comparable, and a replayed
@@ -123,6 +122,16 @@ pub fn proof_receipt_goals(
                 // "not cached", which is the direction that hides a replayed
                 // verdict, on the payload the receipt hashes.
                 "from_cache": json!(crate::mcp::server::wpclass::goal_is_from_cache(&goal)),
+                "fct": crate::mcp::server::wpclass::goal_owner_name(&goal),
+
+                // The function this goal belongs to, so a reader of the receipt
+                // can scope a count to a target the way run_wp does. Without it
+                // the receipt recorded ids and statuses only, and the goal
+                // floor at the conclusion door had to count the whole array: a
+                // receipt from a whole-project run carries every function's
+                // goals, so an emptied target cleared its floor on its
+                // neighbours' obligations. Null for a goal that names none.
+
             })
         })
         .collect::<Vec<_>>();
@@ -138,6 +147,20 @@ pub fn proof_receipt_goals(
         a_key.cmp(&b_key)
     });
     receipt_goals
+}
+
+/// Whether these receipt goals come from a build that records goal owners.
+///
+/// A shape question, not a content one. Asking whether any goal names an owner
+/// answered "no" for a receipt this build wrote whose goals are all WP globals,
+/// since those carry "fct": null, and sent it down the path meant for receipts
+/// written before the field existed. The key's presence is what separates the
+/// two, and an unowned goal carries the key with a null in it.
+///
+/// Beside proof_receipt_goals because that is what writes the field: the reader
+/// and the writer of this contract are three screens apart otherwise.
+pub fn receipt_goals_record_owner(goals: &[serde_json::Value]) -> bool {
+    goals.iter().all(|goal| goal.get("fct").is_some())
 }
 
 pub fn proof_receipt_with_hash(mut body: serde_json::Value) -> serde_json::Value {

--- a/src/mcp/selfcheck.rs
+++ b/src/mcp/selfcheck.rs
@@ -905,6 +905,8 @@ impl FramaCMcpServer {
         let mut payload = json!({
             "server": {
                 "version": env!("CARGO_PKG_VERSION"),
+
+                "build_commit": env!("BUILD_COMMIT"),
                 "frama_c_path": self.frama_c_path,
                 "max_sandboxes": self.max_sandboxes,
             },

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1620,7 +1620,9 @@ pub fn cpp_extra_args(options: &ProjectLoadOptions) -> Option<String> {
         machdep: _,
         compilation_database: _,
 
-        // Not a flag at all: it selects whether Frama-C is started with -rte.
+        // Not a preprocessor flag, and no longer any flag here: run_wp
+        // generates WP's own RTE guards rather than the spawn asking the kernel
+        // for its larger set.
         rte: _,
     } = options;
 
@@ -1681,6 +1683,46 @@ impl FramaCMcpServer {
     }
 }
 
+/// The argv for the long-lived main Frama-C process.
+///
+/// A free function so a test can assert it. It is the only place kernel "-rte"
+/// could be added back to the main load, and the reason it must not be is in
+/// project_cli_args: the kernel's RTE generator and WP's own are different
+/// analyses over the same code, the kernel emitting pointer_alignment
+/// assertions that WP's does not. A build that proves runtime errors does it
+/// with -wp-rte, so a load started under kernel -rte proves a strictly larger
+/// set than the target it claims to be. Measured on one 3-function target:
+/// -wp-rte alone generates 40 obligations and discharges all of them, while
+/// -rte alongside it generates 42 and leaves the two extra alignment goals
+/// open. run_wp implements the load's rte flag through WP's generator instead.
+///
+/// The options-derived arguments come from project_cli_args rather than being
+/// spelled again here. They were spelled again until the -rte line went, which
+/// was the only difference between the two, and the copy carried its own
+/// exhaustive destructure: two assertions that neither copy forgets a field,
+/// and nothing at all that they agree on what to emit.
+pub fn main_frama_c_args(
+    frama_c_path: &str,
+    files: &[String],
+    options: &ProjectLoadOptions,
+    socket_path: &Path,
+) -> Vec<String> {
+    let mut command_line = vec![frama_c_path.to_string()];
+    command_line.extend(project_cli_args(options));
+    command_line.extend(files.iter().cloned());
+    command_line.extend([
+        "-load-module".to_string(),
+        "ast_utils_plugin".to_string(),
+        "-server-socket".to_string(),
+        socket_path.display().to_string(),
+        "-wp-prover".to_string(),
+        default_wp_provers().to_string(),
+        "-wp-model".to_string(),
+        default_wp_model().to_string(),
+    ]);
+    command_line
+}
+
 pub fn project_cli_args(options: &ProjectLoadOptions) -> Vec<String> {
     // Destructured exhaustively, as cpp_extra_args is and for the reason given
     // on ProjectLoadOptions: a field added there is a compile error here rather
@@ -1696,11 +1738,11 @@ pub fn project_cli_args(options: &ProjectLoadOptions) -> Vec<String> {
         isystem_paths: _,
         nostdinc: _,
 
-        // Not emitted here. These arguments serve short-lived CLI runs that
-        // generate their own obligations, and each already decides for itself:
-        // wpcli passes -wp-rte where the run needs it, and parse_surface runs
-        // no proof at all. Emitting -rte here would add obligations to runs
-        // whose callers pass the flag a second time.
+        // Not emitted here, by anyone. The short-lived CLI runs each decide for
+        // themselves: wpcli passes -wp-rte where the run needs it, and
+        // parse_surface runs no proof at all. The main spawn reaches this
+        // through main_frama_c_args, whose doc carries the measurement for why
+        // the kernel's generator is the wrong one.
         rte: _,
     } = options;
 
@@ -1757,12 +1799,23 @@ pub struct WpModelSupport {
     source: &'static str,
 }
 
+/// Memory models Frama-C's -wp-model parser accepts and its help text omits.
+///
+/// Caveat is the one measured so far: the parser takes it, -wp-h names it
+/// nowhere, and a project proved under it was told its own model was invalid.
+/// One of elfuse's 21 targets uses it. The advertised set is what Frama-C
+/// documents; this server validates against what it accepts.
+pub const ACCEPTED_BUT_UNDOCUMENTED_BASES: &[&str] = &["Caveat"];
+
 impl WpModelSupport {
-    fn fallback() -> Self {
+    /// Public so a test can assert the list reflects what Frama-C accepts
+    /// rather than what its help text documents.
+    pub fn fallback() -> Self {
         Self {
             bases: ["Hoare", "Typed", "Bytes", "Region", "Eva"]
                 .into_iter()
                 .map(String::from)
+                .chain(ACCEPTED_BUT_UNDOCUMENTED_BASES.iter().map(|base| base.to_string()))
                 .collect(),
             modifiers: [
                 "nocast", "cast", "raw", "ref", "nat", "int", "real", "float",
@@ -1784,7 +1837,19 @@ impl WpModelSupport {
     fn validate_one(&self, model: &str) -> Result<(), String> {
         let mut parts = model.split('+');
         let base = parts.next().unwrap_or_default();
-        if base.is_empty() || !self.bases.iter().any(|known| known == base) {
+
+        // Case-insensitively, because Frama-C is: "-wp-model typed" and
+        // "-wp-model Typed" are the same invocation to it, and a build system
+        // that writes the lowercase spelling is not making a different claim.
+        // Comparing exactly refused 19 of one project's 21 targets, every one
+        // of them a profile emitted faithfully from the command that proves it,
+        // which is the drift these profiles exist to prevent, inverted.
+        if base.is_empty()
+            || !self
+                .bases
+                .iter()
+                .any(|known| known.eq_ignore_ascii_case(base))
+        {
             return Err(format!(
                 "invalid WP model '{}'; bases: {}; modifiers: {}; examples: {}",
                 model,
@@ -1794,7 +1859,12 @@ impl WpModelSupport {
             ));
         }
         for modifier in parts {
-            if modifier.is_empty() || !self.modifiers.iter().any(|known| known == modifier) {
+            if modifier.is_empty()
+                || !self
+                    .modifiers
+                    .iter()
+                    .any(|known| known.eq_ignore_ascii_case(modifier))
+            {
                 return Err(format!(
                     "invalid WP model '{}'; bases: {}; modifiers: {}; examples: {}",
                     model,
@@ -1892,6 +1962,20 @@ pub fn parse_wp_model_support(help: &str) -> WpModelSupport {
     if bases.is_empty() || modifiers.is_empty() {
         WpModelSupport::fallback()
     } else {
+        // Parsed from the help text, which lists what Frama-C documents rather
+        // than what it accepts. Added here as well as to the fallback so the
+        // parsed path is not the stricter of the two, and from the same list,
+        // because two literals encoding one fact about the installed Frama-C
+        // means the next one is added to whichever path the author was reading.
+        for accepted_but_undocumented in ACCEPTED_BUT_UNDOCUMENTED_BASES {
+            if !bases
+                .iter()
+                .any(|known| known.eq_ignore_ascii_case(accepted_but_undocumented))
+            {
+                bases.push(accepted_but_undocumented.to_string());
+            }
+        }
+
         WpModelSupport {
             bases,
             modifiers,
@@ -2256,9 +2340,16 @@ pub struct ProjectLoadOptions {
 
     /// Whether this load generates runtime-error obligations.
     ///
-    /// Part of the load identity, not a run setting: -wp-rte is applied when
-    /// Frama-C starts, and it changes which obligations exist, so two loads
-    /// differing only here are different programs to prove.
+    /// Part of the load identity, not a run setting: it says whether the
+    /// target's own command proves them, which decides which obligations a
+    /// receipt is about, so two loads differing only here are not comparable.
+    ///
+    /// Nothing on the command line carries it any more. The kernel's -rte was
+    /// dropped because it emits pointer_alignment assertions WP's generator
+    /// does not, and run_wp generates WP's guards for every main-instance run,
+    /// which is what a -wp-rte build proves. So this flag reaches Frama-C
+    /// through the isolated CLI payloads and the reproduce line rather than
+    /// through the spawn.
     pub rte: bool,
 
     /// System include directories, as `-isystem <dir>`.
@@ -2410,8 +2501,10 @@ impl SandboxRegistry {
 /// Seven locks, one order, and it is the whole rule. Take them in this
 /// sequence and never in any other:
 ///
-///     main_wp_lock -> main_eva_lock -> main_spawn_lock -> main_frama_c_state
-///         -> client -> state -> sandboxes
+/// ```text
+/// main_wp_lock -> main_eva_lock -> main_spawn_lock -> main_frama_c_state
+///     -> client -> state -> sandboxes
+/// ```
 ///
 /// It is written here rather than beside each lock because it used to be
 /// exactly that: four doc comments each stating its own fragment, two of them
@@ -3070,43 +3163,16 @@ impl FramaCMcpServer {
 
     /// The argv for a new main instance.
     ///
-    /// RTE is read off project_options rather than passed beside it. It used to
-    /// be both, and nothing made the two agree: a caller that passed one value
-    /// and an options struct carrying the other started a process the receipt
-    /// did not describe.
+    /// A thin wrapper so the spawn path has one caller-facing name; the argv
+    /// itself is main_frama_c_args, which is a free function so a test can
+    /// assert what this process is started with.
     fn main_frama_c_command_line(
         &self,
         files: &[String],
         project_options: &ProjectLoadOptions,
         socket_path: &Path,
     ) -> Vec<String> {
-        let mut command_line = vec![self.frama_c_path.clone()];
-        if let Some(cpp_args) = cpp_extra_args(project_options) {
-            command_line.push(format!("-cpp-extra-args={cpp_args}"));
-        }
-        if let Some(machdep) = &project_options.machdep {
-            command_line.push("-machdep".to_string());
-            command_line.push(machdep.clone());
-        }
-        if let Some(compilation_database) = &project_options.compilation_database {
-            command_line.push("-compilation-db".to_string());
-            command_line.push(compilation_database.clone());
-        }
-        command_line.extend(files.iter().cloned());
-        command_line.extend([
-            "-load-module".to_string(),
-            "ast_utils_plugin".to_string(),
-            "-server-socket".to_string(),
-            socket_path.display().to_string(),
-            "-wp-prover".to_string(),
-            default_wp_provers().to_string(),
-            "-wp-model".to_string(),
-            default_wp_model().to_string(),
-        ]);
-        if project_options.rte {
-            command_line.push("-rte".to_string());
-        }
-        command_line
+        main_frama_c_args(&self.frama_c_path, files, project_options, socket_path)
     }
 
     /// Starts without a Frama-C process: `client` and `main_frama_c_state`
@@ -3369,6 +3435,7 @@ impl FramaCMcpServer {
                     .ok_or_else(|| McpError::from(FramaCError::FunctionNotFound(function.clone())))
             })
             .collect::<Result<Vec<_>, _>>()?;
+
         // Read before any proof is scheduled: after the drain the average is
         // largely this run's own provers. See host_load_per_cpu.
         let host_load = crate::mcp::server::wpclass::host_load();
@@ -4216,6 +4283,10 @@ impl FramaCMcpServer {
         json!({
             "server": {
                 "version": env!("CARGO_PKG_VERSION"),
+
+                // The commit, because the version has read 0.1.0 throughout and
+                // cannot tell an installed binary from the source beside it.
+                "build_commit": env!("BUILD_COMMIT"),
 
                 // Counted off the router rather than written down. A number in
                 // a constant is one a person edits to make a build green, which

--- a/src/mcp/status.rs
+++ b/src/mcp/status.rs
@@ -136,11 +136,12 @@ pub fn status_is_failed(status: &str) -> bool {
 /// Whether a status says the prover ran out of its wall-clock budget.
 ///
 /// The sibling of status_is_failed, here for the reason spelled out above it:
-/// four callers arrived at this predicate independently. classify_failure_reason
-/// and wp_timeout_triage_from_goal compare the normalized and the raw spelling,
-/// run_measurement counts goals at timeout, and the proofread report categorizes
-/// them, which is four answers available to one question. Which status to read
-/// stays the call site's decision; the comparison itself lives here.
+/// four callers arrived at this predicate independently.
+/// classify_failure_reason and wp_timeout_triage_from_goal compare the
+/// normalized and the raw spelling, run_measurement counts goals at timeout,
+/// and the proofread report categorizes them, which is four answers available
+/// to one question. Which status to read stays the call site's decision; the
+/// comparison itself lives here.
 pub fn status_is_timeout(status: &str) -> bool {
     status.eq_ignore_ascii_case("timeout")
 }
@@ -225,10 +226,10 @@ pub fn own_status_is_proved(row: &Value) -> bool {
 ///
 /// own_status, not consolidated_status, and the distinction is the whole point
 /// of this module: a goal at TIMEOUT can hang off a property that consolidated
-/// to valid, and the consolidated reader answers "valid" for it. run_measurement
-/// asked the property's verdict for a question about the goal, beside a line
-/// asking the goal's own verdict for whether it was proved, so one loop asked
-/// two different questions about the same row.
+/// to valid, and the consolidated reader answers "valid" for it.
+/// run_measurement asked the property's verdict for a question about the goal,
+/// beside a line asking the goal's own verdict for whether it was proved, so
+/// one loop asked two different questions about the same row.
 pub fn own_status_is_timeout(row: &Value) -> bool {
     own_status(row).is_some_and(status_is_timeout)
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -235,8 +235,20 @@ pub struct ReloadProjectParams {
     /// loaded from this database.
     #[serde(alias = "compilation_db")]
     pub compilation_database: Option<String>,
-    /// Enable generated RTE annotations by restarting Frama-C with `-rte`.
-    /// Default: false.
+
+    // Deliberately a plain comment and not part of the doc below. This field's
+    // doc comment is the property description in the published tool schema,
+    // which tool_registry_count_matches_declared_snapshots caps at 90
+    // characters, so an explanation written there ships to every agent on every
+    // turn and fails the build.
+    //
+    // Nothing on the command line carries this any more. The kernel's -rte
+    // emits pointer_alignment assertions that WP's generator does not, so a
+    // load started under it proves a strictly larger set than a -wp-rte build,
+    // and run_wp generates WP's own guards for every main-instance run instead.
+    // Still part of the load identity, so two receipts differing here are not
+    // comparable.
+    /// Whether this load proves runtime-error obligations. Default: false.
     #[serde(default, deserialize_with = "deserialize_bool_or_string")]
     pub rte: Option<bool>,
     /// Register what the project's build system proves each target under, as an
@@ -253,6 +265,18 @@ pub struct ReloadProjectParams {
     /// because each decides which obligations exist at all. A profile written
     /// before those two were required loads as before and is refused only
     /// where it would have become evidence; state them to restore it.
+    ///
+    /// Two optional fields say what this server cannot otherwise know.
+    /// min_goals is the floor on obligations the target requires WP to
+    /// generate, and a run that generates fewer is refused: "N of N
+    /// discharged" is not evidence on its own, since an emptied body or a
+    /// dropped contract discharges 0 of 0. build_gates names checks the
+    /// target's own command runs that this server does not, and they are
+    /// echoed back under declared_build_gates_not_run_here so a verdict here is
+    /// not mistaken for the build's. "Declared" is the load-bearing word: the
+    /// list is whatever the profile author wrote, so an empty one means none
+    /// were declared rather than that none exist.
+    ///
     /// Registered for the session; passing it again replaces the set.
     ///
     /// Tolerant of the JSON text of the object as well as the object, like the

--- a/src/mcp/wpclass.rs
+++ b/src/mcp/wpclass.rs
@@ -67,9 +67,10 @@ fn classify_failure_reason(
     goal_kind: &str,
     name: &str,
     text: &str,
+    from_cache: bool,
     push_evidence: &mut impl FnMut(&str, serde_json::Value),
 ) -> (&'static str, &'static str, &'static str) {
-    if crate::mcp::status::status_is_timeout(normalized_status)
+    let classification = if crate::mcp::status::status_is_timeout(normalized_status)
         || crate::mcp::status::status_is_timeout(raw_status)
     {
         push_evidence("normalized_status", json!(normalized_status));
@@ -280,6 +281,21 @@ fn classify_failure_reason(
             "low",
             "Inspect the VC details before changing annotations.",
         )
+    };
+
+    if from_cache {
+        push_evidence("from_cache", json!(true));
+
+        // Scored down here and explained in wp_timeout_triage, which is the
+        // per-goal field a caller already reads for "why is this verdict weak".
+        // Appending the sentence to the reason instead cost 471 bytes on every
+        // classified goal, twice, and for a replayed timeout it was duplicating
+        // a string the same payload already carried; the stdio payload budget
+        // caught it. A constant repeated per goal belongs in neither half of a
+        // split classification.
+        (classification.0, "low", classification.2)
+    } else {
+        classification
     }
 }
 
@@ -323,6 +339,7 @@ pub fn classify_wp_failure_from_goal(
         goal_kind,
         name,
         &text,
+        goal_is_from_cache(goal),
         &mut push_evidence,
     );
     let failure_kind = wp_failure_kind(category, triage_kind);
@@ -736,19 +753,7 @@ fn proofread_finding_from_wp_failure(
     // name is the only field left that points a reader at the code. Reading it
     // from the run target instead left findings rendering as "unknown:?" with
     // an empty function, which names nothing.
-    //
-    // "scope" and "function_marker" are declaration markers such as "#F24", not
-    // names, so they are read only as a last resort and a marker is rejected: a
-    // finding whose function field says "#F24" points at less than the run
-    // target does, and the marker is reallocated on the next reload anyway.
-    let owner = goal
-        .get("fct")
-        .or_else(|| goal.get("scope"))
-        .or_else(|| goal.get("function_marker"))
-        .and_then(|value| value.as_str())
-        .filter(|owner| !owner.is_empty() && !owner.starts_with('#'))
-        .or(function)
-        .unwrap_or("");
+    let owner = goal_owner_name(goal).or(function).unwrap_or("");
     json!({
         "id": format!("wp_failure:{stable_id}:{category}"),
         "severity": severity,
@@ -1021,20 +1026,9 @@ fn stable_goal_id_for(
         return label.to_string();
     }
 
-    // `fct` before `scope`, because `scope` and `function_marker` are `#F<vid>`
-    // markers that Frama-C reallocates on every reload. A caller that passes no
-    // function name (`check` does not) would otherwise get a different id for
-    // the same goal after a reload in the same session, while two fresh
-    // processes agreed and hid it.
-    let scope = stable_scope.map(str::to_string).unwrap_or_else(|| {
-        goal
-            .get("fct")
-            .or_else(|| goal.get("scope"))
-            .or_else(|| goal.get("function_marker"))
-            .and_then(|value| value.as_str())
-            .unwrap_or("")
-            .to_string()
-    });
+    // A caller that passes no scope (check does not) gets the goal's own, which
+    // is why goal_scope_key keeps a marker rather than rejecting one.
+    let scope = stable_scope.unwrap_or_else(|| goal_scope_key(goal));
     let payload = json!({
         "scope": scope,
         "goal_kind": goal_kind,
@@ -1047,6 +1041,34 @@ fn stable_goal_id_for(
     // Sixteen characters, which is the first eight bytes: the same id the
     // eight-way format string produced before this shared a helper.
     format!("sg_{}", &sha256_hex(payload.to_string().as_bytes())[..16])
+}
+
+/// The raw scope string a goal hashes under.
+///
+/// "fct" before "scope", because "scope" and "function_marker" are "#F<vid>"
+/// markers that Frama-C reallocates on every reload. A caller that passes no
+/// function name would otherwise get a different id for the same goal after a
+/// reload in the same session, while two fresh processes agreed and hid it.
+/// Markers are kept here rather than rejected: this answer is a hash input, so
+/// a reallocated marker is better than an empty key.
+pub fn goal_scope_key(goal: &serde_json::Value) -> &str {
+    goal.get("fct")
+        .or_else(|| goal.get("scope"))
+        .or_else(|| goal.get("function_marker"))
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+}
+
+/// The function a goal belongs to, when the goal names one a reader can use.
+///
+/// The same three fields as goal_scope_key and the opposite decision about
+/// markers: a finding whose function field says "#F24" points at less than the
+/// run target does, and the marker is reallocated on the next reload anyway.
+/// Both rules used to be spelled out at each of the four call sites, which is
+/// how "is a marker an owner" came to be answered differently at each.
+pub fn goal_owner_name(goal: &serde_json::Value) -> Option<&str> {
+    let owner = goal_scope_key(goal);
+    (!owner.is_empty() && !owner.starts_with('#')).then_some(owner)
 }
 
 /// Whether WP replayed this goal's verdict from its cache instead of proving
@@ -1227,6 +1249,7 @@ pub fn host_load() -> HostLoad {
     // both platforms this runs on, so there is no subprocess to block a Tokio
     // worker, no PATH to resolve, and no output format to parse.
     let mut avg = [0.0f64; 1];
+
     // Safety: getloadavg writes at most nelem doubles, and the buffer holds
     // exactly that many.
     if unsafe { libc::getloadavg(avg.as_mut_ptr(), 1) } != 1 {
@@ -1307,6 +1330,7 @@ pub fn run_measurement(goals: &[serde_json::Value]) -> RunMeasurement {
         // The module that owns "is this goal proved" answers it. Spelling the
         // test here was how the two callers of its sibling drifted apart.
         let unproved = !crate::mcp::status::own_status_is_proved(goal);
+
         // The goal's own verdict, like the line above it. Reading the
         // consolidated one asked what the property it hangs off decided, which
         // answers "valid" for a timed-out goal under a property that
@@ -1350,6 +1374,50 @@ pub fn wp_timeout_triage_none() -> serde_json::Value {
     )
 }
 
+/// Why a goal this run replayed cannot carry a confident verdict.
+///
+/// A cached verdict was not attempted here, so nothing this run did explains
+/// it: not the goal's difficulty, not the prover budget, not the machine. Every
+/// verdict in this module rests on the run having measured what it reports, and
+/// this is the one input that makes that false for a single goal.
+///
+/// Stated once because it was stated in one place and contradicted in two:
+/// prover_timeout_triage withdrew confidence for a replayed run while
+/// wp_timeout_triage_from_goal answered "high, a higher prover timeout may
+/// help" about the same goal.
+pub const REPLAYED_GOAL_REASON: &str =
+    "This goal's verdict came back from WP's cache rather than being attempted on this run, so \
+     nothing here measured it. WP's cache defaults to Update and stores timeout verdicts too. \
+     Re-run with cache: \"None\" before treating it as a property of the goal.";
+
+/// The same fact about a whole run rather than about one goal.
+///
+/// Beside its sibling rather than inline at the one call site, because the
+/// doc above claims the rule is stated once and that was not true while a
+/// second wording of it sat a hundred lines away. Two constants, because the
+/// scopes really do differ: one goal's verdict was replayed, or every timed-out
+/// goal in the run was. Composing one from the other would save a sentence and
+/// cost the reader the difference.
+pub const REPLAYED_RUN_REASON: &str =
+    "Every timed-out goal in this run came back from WP's cache rather than being attempted, so \
+     this run measured nothing about them. WP's cache defaults to Update and stores timeout \
+     verdicts too. Re-run with cache: \"None\" before drawing any conclusion.";
+
+/// The triage for a goal this run replayed rather than attempted.
+///
+/// One call shape, two kinds. Written twice it was two five-argument literals
+/// differing in one word, whose evidence arrays had to be kept identical by
+/// hand.
+fn replayed_goal_triage(kind: &str) -> serde_json::Value {
+    wp_timeout_triage(
+        kind,
+        false,
+        "low",
+        REPLAYED_GOAL_REASON,
+        json!([{"field": "from_cache", "value": true}]),
+    )
+}
+
 pub fn wp_timeout_triage_from_goal(goal: &serde_json::Value) -> serde_json::Value {
     let normalized_status = crate::mcp::status::consolidated_status(goal)
         .unwrap_or("unknown");
@@ -1358,6 +1426,9 @@ pub fn wp_timeout_triage_from_goal(goal: &serde_json::Value) -> serde_json::Valu
     if crate::mcp::status::status_is_timeout(normalized_status)
         || crate::mcp::status::status_is_timeout(raw_status)
     {
+        if goal_is_from_cache(goal) {
+            return replayed_goal_triage("prover_timeout");
+        }
         return wp_timeout_triage(
             "prover_timeout",
             true,
@@ -1385,6 +1456,22 @@ pub fn wp_timeout_triage_from_goal(goal: &serde_json::Value) -> serde_json::Valu
                 {"field": "raw_status", "value": raw_status},
             ]),
         );
+    }
+
+    // A replayed goal that did not time out. The branches above already say
+    // this for a replayed timeout; without this one, a cached prover_unknown
+    // scored its confidence down to low and nothing in the payload said why,
+    // which is the half of the rule that was still missing after the timeout
+    // half was fixed.
+    //
+    // The kind stays "none", because it is what this field means and
+    // wp_failure_kind maps it: there is no timeout evidence here, and what the
+    // goal needs said is why its verdict is thin. Written into the reason
+    // rather than appended to the classification's, because the reason on a
+    // classification is per goal by design and a constant repeated per goal
+    // belongs in neither half of the split.
+    if goal_is_from_cache(goal) {
+        return replayed_goal_triage("none");
     }
     wp_timeout_triage_none()
 }
@@ -1454,8 +1541,8 @@ pub fn prover_timeout_triage(
         // it in every payload; what the verdict below rests on is this bool.
         {"field": "every_timed_out_goal_was_replayed", "value": all_replayed},
 
-        // Categorized, never the reading: this payload is hashed into the
-        // proof receipt. See HostLoad::category.
+        // Categorized, never the reading: this payload is hashed into the proof
+        // receipt. See HostLoad::category.
         {"field": "host_load", "value": host_load.category()},
     ]);
 
@@ -1466,9 +1553,7 @@ pub fn prover_timeout_triage(
     // sends the caller to re-run with cache "None" on the machine that will
     // grind to the budget again.
     let withdrawn: Vec<&str> = [
-        all_replayed.then_some(
-            "Every timed-out goal in this run came back from WP's cache rather than being attempted, so this run measured nothing about them. WP's cache defaults to Update and stores timeout verdicts too. Re-run with cache: \"None\" before drawing any conclusion.",
-        ),
+        all_replayed.then_some(REPLAYED_RUN_REASON),
         host_load.timeout_caveat(),
     ]
     .into_iter()

--- a/src/state.rs
+++ b/src/state.rs
@@ -289,6 +289,26 @@ pub struct VerificationProfile {
     /// profile does not speak to it.
     pub nostdinc: Option<bool>,
 
+    /// The floor on obligations this target's own command requires WP to
+    /// generate.
+    ///
+    /// "N of N discharged" is not evidence on its own: an emptied function body
+    /// or a dropped contract discharges 0 of 0 and reports success. A build
+    /// system that carries such a floor is carrying the only check that catches
+    /// that, and a run here that generated fewer obligations than the target
+    /// requires is not that target's evidence however green it looks.
+    pub min_goals: Option<u32>,
+
+    /// Checks the target's own command runs that this server does not.
+    ///
+    /// Named rather than imported. A profile can express what Frama-C is
+    /// invoked with, but a build gate may be a separate script over the same
+    /// sources, and nothing here can run it. Listing them is what keeps a
+    /// verdict from reading as the build's verdict: the response repeats the
+    /// list so a caller sees which of the target's checks did not happen.
+    #[serde(default)]
+    pub build_gates: Vec<String>,
+
     /// Whether the target's own command generates runtime-error obligations.
     ///
     /// Pinned like the model and the provers, and for the same reason: -wp-rte
@@ -344,6 +364,16 @@ pub fn parse_verification_profiles(
         let mut profile: VerificationProfile = serde_json::from_value(body.clone())
             .map_err(|e| format!("profile \"{name}\": {e}"))?;
 
+        // A floor of zero passes every run, and None already says the target
+        // declares none. Accepting it would let a profile carry the field while
+        // checking nothing, which reads as a floor to anyone who sees the key
+        // present.
+        if profile.min_goals == Some(0) {
+            return Err(format!(
+                "profile \"{name}\": min_goals 0 checks nothing; omit it to declare no floor"
+            ));
+        }
+
         // Function and prover names are trimmed, and one that is nothing but
         // padding is refused. The remaining lists contain command arguments or
         // paths, whose spelling must be left for their later validation.
@@ -357,6 +387,14 @@ pub fn parse_verification_profiles(
         for (field, entries) in [
             ("functions", &mut profile.functions),
             ("provers", &mut profile.provers),
+
+            // A gate name is only ever printed back, never matched, so the
+            // padding costs nothing on its own. A blank one does not: it
+            // becomes an empty string in declared_build_gates_not_run_here,
+            // where a reader counts entries to see what did not run, and an
+            // accidental empty from a build system inflates that count with a
+            // gate that has no name.
+            ("build_gates", &mut profile.build_gates),
         ] {
             for entry in entries.iter_mut() {
                 let trimmed = entry.trim();

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -10168,10 +10168,10 @@ async fn naming_a_profile_does_not_turn_off_the_runtime_error_checks() {
     );
 
     // A load without RTE says so in incomplete[], whichever of the three
-    // decided it. check resolves rte before reload_project sees it, and the
-    // gap list used to be handed the caller's unresolved value, so naming a
-    // profile that turns RTE off produced a load with no runtime-error
-    // obligations and no RTE_DISABLED gap to say so.
+    // decided it. check resolves rte before reload_project sees it, and the gap
+    // list used to be handed the caller's unresolved value, so naming a profile
+    // that turns RTE off produced a load with no runtime-error obligations and
+    // no RTE_DISABLED gap to say so.
     let gap_codes = |args: serde_json::Value| {
         let client = &client;
         async move {

--- a/tests/unit/check-gaps.rs
+++ b/tests/unit/check-gaps.rs
@@ -688,6 +688,53 @@ fn an_assumed_property_with_a_goal_reports_on_both_channels() {
 /// "nothing wrong". An axiom leaves every goal valid, so neither the alarm nor
 /// the goal path offers a call, and the old wording read as all clear next to
 /// a verdict of incomplete naming that axiom.
+// The gap names the half of the check it is about. run_wp generates WP's own
+// RTE guards for every main-instance run, so a load with rte off still gets
+// runtime-error goals; EVA ran before them and its alarms do not cover them.
+// Saying both were excluded told a caller to discard a WP verdict that is
+// sound, and it was only ever true while the kernel's -rte at load was the
+// single source of these annotations.
+#[test]
+fn the_rte_gap_says_which_half_of_the_check_it_is_about() {
+    let gaps = |wp: serde_json::Value, wanted| {
+        check_incomplete_items(
+            Some(false),
+            &json!({"status": "success"}),
+            &json!({"status": "success"}),
+            &json!({"status": "success"}),
+            &wp,
+            &json!([]),
+            wanted,
+        )
+        .into_iter()
+        .find(|item| item["code"] == "RTE_DISABLED")
+        .map(|item| item["reason"].as_str().unwrap_or_default().to_string())
+        .expect("a load with rte off always leaves an RTE gap")
+    };
+
+    let guarded = gaps(
+        json!({"status": "success", "effective_wp_config": {"rte": true}}),
+        WantedAnalyses::BOTH,
+    );
+    assert!(guarded.contains("EVA's alarms exclude"), "{guarded}");
+    assert!(guarded.contains("goals do cover them"), "{guarded}");
+
+    // WP not asked for, so nothing generated the guards and the wider reading
+    // is the true one.
+    let unguarded = gaps(
+        json!({"status": "success", "effective_wp_config": {"rte": true}}),
+        WantedAnalyses { eva: true, wp: false },
+    );
+    assert!(unguarded.contains("absence of alarms/goals"), "{unguarded}");
+
+    // WP ran but reported no RTE obligations, which is the same reading.
+    let no_guards = gaps(
+        json!({"status": "success", "effective_wp_config": {"rte": false}}),
+        WantedAnalyses::BOTH,
+    );
+    assert!(no_guards.contains("absence of alarms/goals"), "{no_guards}");
+}
+
 #[test]
 fn the_fallback_recommendation_names_what_is_blocking() {
     assert_eq!(

--- a/tests/unit/repo-guards.rs
+++ b/tests/unit/repo-guards.rs
@@ -330,6 +330,11 @@ fn no_em_dash_in_a_rust_comment() {
         source_files(&root.join(dir), "rs", &mut sources);
     }
 
+    // Plus the build script, which is Rust and is in neither directory, so a
+    // list of directories exempted it by construction. Cargo requires it at
+    // this path under this name, so naming it beats walking for it.
+    sources.push(root.join("build.rs"));
+
     let mut offenders = Vec::new();
     for path in &sources {
         let text = std::fs::read_to_string(path)
@@ -394,7 +399,11 @@ fn no_function_in_src_runs_past_the_length_ceiling() {
 
     let mut offenders = Vec::new();
     for path in files {
-        let Ok(text) = std::fs::read_to_string(&path) else { continue };
+        // Panics rather than skipping, like source_files above and for its
+        // reason: a reader inside a file this guard could not open would escape
+        // the check with nothing said, which is the quiet green this whole file
+        // exists to refuse.
+        let text = read_source(&path);
         let lines: Vec<&str> = text.lines().collect();
         for (start, line) in lines.iter().enumerate() {
             let Some(name) = function_name(line) else { continue };
@@ -625,6 +634,20 @@ fn closes_at(line: &str, close: &str) -> bool {
     let Some(rest) = line.strip_prefix(close) else { return false };
     let rest = rest.trim();
     rest.is_empty() || rest.starts_with("//")
+}
+
+/// One source file, or a panic naming it.
+///
+/// The same argument source_files makes for panicking on a directory it cannot
+/// read: every caller is a guard, and a guard that quietly skips the file it
+/// could not open reports on the part of the tree it happened to reach.
+///
+/// Eight other reads in this file still use "else { continue }" or
+/// unwrap_or_default. They have the same hole and are not this change's to
+/// close.
+fn read_source(path: &std::path::Path) -> String {
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", path.display()))
 }
 
 /// Walk every file whose extension is the one asked for, under a directory.
@@ -2172,4 +2195,315 @@ fn jobs_running_repo_scripts_check_out_the_repo() {
         "these jobs run a script out of the tree without checking it out first, \
          so the step fails with no such file: {offenders:?}"
     );
+}
+
+/// Every reader of a whole ProjectLoadOptions destructures it exhaustively.
+///
+/// The load identity is the server's central claim: two loads that differ in
+/// any field are different programs, and the functions that read one have to
+/// agree on that or the claim is void. Forgetting a field is silent and fails
+/// open in every direction. cpp_extra_args forgetting one means the flag never
+/// reaches Frama-C at all; frama_c_command_line forgetting one means the same;
+/// profile_matches_loaded_project forgetting one accepts a load the profile
+/// does not describe. None of them reports anything when it happens.
+///
+/// project_load_identity is the exception and is deliberately left out: it
+/// serializes the struct rather than reading fields, which is the stronger
+/// guarantee, so nobody should "fix" it into a destructure to satisfy this.
+///
+/// Exhaustive destructuring turns each of those into a compile error, and this
+/// guard is what stops the next reader appearing without one. It checks the
+/// shape rather than the field list, so adding a field needs no edit here.
+///
+/// Field access is the tell: a function that reads "options.machdep" is
+/// deciding, per field, what to do with it, which is exactly the decision that
+/// goes stale. One that destructures has already been made to see every field,
+/// unless it wrote ".." in the pattern, which is why that is rejected too: a
+/// rest pattern is exactly the silence this guard exists to refuse, wearing the
+/// shape it asks for.
+#[test]
+fn every_reader_of_the_whole_load_options_destructures_it() {
+    let mut files = Vec::new();
+    source_files(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+        "rs",
+        &mut files,
+    );
+
+    let mut offenders = Vec::new();
+    for path in files {
+        let Ok(text) = std::fs::read_to_string(&path) else { continue };
+        let lines: Vec<&str> = text.lines().collect();
+
+        for (number, line) in lines.iter().enumerate() {
+            let Some(parameter) = load_options_parameter_name(line) else {
+                continue;
+            };
+
+            // The window starts at the "fn" line rather than at the parameter,
+            // because a multi-line signature puts the parameter at the same
+            // indentation as the body and a window measured from there closes
+            // on the very next line of the signature.
+            let Some(signature) = (0..=number)
+                .rev()
+                .find(|at| function_name(lines[*at]).is_some())
+            else {
+                continue;
+            };
+
+            let body = function_body(&lines[signature..]);
+
+            if reads_load_options_field_by_field(&body, &parameter) {
+                offenders.push(format!(
+                    "{}:{} reads ProjectLoadOptions field by field without \
+                     destructuring it, so a field added later is silently ignored here",
+                    path.display(),
+                    number + 1
+                ));
+            }
+        }
+    }
+
+    assert!(offenders.is_empty(), "{offenders:#?}");
+}
+
+/// The guard above is a string heuristic, so it needs its own counterexamples.
+///
+/// A structural guard that cannot fail is decoration, and this one decides by
+/// reading source text rather than by asking the compiler. If its shape
+/// matching ever stops recognising a field read, it goes quietly green and the
+/// property it protects is gone with it. So every part that decides gets a
+/// fixture: the predicate, the signature filter, and the body window, which
+/// were the two the first version of this test left unexercised while they
+/// were the fragile ones.
+#[test]
+fn the_destructuring_guard_can_tell_the_shapes_apart() {
+    // The shape the guard exists to catch.
+    let field_by_field = "\
+fn build(options: &ProjectLoadOptions) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(machdep) = &options.machdep {
+        out.push(machdep.clone());
+    }
+    out
+}";
+    // The shape it must accept.
+    let destructured = "\
+fn build(options: &ProjectLoadOptions) -> Vec<String> {
+    let ProjectLoadOptions { machdep, compilation_database, include_paths: _ } = options;
+    let mut out = Vec::new();
+    if let Some(machdep) = machdep {
+        out.push(machdep.clone());
+    }
+    out
+}";
+
+    // A rest pattern is not exhaustive. It is the silence the guard exists to
+    // refuse, wearing the shape the guard asks for, and it passed until a
+    // reviewer read the fixture rather than the rule.
+    let rest_pattern = "\
+fn build(options: &ProjectLoadOptions) -> Vec<String> {
+    let ProjectLoadOptions { machdep, .. } = options;
+    match machdep {
+        Some(machdep) => vec![machdep.clone()],
+        None => Vec::new(),
+    }
+}";
+
+    // A function that forwards the whole struct and reads nothing off it makes
+    // no per-field decision, so it has nothing to go stale and is not asked to
+    // destructure. Both spellings: passing it on, and calling a method on it,
+    // which a bare "options." read as a field access.
+    let forwards = "\
+fn build(options: &ProjectLoadOptions) -> Option<String> {
+    cpp_extra_args(options)
+}";
+    let forwards_by_method = "\
+fn build(options: &ProjectLoadOptions) -> ProjectLoadOptions {
+    options.clone()
+}";
+
+    // Through function_body, which is the window the guard actually uses. The
+    // fixtures used to be handed to the predicate directly, so the two fragile
+    // parts, the window and the signature scan, were the two nothing exercised,
+    // and the window was closing before the body began.
+    let judge = |source: &str| {
+        let lines: Vec<&str> = source.lines().collect();
+        reads_load_options_field_by_field(&function_body(&lines), "options")
+    };
+
+    assert!(
+        judge(field_by_field),
+        "the guard no longer recognises a field read, so it protects nothing"
+    );
+    assert!(
+        !judge(destructured),
+        "the guard rejects the shape it is asking for"
+    );
+    assert!(
+        judge(rest_pattern),
+        "a .. pattern is not exhaustive and must not satisfy the guard, whether or not \
+         the body goes on to read a field through the parameter"
+    );
+    for (source, shape) in [(forwards, "passing it on"), (forwards_by_method, "a method call")] {
+        assert!(
+            !judge(source),
+            "a forwarder makes no per-field decision and has nothing to destructure ({shape})"
+        );
+    }
+
+    // The signature filter takes the parameter's name from the signature rather
+    // than assuming it. Assuming it is what made both readers this guard was
+    // written for invisible to it, since they are spelled project_options.
+    assert_eq!(
+        load_options_parameter_name("fn build(project_options: &ProjectLoadOptions) -> X {"),
+        Some("project_options".to_string())
+    );
+    assert_eq!(
+        load_options_parameter_name("    load: &super::ProjectLoadOptions,"),
+        Some("load".to_string())
+    );
+    assert_eq!(load_options_parameter_name("struct X { inner: ProjectLoadOptions }"), None);
+
+    // And a field read must be attributed to the parameter that names it: a
+    // body mentioning some other struct's field is not this reader's problem.
+    let lines: Vec<&str> = field_by_field.lines().collect();
+    assert!(!reads_load_options_field_by_field(&function_body(&lines), "cfg"));
+}
+
+/// The predicate the guard applies to one function body.
+///
+/// One definition, used by the guard and by the counterexamples above. Written
+/// twice it would be the guard's own failure mode: the copy the test exercises
+/// drifting from the copy that decides.
+fn reads_load_options_field_by_field(body: &str, parameter: &str) -> bool {
+    let patterns: Vec<&str> = ["let ProjectLoadOptions {", "let super::ProjectLoadOptions {"]
+        .iter()
+        .filter_map(|opener| body.find(opener).map(|at| &body[at + opener.len()..]))
+        .map(|rest| &rest[..rest.find('}').unwrap_or(rest.len())])
+        .collect();
+
+    // Neither destructuring nor reading a field is a function that forwards the
+    // whole struct somewhere else, such as the cpp_extra_args caller. It makes
+    // no per-field decision, so it has nothing to go stale.
+    if patterns.is_empty() {
+        return reads_a_field_of(body, parameter);
+    }
+
+    // Exhaustive means no rest pattern, so this asks about the pattern itself
+    // rather than about the presence of the keyword. A "{ machdep, .. }" wears
+    // the shape the guard asks for and ignores every field added after it.
+    patterns.iter().any(|pattern| pattern.contains(".."))
+}
+
+/// Whether a body reads a field off this parameter, rather than calling a
+/// method on it.
+///
+/// "options." alone cannot tell the two apart, so a forwarder written as
+/// "options.clone()" was reported as reading fields one at a time, and the
+/// guard would have failed the build with a finding about a function that
+/// makes no per-field decision at all. A call has an opening parenthesis after
+/// the name; a field read does not.
+fn reads_a_field_of(body: &str, parameter: &str) -> bool {
+    let needle = format!("{parameter}.");
+    body.match_indices(&needle).any(|(at, _)| {
+        let rest = &body[at + needle.len()..];
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        !name.is_empty() && !rest[name.len()..].starts_with('(')
+    })
+}
+
+/// One function, from its signature to its closing brace.
+///
+/// Braces rather than indentation, and neither was the first answer. Stopping
+/// at a column-zero brace only ever worked for a free function, since a method
+/// inside an impl closes with an indented one and the window ran to the end of
+/// the impl. Stopping at the signature's own indentation was worse: the closing
+/// paren of a multi-line signature sits at exactly that column, so the window
+/// closed before the body began and the guard silently checked nothing.
+///
+/// A brace inside a string literal would throw the count off. The window would
+/// run long, which loses a finding rather than inventing one, and telling the
+/// two apart needs a lexer.
+fn function_body(lines: &[&str]) -> String {
+    let mut depth = 0usize;
+    let mut body = Vec::new();
+    for line in lines {
+        body.push(*line);
+        depth += line.matches('{').count();
+        depth = depth.saturating_sub(line.matches('}').count());
+        if depth == 0 && body.len() > 1 && line.contains('}') {
+            break;
+        }
+    }
+    body.join("\n")
+}
+
+/// The parameter a signature line binds a whole ProjectLoadOptions to.
+///
+/// Read from the line rather than assumed, because the name is a choice the
+/// author makes and nothing in this repository constrains it. An earlier
+/// version required "options" or "opts", so "fn f(load: &ProjectLoadOptions)"
+/// was invisible to the guard, and so were both readers it was written for,
+/// which spell it project_options.
+///
+/// This is also the whole signature filter. A line that binds one field by
+/// value does not name the type, so nothing further has to exclude it.
+fn load_options_parameter_name(line: &str) -> Option<String> {
+    let at = line.find(": &ProjectLoadOptions")
+        .or_else(|| line.find(": &super::ProjectLoadOptions"))?;
+    let name: String = line[..at]
+        .chars()
+        .rev()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    (!name.is_empty()).then(|| name.chars().rev().collect())
+}
+
+/// The running binary names the commit it was built from.
+///
+/// `version` reads 0.1.0 and always has, so it cannot distinguish an installed
+/// binary from the source beside it. `build_commit` is what closes that, and
+/// it comes from build.rs through an environment variable: delete the build
+/// script, or rename the variable it sets, and this stops compiling rather than
+/// quietly reporting a value nobody set.
+///
+/// The value itself is not asserted. A tarball build has no git and honestly
+/// reports "unknown"; what must hold is that the field exists, is non-empty,
+/// and is one of the two shapes a reader is told to expect. A git that cannot
+/// answer whether the tree is clean reports "-dirty" rather than a third
+/// shape, because that is what a reader has to do with either.
+#[test]
+fn the_binary_reports_the_commit_it_was_built_from() {
+    let stamp = env!("BUILD_COMMIT");
+    assert!(!stamp.is_empty(), "build.rs set an empty BUILD_COMMIT");
+
+    // The full object id, because the length git abbreviates to grows with the
+    // object database and a stamp that changes without the commit changing is
+    // not an identity.
+    let commit = stamp.trim_end_matches("-dirty");
+    let looks_like_a_commit = commit.len() == 40 && commit.chars().all(|c| c.is_ascii_hexdigit());
+    assert!(
+        stamp == "unknown" || looks_like_a_commit,
+        "BUILD_COMMIT {stamp:?} is neither a commit nor the documented \"unknown\""
+    );
+
+    // And a reader is told where to find it, and what every shape of it means.
+    let readme = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md"),
+    )
+    .expect("README.md");
+    assert!(
+        readme.contains("build_commit"),
+        "build_commit is reported but not documented, so nobody knows to compare it"
+    );
+    for shape in ["-dirty", "`unknown`"] {
+        assert!(
+            readme.contains(shape),
+            "build_commit can read {shape} and README does not say what that means"
+        );
+    }
 }

--- a/tests/unit/server.rs
+++ b/tests/unit/server.rs
@@ -1558,6 +1558,7 @@ chmod +x "$out.e-acsl"
             "{flag} did not carry the preprocessor flags"
         );
     }
+
     // -nostdinc is the one flag that goes to the analyzer and not to the
     // compiler behind it. Frama-C's modeled libc exists to be analyzed:
     // dropping the real system headers from the gcc that builds the

--- a/tests/unit/state.rs
+++ b/tests/unit/state.rs
@@ -1736,8 +1736,8 @@ fn a_string_that_is_not_json_is_refused_at_the_boundary() {
     assert!(err.contains("not valid JSON"), "{err}");
 }
 
-// The old message said only "must be an object", which gave a caller who sent
-// a string no way to tell that from a malformed object.
+// The old message said only "must be an object", which gave a caller who sent a
+// string no way to tell that from a malformed object.
 #[test]
 fn a_wrong_type_names_what_arrived() {
     let err = parse_verification_profiles(&json!([])).unwrap_err();
@@ -1786,8 +1786,9 @@ fn a_profile_silent_on_rte_or_nostdinc_cannot_check_a_receipt() {
     for (rte, nostdinc) in [(None, Some(false)), (Some(false), None), (None, None)] {
         let err = profile_evidence_error("t", &profile(rte, nostdinc), "f", Some(&receipt))
             .unwrap_or_else(|| panic!("accepted a profile silent on one of them"));
-        // Names both, because the guard fires when either is unset and
-        // "rte or nostdinc" reads as though only one of them were missing.
+
+        // Names both, because the guard fires when either is unset and "rte or
+        // nostdinc" reads as though only one of them were missing.
         assert!(err.contains("must state both rte and nostdinc"), "{err}");
     }
 
@@ -1799,4 +1800,273 @@ fn a_profile_silent_on_rte_or_nostdinc_cannot_check_a_receipt() {
         err.as_deref().is_none_or(|e| !e.contains("rte or nostdinc")),
         "{err:?}"
     );
+}
+
+// A build system's floor on obligations generated is the only check that
+// catches a proof passing by proving less, and nothing else in a profile can
+// express it. Absent means the target has no floor, not a floor of zero.
+#[test]
+fn a_profile_carries_the_targets_goal_floor_and_its_unrun_gates() {
+    let profile: crate::state::VerificationProfile = serde_json::from_value(json!({
+        "functions": ["f"],
+        "sources": ["a.c"],
+        "model": "typed",
+        "provers": ["alt-ergo"],
+        "timeout_seconds": 30,
+        "rte": true,
+        "nostdinc": true,
+        "min_goals": 17,
+        "build_gates": ["check-acsl-coverage.py", "check-char-signedness.py"]
+    }))
+    .unwrap();
+    assert_eq!(profile.min_goals, Some(17));
+    assert_eq!(profile.build_gates.len(), 2);
+
+    // Both optional: a project without either still registers.
+    let bare: crate::state::VerificationProfile = serde_json::from_value(json!({
+        "functions": ["f"],
+        "sources": ["a.c"]
+    }))
+    .unwrap();
+    assert_eq!(bare.min_goals, None);
+    assert!(bare.build_gates.is_empty());
+}
+
+// The case the floor exists for: a run that discharges everything it generated
+// while generating almost nothing. Every other check on that path passes it.
+#[test]
+fn a_run_that_generated_too_few_obligations_is_not_the_targets_evidence() {
+    use frama_c_mcp::mcp::server::analysis::goal_floor_shortfall;
+
+    let target = vec!["gva".to_string()];
+    let goals = |n: usize| -> Vec<serde_json::Value> {
+        (0..n).map(|i| json!({"fct": "gva", "name": format!("g{i}")})).collect()
+    };
+
+    let err = goal_floor_shortfall("t", Some(69), &goals(0), &target)
+        .expect("0 of 0 must be refused");
+    assert!(err.contains("at least 69"), "{err}");
+    assert!(err.contains("generated 0"), "{err}");
+
+    // The refusal says what already happened, because it lands after the proof
+    // and the goals are still in Frama-C's table.
+    assert!(err.contains("WP did run"), "{err}");
+
+    // At the floor and above it are both the target's evidence.
+    assert!(goal_floor_shortfall("t", Some(69), &goals(69), &target).is_none());
+    assert!(goal_floor_shortfall("t", Some(69), &goals(70), &target).is_none());
+    assert!(goal_floor_shortfall("t", Some(69), &goals(68), &target).is_some());
+
+    // No floor is not a floor of zero: a target that declares none is unchecked
+    // here rather than trivially passing.
+    assert!(goal_floor_shortfall("t", None, &goals(0), &target).is_none());
+}
+
+// fetchGoals returns the whole table, so a run_wp on one function leaves its
+// goals sitting there for the next call. Counting them would let an unrelated
+// function clear a gutted target's floor, which is the one thing the floor
+// exists to catch.
+#[test]
+fn another_functions_leftover_goals_do_not_clear_this_targets_floor() {
+    use frama_c_mcp::mcp::server::analysis::{goal_floor_shortfall, goals_owned_by};
+
+    let table = vec![
+        json!({"fct": "proved_earlier", "name": "a"}),
+        json!({"fct": "proved_earlier", "name": "b"}),
+        json!({"fct": "proved_earlier", "name": "c"}),
+        json!({"fct": "gva", "name": "d"}),
+    ];
+    let target = vec!["gva".to_string()];
+
+    assert_eq!(goals_owned_by(&table, &target), 1);
+    let err = goal_floor_shortfall("t", Some(3), &table, &target)
+        .expect("three goals belonging to another function must not clear this floor");
+    assert!(err.contains("generated 1"), "{err}");
+
+    // A goal owning no name does not count. The table is global, so an entry an
+    // earlier run left unowned would otherwise count once for every profiled
+    // target afterwards and could carry an emptied one over its floor, which is
+    // the case the floor exists for.
+    let unowned = vec![json!({"name": "lemma"}), json!({"fct": "gva", "name": "d"})];
+    assert_eq!(goals_owned_by(&unowned, &target), 1);
+
+    // A reallocated declaration marker is not a name either, so it cannot be
+    // compared against one and cannot be attributed to this target.
+    let marked = vec![json!({"scope": "#F24", "name": "x"})];
+    assert_eq!(goals_owned_by(&marked, &target), 0);
+
+    // Every function the call named counts, not just the first.
+    let two = vec![json!({"fct": "a", "name": "x"}), json!({"fct": "b", "name": "y"})];
+    assert_eq!(goals_owned_by(&two, &["a".to_string(), "b".to_string()]), 2);
+    assert_eq!(goals_owned_by(&two, &["a".to_string()]), 1);
+}
+
+// run_wp is not the only door. store_function_conclusion takes a receipt from
+// the caller, so a run made without the profile over a gutted target could be
+// stored under the profile's name and the floor would never have run. The
+// conclusion is durable and names the target, which makes this the worse miss.
+#[test]
+fn a_stored_receipt_below_the_targets_goal_floor_is_not_its_evidence() {
+    use frama_c_mcp::mcp::server::receipt::project_load_identity;
+
+    let profile = crate::state::VerificationProfile {
+        functions: vec!["f".into()],
+        sources: vec!["a.c".into()],
+        model: Some("Typed".into()),
+        provers: vec!["alt-ergo".into()],
+        timeout_seconds: Some(10),
+        rte: Some(true),
+        nostdinc: Some(true),
+        min_goals: Some(4),
+        ..Default::default()
+    };
+    let load = project_load_identity(&frama_c_mcp::mcp::server::ProjectLoadOptions {
+        rte: true,
+        nostdinc: true,
+        ..Default::default()
+    });
+    let receipt = |goals: usize| {
+        json!({
+            "wp": {"functions": ["f"], "model": "Typed"},
+            "subject": {"files": [{"path": "a.c", "sha256": "h"}], "project_load": load},
+            "goals": (0..goals).map(|i| json!({"stable_goal_id": format!("sg_{i}"), "status": "valid"}))
+                .collect::<Vec<_>>()
+        })
+    };
+
+    let err = profile_evidence_error("t", &profile, "f", Some(&receipt(1)))
+        .expect("a receipt recording one obligation cannot be a four-obligation target's evidence");
+    assert!(err.contains("at least 4"), "{err}");
+    assert!(err.contains("records 1"), "{err}");
+
+    // A receipt with no goals array at all is the same case, not an exemption.
+    let empty = json!({
+        "wp": {"functions": ["f"], "model": "Typed"},
+        "subject": {"files": [{"path": "a.c", "sha256": "h"}], "project_load": load}
+    });
+    assert!(profile_evidence_error("t", &profile, "f", Some(&empty)).is_some());
+
+    // At the floor it passes, and a profile declaring no floor never asks.
+    assert_eq!(profile_evidence_error("t", &profile, "f", Some(&receipt(4))), None);
+    let no_floor = crate::state::VerificationProfile { min_goals: None, ..profile.clone() };
+    assert_eq!(profile_evidence_error("t", &no_floor, "f", Some(&receipt(0))), None);
+
+    // And a conclusion stored before any proof exists is still nameable: the
+    // floor is a question about a receipt, not about the target.
+    assert_eq!(profile_evidence_error("t", &profile, "f", None), None);
+}
+
+// A receipt need not be about the whole target. check {function: "a"} scopes
+// its goals to a, so an honest receipt for one function of a multi-function
+// profile records a fraction of the floor, and asking the floor of it refused
+// evidence that was correct. proof_coverage re-runs this check over every
+// stored conclusion, so the refusal also reached conclusions stored earlier.
+#[test]
+fn the_goal_floor_is_asked_only_of_a_receipt_covering_the_whole_target() {
+    use frama_c_mcp::mcp::server::receipt::project_load_identity;
+
+    let profile = crate::state::VerificationProfile {
+        functions: vec!["a".into(), "b".into(), "c".into()],
+        sources: vec!["a.c".into()],
+        model: Some("Typed".into()),
+        provers: vec!["alt-ergo".into()],
+        timeout_seconds: Some(10),
+        rte: Some(true),
+        nostdinc: Some(true),
+        min_goals: Some(60),
+        ..Default::default()
+    };
+    let load = project_load_identity(&frama_c_mcp::mcp::server::ProjectLoadOptions {
+        rte: true,
+        nostdinc: true,
+        ..Default::default()
+    });
+    // Goals carry "fct", which is what a receipt this build writes looks like.
+    // Without it every assertion below would exercise the compatibility branch
+    // for older receipts instead of the rule this test is named for.
+    let receipt = |functions: serde_json::Value, goals: usize, owner: fn(usize) -> &'static str| {
+        json!({
+            "wp": {"functions": functions, "model": "Typed"},
+            "subject": {"files": [{"path": "a.c", "sha256": "h"}], "project_load": load},
+            "goals": (0..goals).map(|i| {
+                json!({"stable_goal_id": format!("sg_{i}"), "fct": owner(i)})
+            }).collect::<Vec<_>>()
+        })
+    };
+    let all_a = |_| "a";
+
+    // One function of three, honestly proved, well under the target's floor.
+    assert_eq!(
+        profile_evidence_error("t", &profile, "a", Some(&receipt(json!(["a"]), 12, all_a))),
+        None,
+        "a receipt scoped to one function was refused for not carrying the whole target's floor"
+    );
+
+    // The whole target, and short: this is the case the floor exists for.
+    let short = receipt(json!(["a", "b", "c"]), 3, all_a);
+    let err = profile_evidence_error("t", &profile, "a", Some(&short))
+        .expect("a receipt covering the whole target must still meet its floor");
+    assert!(err.contains("at least 60"), "{err}");
+
+    // Padding with another function's goals does not clear it. A whole-project
+    // run's receipt legitimately carries every function's goals, so counting
+    // the array let an emptied target pass on its neighbours' obligations,
+    // which is looser than the rule run_wp applies to the same profile.
+    let padded = receipt(json!(["a", "b", "c"]), 80, |i| if i < 4 { "a" } else { "elsewhere" });
+    let err = profile_evidence_error("t", &profile, "a", Some(&padded))
+        .expect("goals owned by another function must not count toward this target's floor");
+    assert!(err.contains("records 4"), "{err}");
+
+    // Owned goals do clear it, counted the way run_wp counts them.
+    let owned = receipt(json!(["a", "b", "c"]), 60, |i| ["a", "b", "c"][i % 3]);
+    assert_eq!(profile_evidence_error("t", &profile, "a", Some(&owned)), None);
+
+    // A receipt from before "fct" existed keeps the older, looser count, so
+    // adding a floor to a profile does not invalidate what is already stored.
+    let older = json!({
+        "wp": {"functions": ["a", "b", "c"], "model": "Typed"},
+        "subject": {"files": [{"path": "a.c", "sha256": "h"}], "project_load": load},
+        "goals": (0..60).map(|i| json!({"stable_goal_id": format!("sg_{i}")}))
+            .collect::<Vec<_>>()
+    });
+    assert_eq!(profile_evidence_error("t", &profile, "a", Some(&older)), None);
+
+    // The whole target, and sufficient.
+    assert_eq!(
+        profile_evidence_error("t", &profile, "a", Some(&receipt(json!(["a", "b", "c"]), 60, all_a))),
+        None
+    );
+}
+
+// None already says the target declares no floor, so zero would be a field that
+// reads as a floor and checks nothing.
+#[test]
+fn a_zero_goal_floor_is_refused_rather_than_accepted_as_no_floor() {
+    let with_zero = json!({"t": {"functions": ["f"], "sources": ["a.c"], "min_goals": 0}});
+    let err = parse_verification_profiles(&with_zero).unwrap_err();
+    assert!(err.contains("checks nothing"), "{err}");
+
+    // Omitted is the way to say a target has none.
+    let omitted = json!({"t": {"functions": ["f"], "sources": ["a.c"]}});
+    let p = parse_verification_profiles(&omitted).expect("no floor is a valid profile");
+    assert_eq!(p["t"].min_goals, None);
+
+    // And one is kept as written.
+    let stated = json!({"t": {"functions": ["f"], "sources": ["a.c"], "min_goals": 1}});
+    let p = parse_verification_profiles(&stated).unwrap();
+    assert_eq!(p["t"].min_goals, Some(1));
+}
+
+// A gate name is printed back rather than matched, so padding is harmless and a
+// blank is not: it lands in declared_build_gates_not_run_here as an entry with
+// no name, in a list a reader counts.
+#[test]
+fn a_blank_build_gate_is_refused_and_a_padded_one_is_trimmed() {
+    let blank = json!({"t": {"functions": ["f"], "sources": ["a.c"], "build_gates": ["  "]}});
+    let err = parse_verification_profiles(&blank).unwrap_err();
+    assert!(err.contains("build_gates"), "{err}");
+
+    let padded = json!({"t": {"functions": ["f"], "sources": ["a.c"], "build_gates": [" check.py "]}});
+    let p = parse_verification_profiles(&padded).unwrap();
+    assert_eq!(p["t"].build_gates, vec!["check.py".to_string()]);
 }

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -164,6 +164,41 @@ fn classify_wp_failure_timeout() {
 }
 
 #[test]
+fn cached_failure_keeps_its_verdict_category() {
+    for (goal, category, failure_kind) in [
+        (
+            json!({"name": "division_by_zero", "goal_kind": "rte_division", "normalized_status": "unknown", "from_cache": true}),
+            "rte",
+            "proof_obligation",
+        ),
+        (
+            json!({"name": "Post", "normalized_status": "failed", "from_cache": true}),
+            "internal_error",
+            "frama_c_internal",
+        ),
+    ] {
+        let classification = classify_wp_failure_from_goal(&goal, Some("f"));
+        assert_eq!(classification["category"], category, "{classification:?}");
+        assert_eq!(classification["failure_kind"], failure_kind, "{classification:?}");
+        assert_eq!(classification["confidence"], "low", "{classification:?}");
+
+        // Scored down and also said. A payload that reads "low" without naming
+        // the cache has told the reader the confidence and withheld what
+        // explains it, and the evidence entry beside it is not prose. Said in
+        // wp_timeout_triage, which is the per-goal field a caller already reads
+        // for why a verdict is thin. Not appended to the classification's own
+        // reason: that is sent per goal, and a constant repeated per goal is
+        // what the stdio payload budget exists to catch.
+        let triage = &classification["wp_timeout_triage"];
+        assert_eq!(triage["confidence"], "low", "{triage:?}");
+        assert!(
+            triage["reason"].as_str().unwrap_or_default().contains("came back from WP's cache"),
+            "a replayed goal says nothing about the cache: {triage:?}"
+        );
+    }
+}
+
+#[test]
 fn classify_wp_failure_includes_proofread_report_shape() {
     let classification = classify_wp_failure_from_goal(
         &json!({
@@ -940,6 +975,44 @@ fn an_absent_eva_config_says_which_absence_it_is() {
     let ran = body(json!({"precision": 2, "slevel": 64}));
     assert_eq!(ran["eva"]["precision"], 2);
     assert_ne!(ran["sha256"], not_requested["sha256"]);
+}
+
+// The floor at the conclusion door counts goals owned by the target's
+// functions, which only works because the receipt records the owner. Nothing
+// asserted that the writer emits it: delete the field from proof_receipt_goals
+// and profile_evidence_error silently falls back to counting the whole array,
+// which is the loose rule that let an emptied target pass on its neighbours'
+// obligations, with every gate still green.
+#[test]
+fn a_receipt_goal_records_the_function_it_belongs_to() {
+    use frama_c_mcp::mcp::server::receipt::receipt_goals_record_owner;
+
+    let goals = proof_receipt_goals(
+        &[
+            json!({"stable_goal_id": "sg_a", "normalized_status": "valid", "fct": "swap"}),
+            json!({"stable_goal_id": "sg_b", "normalized_status": "valid"}),
+        ],
+        None,
+        &HashMap::new(),
+    );
+    let owner_of = |id: &str| {
+        goals
+            .iter()
+            .find(|goal| goal["stable_goal_id"] == id)
+            .unwrap_or_else(|| panic!("{id} is in the receipt"))["fct"]
+            .clone()
+    };
+    assert_eq!(owner_of("sg_a"), json!("swap"));
+
+    // Null rather than absent for a goal owning no function, because the key's
+    // presence is what tells a reader this receipt records owners at all.
+    assert_eq!(owner_of("sg_b"), serde_json::Value::Null);
+    assert!(receipt_goals_record_owner(&goals));
+
+    // And a receipt written before the field carries the key nowhere, which is
+    // the shape the fallback exists for.
+    let older = vec![json!({"stable_goal_id": "sg_a", "status": "valid"})];
+    assert!(!receipt_goals_record_owner(&older));
 }
 
 #[test]
@@ -2205,9 +2278,9 @@ fn a_profile_only_labels_its_loaded_project() {
     assert!(!profile_matches_loaded_project(&profile, &["src/target.c".into()], &ProjectLoadOptions::default()));
 }
 
-// A prover budget is wall clock, so on an oversubscribed host every goal
-// grinds to it whatever its difficulty. Reporting that run at high confidence
-// states a verdict about the code that the run cannot support.
+// A prover budget is wall clock, so on an oversubscribed host every goal grinds
+// to it whatever its difficulty. Reporting that run at high confidence states a
+// verdict about the code that the run cannot support.
 #[test]
 fn a_saturated_host_withdraws_the_timeout_verdict() {
     let t = prover_timeout_triage(18, vec![], HostLoad::from_reading(Some(7.6)), None);
@@ -2374,9 +2447,9 @@ fn a_non_finite_reading_never_reads_as_a_quiet_host() {
 
 // The triage goes into the proof receipt's reported block, and that block is
 // hashed. A reading in it would give two runs of the same proof on the same
-// machine different receipt digests, which is the one property a receipt
-// exists to carry. Rounding does not save it, so the payload carries a
-// category and the reading is reported outside the receipt.
+// machine different receipt digests, which is the one property a receipt exists
+// to carry. Rounding does not save it, so the payload carries a category and
+// the reading is reported outside the receipt.
 #[test]
 fn the_timeout_verdict_does_not_move_with_the_load_reading() {
     let quiet = prover_timeout_triage(3, vec![], HostLoad::from_reading(Some(0.11)), None);
@@ -2443,8 +2516,8 @@ fn receipt_load_identity_includes_all_obligation_shaping_options() {
     assert_eq!(identity["nostdinc"], true);
 }
 
-// Without this a load against the real system headers passes for a load
-// against the modeled libc, which is a different program to prove.
+// Without this a load against the real system headers passes for a load against
+// the modeled libc, which is a different program to prove.
 #[test]
 fn a_load_that_kept_the_system_headers_does_not_match_a_target_that_dropped_them() {
     let profile = frama_c_mcp::state::VerificationProfile {
@@ -2540,16 +2613,16 @@ fn a_timeout_under_a_valid_property_still_counts_as_a_timeout() {
     assert_eq!(run_measurement(std::slice::from_ref(&valid)).timed_out, 0);
 }
 
-// A profile that names no system include directories does not match a load
-// that carries some.
+// A profile that names no system include directories does not match a load that
+// carries some.
 //
 // isystem_paths is a Vec, so omission and "explicitly empty" are the same
 // value, and the evidence gate requires rte and nostdinc but not this list.
 // Treating an empty list as "unset" therefore let a profile match a load
-// carrying any -isystem at all, and run_wp would label that run as the
-// target's evidence under a load identity that is not the target's. The three
-// Vec fields beside it have always compared exactly; only the two Option flags
-// can say "unset".
+// carrying any -isystem at all, and run_wp would label that run as the target's
+// evidence under a load identity that is not the target's. The three Vec fields
+// beside it have always compared exactly; only the two Option flags can say
+// "unset".
 #[test]
 fn a_profile_that_names_no_system_includes_does_not_match_a_load_that_has_them() {
     let profile = frama_c_mcp::state::VerificationProfile {
@@ -2574,4 +2647,122 @@ fn a_profile_that_names_no_system_includes_does_not_match_a_load_that_has_them()
         !profile_matches_loaded_project(&profile, &files, &with_isystem),
         "an omitted isystem_paths matched a load that passes one"
     );
+}
+
+// The rule stated in one place used to be contradicted in two: for a replayed
+// timeout, prover_timeout_triage withdrew confidence while
+// wp_timeout_triage_from_goal answered "high, a higher prover timeout may help"
+// about the same goal. A caller reading both got opposite instructions.
+#[test]
+fn every_triage_agrees_a_replayed_goal_was_not_measured_here() {
+    let replayed = json!({
+        "stable_goal_id": "g",
+        "status": "timeout",
+        "normalized_status": "timeout",
+        "from_cache": true
+    });
+
+    let per_goal = wp_timeout_triage_from_goal(&replayed);
+    assert_eq!(per_goal["confidence"], "low");
+
+    // And it must not advise spending more budget on a goal no budget was spent
+    // on, which is what the uncapped branch said.
+    assert_eq!(per_goal["retry_with_higher_prover_timeout"], false);
+
+    let m = run_measurement(std::slice::from_ref(&replayed));
+    assert_eq!(prover_timeout_triage(1, vec![], HostLoad::Load(0.1), Some(&m))["confidence"], "low");
+
+    // A freshly attempted timeout still gets the confident reading from both,
+    // so the cap is about the replay and not about timeouts in general.
+    let fresh = json!({
+        "stable_goal_id": "g",
+        "status": "timeout",
+        "normalized_status": "timeout",
+        "from_cache": false
+    });
+    assert_eq!(wp_timeout_triage_from_goal(&fresh)["confidence"], "high");
+    let m = run_measurement(std::slice::from_ref(&fresh));
+    assert_eq!(prover_timeout_triage(1, vec![], HostLoad::Load(0.1), Some(&m))["confidence"], "high");
+}
+
+// The kernel's RTE generator and WP's own are different analyses over the same
+// code, and only one of them is what a -wp-rte build proves. Measured on
+// elfuse's iov target: -wp-rte alone generates 40 obligations and discharges
+// all of them, while kernel -rte alongside it generates 42 and leaves the two
+// extra pointer_alignment goals open. A load started with kernel -rte is
+// therefore proving a strictly larger set than the target it names.
+//
+// This asserts the command line rather than the goal count, because the goal
+// count needs Frama-C and this is the decision that produces it.
+//
+// On main_frama_c_args, which is the argv that changed. Asserting
+// project_cli_args alone could never fail: it has never emitted -rte, at HEAD
+// or before it, and its own comment says so, so the test would have passed
+// against the code it was written to pin.
+#[test]
+fn a_load_that_proves_runtime_errors_does_not_ask_the_kernel_for_them() {
+    let options = ProjectLoadOptions { rte: true, ..Default::default() };
+    let args = frama_c_mcp::mcp::server::main_frama_c_args(
+        "frama-c",
+        &["a.c".to_string()],
+        &options,
+        std::path::Path::new("/tmp/s.sock"),
+    );
+    assert!(
+        !args.iter().any(|a| a == "-rte"),
+        "kernel -rte generates pointer_alignment assertions that WP's own \
+         generator does not, so a run under it is not the target's evidence: {args:?}"
+    );
+
+    // And the load settings still reach it, so the assertion above is about a
+    // command line that carries them rather than an empty one.
+    let with_machdep = ProjectLoadOptions {
+        rte: true,
+        machdep: Some("gcc_x86_64".to_string()),
+        ..Default::default()
+    };
+    let args = frama_c_mcp::mcp::server::main_frama_c_args(
+        "frama-c",
+        &["a.c".to_string()],
+        &with_machdep,
+        std::path::Path::new("/tmp/s.sock"),
+    );
+    assert!(args.windows(2).any(|w| w == ["-machdep", "gcc_x86_64"]), "{args:?}");
+}
+
+// The advertised model list is what Frama-C documents; this server validates
+// against what it accepts. Caveat is the known gap: -wp-h names it nowhere and
+// the parser takes it, so a project proved under it was told its own model was
+// invalid. Both spellings, because the build system writes whichever it likes
+// and Frama-C does not care.
+#[test]
+fn a_model_frama_c_accepts_is_not_called_invalid() {
+    use frama_c_mcp::mcp::server::{
+        parse_wp_model_support, WpModelSupport, ACCEPTED_BUT_UNDOCUMENTED_BASES,
+    };
+
+    // Both paths, and parameterized over the list rather than naming Caveat
+    // again here. The parsed path is built from help text that omits these by
+    // definition, so it is the one that goes stricter when a second model is
+    // added to only one of the two lists.
+    let parsed = parse_wp_model_support(
+        "  -wp-model  use 'Hoare', 'Typed', 'Bytes', 'Region', 'Eva' with '+nocast' or '+cast'\n         -wp-prover  ...",
+    );
+    for support in [WpModelSupport::fallback(), parsed] {
+        for base in ACCEPTED_BUT_UNDOCUMENTED_BASES {
+            assert!(
+                support.validate(base).is_ok(),
+                "{base} is accepted by frama-c -wp-model and must not be refused here"
+            );
+        }
+        for model in ["typed", "Typed", "Bytes", "bytes", "Typed+nocast"] {
+            assert!(
+                support.validate(model).is_ok(),
+                "{model}: {:?}",
+                support.validate(model)
+            );
+        }
+        // Still a closed set: a name Frama-C would reject is refused here too.
+        assert!(support.validate("NotAModel").is_err());
+    }
 }


### PR DESCRIPTION
A profile says what a target's own build proves. Three things it could not say are what this adds, and the rest of the change is what a review and the gates found wrong with saying them.

min_goals is the floor on obligations the target requires WP to generate. "N of N discharged" is not evidence on its own: an emptied body or a dropped contract discharges 0 of 0, and every other check on the path passes it, so a build system carrying such a floor carries the only check that catches it. A floor of 0 is refused at parse time, because omitting the field already says the target declares none and a present key that checks nothing reads as a floor to whoever sees it.

The count is over the target's own obligations rather than over the goal table. fetchGoals returns everything WP holds, including goals from functions proved earlier in the session, so run_wp on one function followed by a profiled run on another would have let the first function's goals clear the second's floor. That is exactly the emptied body the floor exists to catch, cleared by goals that have nothing to do with the target. check reloads first and never saw it; a direct run_wp in a CEGIS loop is where the stale goals live.

run_wp is not the only door. store_function_conclusion takes a receipt from the caller, so a run made without the profile over a gutted target could be stored under the profile's name with the floor never having run, and the conclusion is durable. profile_evidence_error asks the floor too, but only of a receipt whose wp.functions covers the whole declared set: a receipt from check {function: "a"} is honestly scoped to a, and asking a three-function target's floor of it would refuse correct evidence and, through proof_coverage, retroactively flip conclusions already stored.

build_gates names checks the target's command runs that this server does not, echoed back as declared_build_gates_not_run_here. "Declared" is load-bearing: nothing here can verify the list, so an empty one means none were declared rather than that none exist. It bounds a verdict downward and never upward.

prop and retry_unproved join the settings a profile refuses. A filtered run attempts the obligations the filter selects and leaves the rest, so its goal count and its summary agree with each other while describing a subset. A retry re-proves at double the profile's timeout and the flipped goals replace the reported set, receipt included, while the receipt records the declared timeout. Both are the mislabelling the refusal list exists to prevent, arriving through parameters that do not look like proof settings.

Kernel -rte is gone from the main spawn, and WP's guards are generated unconditionally in its place. The two are different analyses over the same code: the kernel emits pointer_alignment assertions WP's generator does not, so a load started under it proves a strictly larger set than the -wp-rte build it claims to be. Measured on one 3-function target, -wp-rte alone generates 40 obligations and discharges all of them while -rte alongside it generates 42 and leaves the two extra open. Making the guard generation conditional on the load's rte flag moved the hole rather than closing it: with the kernel out of it nothing else generates these, so rte=false produced no runtime-error obligations at all, which two stdio tests had documented as deliberate behaviour, since generating them in place is what lets a caller ask for them without a reload that discards this session's injected annotations.

That decision is now testable. main_frama_c_args is a free function because the test asserting it pinned project_cli_args instead, which has never emitted -rte and says so in its own comment, so it passed against the code it was written to pin. The spawn argv also stopped spelling out the options-derived arguments: they were byte-identical to project_cli_args once the -rte line went, and the copy carried its own exhaustive destructure, which is two assertions that neither copy forgets a field and nothing at all that they agree on what to emit.

A goal whose verdict WP replayed from its cache no longer carries a confident reading. The fact is stated in wp_timeout_triage, which is the per-goal field a caller already reads for why a verdict is thin, rather than appended to the classification's reason: that costs 471 bytes on every classified goal, twice, and for a replayed timeout duplicates a string the same payload already carries. The stdio payload budget caught it.

self_check and context report build_commit. CARGO_PKG_VERSION has read 0.1.0 for the project's life, so an installed binary and a freshly built one describe themselves identically, and a caller comparing behaviour against source cannot tell that the server answering predates the code they are reading. build.rs stamps it, watching the tracked files from git ls-files rather than the directory listing: reading the directory watched 12,483 files and 220 MB, including the .frama-c cache every WP run writes, none of which can move a stamp computed from git, and it cost a full release recompile in the middle of a gate run. Dirtiness comes from git diff rather than diff-index, because GIT_OPTIONAL_LOCKS=0 stops git refreshing a stale index and diff-index then reports every file rewritten with identical bytes as a difference. A copy of these sources vendored elsewhere reports unknown rather than that repository's HEAD: a confident wrong sha is the value a caller compares against.

Every reader of a whole ProjectLoadOptions destructures it exhaustively, so a field added later is a compile error rather than a flag that silently never reaches Frama-C, and a guard in repo-guards stops the next reader appearing without one. The guard needed the same scrutiny it applies: it accepted a ".." rest pattern, which is the silence it exists to refuse wearing the shape it asks for, and its body window closed before the body began, because the closing paren of a multi-line signature sits at the signature's own indentation. It was checking nothing at all. It now windows by brace depth, reads the parameter name off the signature, and its fixtures run through the real window.

Caveat is accepted by Frama-C's -wp-model parser and named nowhere in -wp-h, and model names are compared case-insensitively, because a build system writes whichever spelling it likes and Frama-C does not care. Both paths read one list, and the test covers both: only the fallback was covered, and the parsed path is the one that goes stricter when a model is added to a single list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Profiled runs now refuse to pass on too few, filtered, or retried goals, and the main Frama-C load generates WP's own runtime-error guards instead of kernel `-rte` checks, so evidence matches `-wp-rte`.

**Profile evidence**

- Adds `min_goals`, a required-positive floor counted over the target's own obligations, enforced for direct runs and stored receipts.
- Refuses `prop` and `retry_unproved`; echoes declared `build_gates` as `declared_build_gates_not_run_here`.

**Diagnostics and safeguards**

- Reports a Git-derived `build_commit` in `self_check` and context, or `unknown` for non-Git source trees.
- Marks cache-replayed WP verdicts as `from_cache` and lowers their timeout-triage confidence.
- Makes all `ProjectLoadOptions` readers exhaustive and accepts case-insensitive `Caveat` model names.

<sup>Written for commit 7c467d7b586c435542514e05b249875f66a610b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/frama-c-mcp/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

