### PR TITLE
Report what a proof still assumes and still needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ payload contract and the change rule. The full set:
 | `LEMMA_NOT_PROVED` | WP assumed a lemma everywhere without discharging it |
 | `ASSUMED_VALID` | Recorded valid by external assumption, an `axiom`, not by proof |
 | `ASSUMED_CALLEE_CONTRACT` | A callee's contract was taken on faith, with no finite `assigns` |
+| `INDIRECT_CALL_UNRESOLVED` | A call names no callee, so WP assumed it may reach any function and the goals it leaves open are unprovable rather than slow |
 | `UNCONSTRAINED_ASSIGNS` | The contract lists a location in `assigns` that no postcondition mentions, so proving the function says nothing about the value written there |
 | `RESULT_UNCONSTRAINED` | The contract bounds `\result` to a small range but never ties some of those values to the inputs, so proving it does not pin down what the function returns |
 | `UNPROVED_ASSUMPTION` | An assertion or postcondition WP could not prove, which it still hands to later goals as a hypothesis |

--- a/README.md
+++ b/README.md
@@ -449,8 +449,21 @@ shell-active character (a parenthesized expression, a quoted string) is refused;
 ### `list` and `run_wp`
 
 `list` accepts a `kind` of `files`, `functions`, `globals`, `declarations`,
-`sandboxes`, or `conclusions`. For conclusions, `status` filters the summaries
-and `function` returns one full conclusion.
+`sandboxes`, `conclusions`, or `contract_frontier`.
+
+`list {kind: "contract_frontier"}` is the one to run before anything else on a
+file you have not seen. It answers, in one request, which defined functions are
+reachable from a function that already carries a contract and carry none
+themselves: the contracts a person still has to write. It is not a verdict and
+produces no `incomplete[]` code, because a function two hops down with no
+contract is not a gap in any caller's proof; `ASSUMED_CALLEE_CONTRACT` covers
+the case where a direct callee's contract is vacuous. The payload carries
+`unresolved_call_sites` alongside, since a frontier computed over a call graph
+that dropped the calls through function pointers is a work list that
+under-reports and a short one looks the same as a complete one.
+
+For conclusions, `status` filters the summaries and `function` returns one full
+conclusion.
 
 `run_wp` accepts `smoke: true` together with `provers` to run isolated CLI
 smoke tests.

--- a/README.md
+++ b/README.md
@@ -618,6 +618,8 @@ payload contract and the change rule. The full set:
 | `EVA_NOT_REQUESTED` | `want` excluded EVA, so nothing here excludes the alarms it finds |
 | `WP_NOT_REQUESTED` | `want` excluded WP, so nothing here is a proof |
 | `WP_BACKEND_ANOMALY` | Why3 aborted, so the FAILED goals of this run were never judged by a prover |
+| `WP_MEMORY_MODEL_HYPOTHESIS` | WP's memory model needed separations it assumed rather than proved, so a valid goal is valid only for callers that satisfy them |
+| `WP_MEMORY_MODEL_UNCHECKED` | The separate run that reads WP's memory-model hypotheses did not complete, so whether the proof rests on an unstated separation is unknown |
 | `AST_ASM_CLOBBER` | Frama-C assumed inline assembly has no effects beyond its operands, so the analyzed statement is weaker than the compiled one |
 | `AST_UNKNOWN_ATTRIBUTE` | Frama-C ignored an unknown attribute, so the analyzed declaration differs from the source |
 | `AST_UNCLASSIFIED_WARNING` | Frama-C emitted parse warnings in categories this server has not classified, so their effect on the analyzed program is unknown |

--- a/ast-utils/src/ast_utils_ast.ml
+++ b/ast-utils/src/ast_utils_ast.ml
@@ -1078,6 +1078,176 @@ let direct_callers_of_kf target =
   ) []
   |> List.rev
 
+(* The functions a proof of this program still needs a contract for.
+
+   Seeded from every defined function that already carries a contract, walked
+   down the syntactic call graph, and reporting the defined functions reached
+   that way which carry none. That is the specification frontier of the
+   reviewed artifact: the work list a person has to write, as opposed to
+   ASSUMED_CALLEE_CONTRACT, which is one hop from whatever a check happened to
+   target and answers about one proof rather than about the program.
+
+   Emptiness of the funspec is the test rather than its presence. Frama-C
+   generates a default spec for every function, so "Annotations.has_funspec"
+   answers true for a function nobody ever specified, and seeding from that
+   would put the whole program in the reachable set and report nothing.
+
+   The unresolved call sites travel with it. A frontier computed over a call
+   graph that silently dropped the calls through function pointers is a work
+   list that under-reports, and the caller cannot tell that from a short one. *)
+
+let kf_is_defined kf =
+  try ignore (Kernel_function.get_definition kf); true
+  with Kernel_function.No_Definition -> false
+
+let kf_has_contract kf =
+  let spec = Annotations.funspec kf in
+  not (Cil.is_empty_funspec spec)
+
+let frontier_function_to_json kf callers =
+  `Assoc [
+    ("function", `String (Kernel_function.get_name kf));
+    ("loc", loc_to_json (Kernel_function.get_location kf));
+    ("called_by",
+     `List (List.map (fun caller -> `String (Kernel_function.get_name caller)) callers));
+  ]
+
+let unresolved_site_to_json kf site =
+  match site with
+  | `Assoc fields -> `Assoc (("function", `String (Kernel_function.get_name kf)) :: fields)
+  | other -> other
+
+let get_contract_frontier () : Yojson.Basic.t =
+  let defined = Globals.Functions.fold
+      (fun kf acc -> if kf_is_defined kf then kf :: acc else acc) []
+  in
+
+  (* The kernel's own collections over Kernel_function, rather than two local
+     Make applications of the comparator it already carries. *)
+  let module KfSet = Kernel_function.Set in
+  let module KfMap = Kernel_function.Map in
+
+  (* One AST walk per defined function, and only one. Three consumers below
+     read the call graph: the downward walk, the callers reported beside each
+     frontier entry, and the unresolved sites. Asking the visitor again for
+     each of them made the callers alone cost one walk per (missing, defined)
+     pair, so a thousand-function program with five hundred uncontracted
+     callees ran half a million whole-body visits inside the single request
+     this tool exists to answer in one round trip. *)
+  let call_info =
+    List.fold_left
+      (fun acc kf -> KfMap.add kf (direct_call_info_of_kf kf) acc)
+      KfMap.empty defined
+  in
+  let call_info_of kf =
+    match KfMap.find_opt kf call_info with Some pair -> pair | None -> ([], [])
+  in
+  let callees_of kf = fst (call_info_of kf) in
+  let unresolved_of kf = snd (call_info_of kf) in
+
+  (* Inverted once, in the traversal order the fold visits, so each entry's
+     "called_by" reads the way a per-function query used to answer. A function
+     never lists itself.
+
+     "defined" is already reverse-Globals order and "add" prepends, so folding
+     it directly puts each list in Globals order, which is what a per-function
+     query yields. Folding the reversal and reversing again on every lookup
+     reached the same order by doing the work twice. *)
+  let callers_of =
+    let add acc caller callee =
+      if Kernel_function.equal caller callee then acc
+      else
+        let previous = match KfMap.find_opt callee acc with Some l -> l | None -> [] in
+        if List.exists (Kernel_function.equal caller) previous then acc
+        else KfMap.add callee (caller :: previous) acc
+    in
+    let table =
+      List.fold_left
+        (fun acc caller -> List.fold_left (fun acc callee -> add acc caller callee)
+            acc (callees_of caller))
+        KfMap.empty defined
+    in
+    fun kf -> match KfMap.find_opt kf table with Some l -> l | None -> []
+  in
+
+  (* Worklist from the contracted functions downwards. A function is in the
+     reachable set when a contracted function calls it, directly or through
+     other functions; a contracted function is not itself in it, since the
+     question is what the contracts already written do not cover. *)
+  (* One funspec lookup per defined function. Annotations.funspec materialises
+     the default spec rather than answering from a cache, and this predicate was
+     asked three times for every function: once to seed the queue, once to
+     filter the missing list, once more to count. That is 2n avoidable calls in
+     the request whose whole claim is that it answers in one round trip, and the
+     call graph directly above already went to some trouble to be walked once. *)
+  let contracted =
+    List.fold_left
+      (fun acc kf -> if kf_has_contract kf then KfSet.add kf acc else acc)
+      KfSet.empty defined
+  in
+  let queue = Queue.create () in
+  List.iter (fun kf -> if KfSet.mem kf contracted then Queue.add kf queue) defined;
+  let reachable = ref KfSet.empty in
+
+  (* Every body the walk actually read: the contracted seeds plus everything
+     reached from them. Kept because the unresolved sites below are a statement
+     about this walk, and a function outside it was never looked down. *)
+  let walked = ref KfSet.empty in
+  while not (Queue.is_empty queue) do
+    let caller = Queue.take queue in
+    walked := KfSet.add caller !walked;
+    List.iter
+      (fun callee ->
+         if kf_is_defined callee && not (KfSet.mem callee !reachable) then begin
+           reachable := KfSet.add callee !reachable;
+           Queue.add callee queue
+         end)
+      (callees_of caller)
+  done;
+
+  let missing =
+    List.filter (fun kf -> KfSet.mem kf !reachable && not (KfSet.mem kf contracted)) defined
+  in
+  let missing =
+    List.sort
+      (fun a b ->
+         let file kf = Ast_utils_compat.loc_file (Kernel_function.get_location kf) in
+         let line kf = Ast_utils_compat.loc_line (Kernel_function.get_location kf) in
+         let c = String.compare (file a) (file b) in
+         if c <> 0 then c
+         else
+           let c = Int.compare (line a) (line b) in
+           if c <> 0 then c
+           else String.compare (Kernel_function.get_name a) (Kernel_function.get_name b))
+      missing
+  in
+  let unresolved =
+    List.concat_map
+      (fun kf -> List.map (unresolved_site_to_json kf) (unresolved_of kf))
+      (List.sort
+         (fun a b -> String.compare (Kernel_function.get_name a) (Kernel_function.get_name b))
+         (List.filter (fun kf -> KfSet.mem kf !walked) defined))
+  in
+  `Assoc [
+    ("contracted_count", `Int (KfSet.cardinal contracted));
+    ("defined_count", `Int (List.length defined));
+    ("missing_count", `Int (List.length missing));
+    ("missing",
+     `List (List.map (fun kf -> frontier_function_to_json kf (callers_of kf)) missing));
+
+    (* Not a detail of the list above. A call this walk could not follow is a
+       branch of the call graph nobody looked down, so a caller reading a short
+       missing list needs to know one was there.
+
+       Scoped to the bodies the walk read, for the same reason. An indirect
+       call in a function no contract reaches hid nothing from the frontier,
+       and reporting it would answer "call_graph_complete: false" on a program
+       whose frontier is complete, which is the field saying nothing at all on
+       any codebase with a callback anywhere in it. *)
+    ("unresolved_call_sites", `List unresolved);
+    ("call_graph_complete", `Bool (unresolved = []));
+  ]
+
 let get_contract_context (kf : kernel_function) : Yojson.Basic.t =
   let callees, unresolved_callees = direct_call_info_of_kf kf in
   `Assoc [

--- a/ast-utils/src/ast_utils_register.ml
+++ b/ast-utils/src/ast_utils_register.ml
@@ -139,6 +139,19 @@ let () =
          with Kernel_function.No_Definition ->
            error_json (Printf.sprintf "function '%s' has no definition" name))
 
+(* getContractFrontier *)
+
+let () =
+  Server.Request.register
+    ~package
+    ~kind:`GET
+    ~name:"getContractFrontier"
+    ~descr:(Markdown.plain
+              "Defined functions reachable from a contracted one that carry no contract")
+    ~input:(module Server.Data.Junit)
+    ~output:(module Server.Data.Jany)
+    (fun () -> Ast_utils_ast.get_contract_frontier ())
+
 (* getContractContext *)
 
 let () =

--- a/ast-utils/test/dune
+++ b/ast-utils/test/dune
@@ -17,3 +17,8 @@
  (alias runtest)
  (deps (source_tree regressions))
  (action (run ./regressions/run-payload-shapes.sh)))
+
+(rule
+ (alias runtest)
+ (deps (source_tree regressions))
+ (action (run ./regressions/run-contract-frontier.sh)))

--- a/ast-utils/test/regressions/contract-frontier.c
+++ b/ast-utils/test/regressions/contract-frontier.c
@@ -1,0 +1,20 @@
+/* Fixture for the getContractFrontier regression.
+   "entry" and "helper" carry contracts; "deep_a" and "deep_b" are reachable
+   from them and carry none, so they are the frontier. "orphan" is defined,
+   unspecified and unreachable from any contract, so it is not. */
+
+int deep_a(int x) { return x + 1; }
+
+int deep_b(int x) { return x * 2; }
+
+/*@ assigns \nothing; ensures \result >= 0; */
+int helper(int x)
+{
+  if (x < 0) return 0;
+  return deep_a(x) + deep_b(x);
+}
+
+/*@ assigns \nothing; ensures \result >= 0; */
+int entry(int x) { return helper(x); }
+
+int orphan(int x) { return x - 1; }

--- a/ast-utils/test/regressions/run-contract-frontier.sh
+++ b/ast-utils/test/regressions/run-contract-frontier.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# getContractFrontier reports the functions a proof still needs a contract for.
+#
+# Seeded from the contracted functions and walked downwards, so a defined and
+# unspecified function nothing contracted reaches is not on the frontier. That
+# is the case a seed over every defined function would get wrong, and it is what
+# this pins.
+set -euo pipefail
+
+FC="${FRAMA_C:-$(command -v frama-c || echo ~/.opam/frama/bin/frama-c)}"
+if [ ! -x "$FC" ]; then
+    echo "SKIP - no frama-c on PATH"
+    exit 2
+fi
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp "$HERE/contract-frontier.c" "$WORK/"
+cat > "$WORK/batch.json" << 'JSON'
+[ {"kind":"GET","id":"frontier","request":"plugins.ast-utils.getContractFrontier","data":null} ]
+JSON
+
+(cd "$WORK" && "$FC" -load-module ast_utils_plugin -server-batch batch.json \
+    -server-batch-output-dir . contract-frontier.c > /dev/null 2>&1)
+
+python3 - "$WORK/batch.out.json" << 'PY'
+import json, sys
+
+rows = {row.get("id"): row for row in json.load(open(sys.argv[1]))}
+frontier = rows.get("frontier", {}).get("data")
+
+fails = []
+
+
+def want(condition, message):
+    if not condition:
+        fails.append(message)
+
+
+want(isinstance(frontier, dict), "getContractFrontier returned no object")
+if isinstance(frontier, dict):
+    names = [entry.get("function") for entry in frontier.get("missing") or []]
+    want(names == ["deep_a", "deep_b"],
+         f"expected the two uncontracted callees in source order, got {names}")
+    want("orphan" not in names,
+         "an unspecified function no contract reaches is not on the frontier")
+    want(frontier.get("missing_count") == 2,
+         f"missing_count was {frontier.get('missing_count')}")
+    want(frontier.get("contracted_count") == 2,
+         f"contracted_count was {frontier.get('contracted_count')}")
+    want(frontier.get("defined_count") == 5,
+         f"defined_count was {frontier.get('defined_count')}")
+    want(frontier.get("call_graph_complete") is True,
+         "this fixture has no indirect call, so the walk is complete")
+    for entry in frontier.get("missing") or []:
+        want(entry.get("called_by") == ["helper"],
+             f"{entry.get('function')} is called by {entry.get('called_by')}")
+        want(isinstance(entry.get("loc"), dict),
+             f"{entry.get('function')} carries no location")
+
+if fails:
+    for message in fails:
+        print(f"FAIL - {message}")
+    sys.exit(1)
+print("PASS - ast-utils contract frontier")
+PY

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,6 +204,7 @@ own payloads.
 | `wp` | object or null | WP run result; null when the reload failed or `want` excluded it |
 | `wp_goals` | array, object, or null | Object when summarized, array when `detail` is `full`, null when WP did not run |
 | `wp_backend_diagnosis` | object or null | Non-null when the message stream shows a Why3 abort, so a `FAILED` goal is a crashed prover and not a verdict. Non-null does not imply `incomplete` |
+| `memory_model_probe` | object | What WP assumed about the memory model, read off the run's own probe. Always present, always carries `ran` and `hypotheses`; `ran: false` carries a `reason` instead of claiming an empty list. "Nothing was assumed" and "nobody looked" are different answers and this is the field that separates them |
 | `messages` | array | Frama-C diagnostics drained for this run |
 | `messages_truncated` | boolean | The drain hit its cap |
 | `recommended_next_call` | object | `{tool, args, reason}`. `args` names tool parameters and is not frozen |

--- a/docs/writing-acsl.md
+++ b/docs/writing-acsl.md
@@ -140,6 +140,12 @@ that say a green-looking run is not one:
 - `PROPERTY_DEAD`: proved about code EVA showed is unreachable, so it
   constrains no run
 - `UNCONSTRAINED_ASSIGNS`: written, and nothing says what was written
+- `WP_MEMORY_MODEL_HYPOTHESIS`: WP's memory model needed a separation and
+  assumed it. Every goal can be valid while this is reported, and that is the
+  case it exists for: a function taking a pointer and writing a global proves
+  under `\separated(p, &g)`, and a caller passing `&g` proves too while the
+  postcondition is false at run time. The entry carries the clause; put it in
+  the function's own `requires` so callers have to discharge it
 - `INDIRECT_CALL_UNRESOLVED`: a call through a function pointer. Without a
   `calls` clause WP assumes the pointer may reach any function, including the
   enclosing one, so the goals underneath come back as timeouts that no extra

--- a/docs/writing-acsl.md
+++ b/docs/writing-acsl.md
@@ -140,6 +140,15 @@ that say a green-looking run is not one:
 - `PROPERTY_DEAD`: proved about code EVA showed is unreachable, so it
   constrains no run
 - `UNCONSTRAINED_ASSIGNS`: written, and nothing says what was written
+- `INDIRECT_CALL_UNRESOLVED`: a call through a function pointer. Without a
+  `calls` clause WP assumes the pointer may reach any function, including the
+  enclosing one, so the goals underneath come back as timeouts that no extra
+  time will close. For a call through the pointer formal `f`, name the callee
+  set with `/*@ calls impl_a, impl_b; */` at the site, then pin the pointer in
+  the contract with `requires f == &impl_a;`; the clause
+  alone leaves the call-point goal open. The code reports the call shape and
+  not the annotation, so it keeps firing once both are written and the goals
+  discharge; its `reports` field says so
 
 `run_wp {cache: "None"}` when you need the verdict computed now rather than
 replayed from an earlier run: `-wp-cache` defaults to `update`, and each goal

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -1236,6 +1236,115 @@ pub fn assumed_callee_contract_findings(
         .collect()
 }
 
+/// The pointer a precondition has to constrain, from the callee expression the
+/// plug-in printed.
+///
+/// The plug-in prints the call's lhost, and CIL normalizes "f()" through a
+/// pointer formal to "( *f)()", so what arrives is "*f" rather than "f". A
+/// precondition constrains the pointer and not its target, so pasting the
+/// printed form would produce "requires *f == &seta;", which is a type error.
+/// The dereference comes off here, and the parentheses a nested expression
+/// prints with come off behind it, so "*(state->handler)" names
+/// "state->handler".
+fn pointer_expression(callee: &str) -> &str {
+    let inner = callee.trim();
+    let inner = inner.strip_prefix('*').unwrap_or(inner).trim();
+    match inner.strip_prefix('(').and_then(|rest| rest.strip_suffix(')')) {
+        Some(unwrapped) if !unwrapped.contains('(') && !unwrapped.contains(')') => {
+            unwrapped.trim()
+        }
+        _ => inner,
+    }
+}
+
+/// The calls this server could not name a callee for.
+///
+/// "direct_callee_visitor" in the plug-in records a call whose host is not a
+/// Var instead of skipping it, and "getContractContext" returns the list as
+/// "unresolved_callees" beside a "callee_resolution_complete" boolean. Nothing
+/// read either until this: the plug-in computed the answer, two tests agreed
+/// the fields were present, and no consumer ever looked at one being false.
+///
+/// It matters because of what WP does with such a call. Measured on Frama-C
+/// 32.1, over a function whose body is one call through a pointer formal: with
+/// no calls clause WP warns "no 'calls' specification for statement(s) ...
+/// Assuming that they can call 'run'", which makes the function recursive,
+/// pulls in a decreases obligation, and leaves 4 of 9 goals at Timeout. This
+/// server reports those as GOAL_NOT_VALID with PROVER_TIMEOUT beside them, so
+/// the cause a caller reads is the prover and the next action it invites, more
+/// time, cannot work. Adding "calls seta;" takes the same file to 9 of 10 and
+/// a precondition pinning the pointer takes it to 10 of 10.
+///
+/// This reports the call shape, not the annotation: the visitor walks the AST
+/// and a statement's own code annotations are not part of what it walks, so
+/// the finding stays after a calls clause is added. That over-reports in the
+/// direction the fail-loud rule asks for, and the message says so rather than
+/// leaving a reader to discover it.
+pub fn unresolved_call_findings(
+    caller: &str,
+    context: &serde_json::Value,
+) -> Vec<serde_json::Value> {
+    let Some(unresolved) = context
+        .get("unresolved_callees")
+        .and_then(|value| value.as_array())
+    else {
+        return Vec::new();
+    };
+    unresolved
+        .iter()
+        .map(|call| {
+            let sid = call.get("sid").cloned().unwrap_or_else(|| json!(null));
+            let expression = call
+                .get("callee")
+                .and_then(|value| value.as_str())
+                .unwrap_or("<unknown>");
+            let pointer = pointer_expression(expression);
+
+            // The statement id is in the id because a function can hold several
+            // indirect calls and each one needs its own clause. Findings are
+            // deduplicated by id downstream, so an id naming only the caller
+            // would report the first call and drop the rest.
+            json!({
+                "id": format!("unresolved-call:{caller}:{sid}"),
+                "severity": "high",
+                "category": "unresolved_call",
+                "function": caller,
+                "callee_expression": expression,
+                "stmt_id": sid,
+                "source_location": call.get("loc").cloned().unwrap_or_else(|| json!(null)),
+                "message": format!(
+                    "{caller} calls through {expression}, which names no callee. Without a calls \
+                     clause WP assumes the pointer may reach any function, including {caller} \
+                     itself, and the goals that follow are unprovable rather than slow."
+                ),
+
+                // Conditional, because this reads the call shape and not the
+                // annotation: the same finding is still produced once a calls
+                // clause and a precondition are in place and every goal is
+                // valid, and an unconditional sentence would then contradict
+                // the goals reported beside it.
+                "why_problem":
+                    "Unless a calls clause at this statement names the callee set, WP has no \
+                     contract to use here and assumes the worst one. The goals it then leaves \
+                     open are reported as prover timeouts, which names the prover for a defect \
+                     that is a missing annotation.",
+                "suggested_fix": format!(
+                    "Write the callee set at the call site, as in /*@ calls impl_a, impl_b; */ \
+                     before the statement, naming every function the pointer may hold. Then \
+                     constrain the pointer in {caller}'s own contract, as in \
+                     requires {pointer} == &impl_a;, naming the one it actually holds. The calls \
+                     clause alone leaves the call-point goal open, because nothing yet says \
+                     which function the pointer holds."
+                ),
+                "evidence": [{
+                    "field": "unresolved_callees[].callee",
+                    "value": expression,
+                }],
+            })
+        })
+        .collect()
+}
+
 async fn main_contract_shape_findings(
     client: &FramaCClient,
     function_names: &[String],
@@ -1251,6 +1360,11 @@ async fn main_contract_shape_findings(
         findings.extend(assumed_callee_contract_findings(function, &context));
         findings.extend(unconstrained_assigns_findings(function, &context));
         findings.extend(result_unconstrained_findings(function, &context));
+
+        // Appended last on purpose. This walk order is hashed into the proof
+        // receipt, so a new producer inserted among the others would change
+        // every receipt over a function that has one of the older findings.
+        findings.extend(unresolved_call_findings(function, &context));
     }
     findings
 }

--- a/src/mcp/analysis.rs
+++ b/src/mcp/analysis.rs
@@ -1183,6 +1183,112 @@ pub fn unproved_assumption_findings(
     findings
 }
 
+/// The inputs the probe-and-receipt tail takes, as one value.
+///
+/// A struct rather than nine loose arguments, and four of them are the same
+/// two types: two &str, two bool-ish name lists. Positional, those swap
+/// silently and the run reports the right goals under the wrong provenance.
+pub(crate) struct ProbeAndReceipt<'a> {
+    pub client: &'a FramaCClient,
+    pub response: &'a mut serde_json::Value,
+    pub project_options: &'a ProjectLoadOptions,
+    pub rte: bool,
+    pub probe_functions: &'a [String],
+    pub temp_dir_prefix: &'a str,
+    pub source_files: Vec<String>,
+    pub wp_goals: &'a [serde_json::Value],
+    pub report_function: Option<&'a str>,
+}
+
+/// What a WP run is about to prove, read off the session state in one go.
+///
+/// A struct rather than a tuple because the last field is the odd one out: four
+/// of these describe the project, and changed_from describes this process's
+/// history with it. A five-tuple at the call site said none of that.
+struct WpRunSubject {
+    requested_model: String,
+    rte_enabled: bool,
+    source_files: Vec<String>,
+    project_options: ProjectLoadOptions,
+
+    /// The model this process last proved under, when it differs from the one
+    /// being asked for now, so an abort can be explained by the change.
+    changed_from: Option<String>,
+}
+
+/// Put a printed AST on disk for a process that can only read files.
+///
+/// A random O_EXCL directory, for the reason materialize_check_source gives at
+/// length. The e-ACSL site was the worse of the two before this was shared: it
+/// created the directory and never removed it, so there was no race to win, an
+/// attacker planted a symlink at current-ast.c once, and every later call wrote
+/// through it into something run_e_acsl then compiles and runs.
+///
+/// The guard goes back to the caller. Dropping it removes the directory, so a
+/// caller that needs the file to outlive one statement has to hold it.
+fn write_ast_source_file(
+    source: &str,
+    prefix: &str,
+) -> Result<(String, tempfile::TempDir), McpError> {
+    let dir = private_temp_dir(prefix).map_err(|error| {
+        McpError::internal_error(format!("failed to create a temp dir: {error}"), None)
+    })?;
+    let path = dir.path().join("current-ast.c");
+    std::fs::write(&path, source).map_err(|error| {
+        McpError::internal_error(format!("failed to write {}: {error}", path.display()), None)
+    })?;
+    Ok((path.display().to_string(), dir))
+}
+
+/// The options a probe over a printed AST is given, from the ones the project
+/// was loaded with.
+///
+/// Only the machine description survives, and dropping the other two is the
+/// point rather than an omission. A printed AST is one already-preprocessed
+/// translation unit: it has no include directive left for -cpp-extra-args to
+/// affect, and -compilation-db maps the project's own source paths to flags,
+/// so pointing it at a temporary file in a temporary directory asks it about a
+/// path it does not describe. The machine description is not optional in the
+/// same way, because it fixes sizeof and alignof and those decide which
+/// separations the memory model needs, which is the whole question here.
+///
+/// Destructured exhaustively rather than written as a struct update, for the
+/// reason project_cli_args gives: a field added to ProjectLoadOptions has to
+/// become a compile error here, or a printed-source probe quietly goes on
+/// running under the old set while the loaded project uses the new one. Every
+/// field dropped is named below with why, so adding one is a decision rather
+/// than an omission.
+fn printed_source_options(options: &ProjectLoadOptions) -> ProjectLoadOptions {
+    let ProjectLoadOptions {
+        machdep,
+
+        // The database maps the project's own source paths to flags, so it has
+        // nothing to say about a temporary file in a temporary directory.
+        compilation_database: _,
+
+        // Preprocessor settings, and a printed AST has already been through the
+        // preprocessor: there is no include directive left for these to affect.
+        include_paths: _,
+        defines: _,
+        force_includes: _,
+        isystem_paths: _,
+        nostdinc: _,
+
+        // Not emitted by project_cli_args for anyone, so there is nothing here
+        // to carry. The probe decides -wp-rte for itself, from what the run it
+        // describes actually guarded.
+        rte: _,
+    } = options;
+
+    ProjectLoadOptions {
+        // The one that survives. It fixes sizeof and alignof, and those decide
+        // which separations the memory model needs, which is the whole question
+        // a probe is asking.
+        machdep: machdep.clone(),
+        ..ProjectLoadOptions::default()
+    }
+}
+
 pub fn assumed_callee_contract_findings(
     caller: &str,
     context: &serde_json::Value,
@@ -2175,32 +2281,13 @@ impl FramaCMcpServer {
     async fn write_current_ast_source(&self) -> Result<(String, tempfile::TempDir), McpError> {
         let client = self.require_client().await?;
         let source = client.print_source().await.map_err(McpError::from)?;
-        let source = source.as_str();
         if source.trim().is_empty() {
             return Err(McpError::internal_error(
                 "printSource returned nothing, so there is no AST to instrument",
                 None,
             ));
         }
-
-        // A random O_EXCL name, for the reason materialize_check_source gives
-        // at length. This site was the worse of the two: it created the
-        // directory and never removed it, so there was no race to win. An
-        // attacker planted a symlink at current-ast.c once and every later call
-        // wrote through it, and what lands here is then compiled and run by
-        // run_e_acsl.
-        //
-        // The guard is returned to the caller, which holds it for the whole run
-        // and only then parks it on the server, so the file outlives the run
-        // and the reported path stays readable.
-        let dir = private_temp_dir("frama-c-mcp-e-acsl-ast-").map_err(|error| {
-            McpError::internal_error(format!("failed to create a temp dir: {error}"), None)
-        })?;
-        let path = dir.path().join("current-ast.c");
-        std::fs::write(&path, source).map_err(|error| {
-            McpError::internal_error(format!("failed to write {}: {error}", path.display()), None)
-        })?;
-        Ok((path.display().to_string(), dir))
+        write_ast_source_file(&source, "frama-c-mcp-e-acsl-ast-")
     }
 
     /// The EVA half of one check: the run, then the alarms it left.
@@ -2316,6 +2403,14 @@ impl FramaCMcpServer {
             // is present because the two build sites carry one field set, which
             // check_returns_one_field_set_on_both_paths freezes.
             "wp_backend_diagnosis": null,
+
+            // Present on this path too, and in the same position, for the
+            // reason "detail" above is null rather than absent. Saying why
+            // rather than reporting an empty hypothesis list: nothing was
+            // proved here, so there is no assumption for a proof to own, and a
+            // reader branching on this key needs "did not run" and "found
+            // nothing" to look different.
+            "memory_model_probe": probe_absent("the reload failed, so nothing was proved", true),
             "messages": messages,
             "messages_truncated": messages_truncated,
             "recommended_next_call": {
@@ -2340,6 +2435,10 @@ impl FramaCMcpServer {
                 }),
                 // No goals, so nothing to discriminate.
                 properties: &HashMap::new(),
+
+                // The reload failed, so there is no AST to have printed.
+                ast_source: None,
+                ast_digest: None,
             })
             .await;
         payload["proof_receipt"] = receipt;
@@ -2372,6 +2471,307 @@ impl FramaCMcpServer {
             .ok()
             .and_then(|profile| profile.rte)
             .unwrap_or(true)
+    }
+
+    /// What this run is about to prove, and what the last one proved.
+    ///
+    /// Read under the WP lock and in one place, because every field here is a
+    /// property of the project as it stands at the moment the lock was taken.
+    /// Split out of run_wp when that function passed the length ceiling: the
+    /// block answers from the session state alone, touching no client, no
+    /// proof and no response, which is the independent sub-unit the ceiling
+    /// exists to find.
+    ///
+    /// Read here and written after the proofs are scheduled, not before. A run
+    /// that fails in configuration or in target resolution never reached WP, so
+    /// recording its model would make the next abort blame a change from a
+    /// model this process never used.
+    async fn wp_run_subject(&self, params: &RunWpParams) -> Result<WpRunSubject, McpError> {
+        let requested_model = params
+            .model
+            .clone()
+            .unwrap_or_else(|| default_wp_model().to_string());
+
+        let main_state = self.main_frama_c_state.lock().await;
+        let state = main_state.as_ref().ok_or_else(no_project_loaded_err)?;
+        Ok(WpRunSubject {
+            rte_enabled: state.project_options.rte,
+            source_files: state.files.clone(),
+
+            // The whole struct, not the one or two fields the probe ends up
+            // using. memory_model_probe_over_printed_ast narrows it through
+            // printed_source_options, whose exhaustive destructure is a compile
+            // error when a field is added, and only machdep survives from here
+            // onto the probe's command line; that function records why each of
+            // the others is dropped. Taken in the block that already reads the
+            // state under the WP lock, so it describes the program this run
+            // proved rather than whatever is loaded when the probe gets to run.
+            project_options: state.project_options.clone(),
+
+            // The model this process last proved under, kept only when it
+            // differs from the one asked for now. None covers both "first run
+            // in this process" and "same model again", which are exactly the
+            // two cases an abort must not be blamed on.
+            changed_from: state
+                .wp_model_used
+                .clone()
+                .filter(|previous| *previous != requested_model),
+            requested_model,
+        })
+    }
+
+    /// Probe the AST this run proved, then digest that same print into the
+    /// receipt.
+    ///
+    /// One method because both proving paths do the identical three steps in
+    /// the identical order, and the middle one exists only to carry the print
+    /// from the first to the third: probe, record the probe, build the receipt
+    /// over the bytes the probe was run on. Written out at both call sites, the
+    /// Option that carries the print read as a value either might use, when in
+    /// fact neither does anything with it but pass it along.
+    pub(crate) async fn attach_probe_and_receipt(
+        &self,
+        args: ProbeAndReceipt<'_>,
+    ) -> Result<(), McpError> {
+        let ProbeAndReceipt {
+            client,
+            response,
+            project_options,
+            rte,
+            probe_functions,
+            temp_dir_prefix,
+            source_files,
+            wp_goals,
+            report_function,
+        } = args;
+
+        let (probe, printed_source) = self
+            .memory_model_probe_over_printed_ast(
+                client,
+                project_options,
+                rte,
+                probe_functions,
+                response,
+                temp_dir_prefix,
+            )
+            .await;
+        response["memory_model_probe"] = probe;
+
+        self.attach_run_wp_receipt(
+            client,
+            response,
+            source_files,
+            wp_goals,
+            report_function,
+            printed_source.as_deref(),
+        )
+        .await
+    }
+
+    /// Probe the AST a run actually proved, and hand back the print it used.
+    ///
+    /// Annotations reach Frama-C through execAddAnnotation and the ghost
+    /// insertions, and none of them writes the source back: a sandbox's
+    /// sandbox.c is written once, at creation, and a main-project file is never
+    /// written at all. So the files on disk are the program as it was before
+    /// this session injected anything, and a probe pointed at them answers "no
+    /// hypotheses" for a proof that rested on a separation an injected contract
+    /// introduced. That is the false clean the payload exists to rule out, and
+    /// it is the shape the CEGIS loop runs in: inject, then run_wp, with no
+    /// reload between. printSource prints the live AST instead, annotations and
+    /// RTE assertions included, as one translation unit that round-trips
+    /// through the C front end.
+    ///
+    /// The returned source is the same text, for a caller that also needs to
+    /// digest it. One print serves both, which is not only cheaper than two
+    /// sixty-second requests but is what makes the digest and the probe
+    /// describe one AST rather than two prints with a window between them.
+    ///
+    /// A print that fails becomes a probe that did not run. Falling back to the
+    /// files on disk would be the same wrong answer arrived at more slowly.
+    ///
+    /// Both proving paths call this, so the sandbox cannot drift from the main
+    /// project on what "the AST that was proved" means. It narrows the options
+    /// through printed_source_options itself rather than trusting each caller
+    /// to, because that function exists to make a field added to
+    /// ProjectLoadOptions a compile error, and a guarantee a caller can skip is
+    /// not one: the sandbox passed its options straight through and would have
+    /// gone on doing so.
+    pub(crate) async fn memory_model_probe_over_printed_ast(
+        &self,
+        client: &FramaCClient,
+        project_options: &ProjectLoadOptions,
+        rte: bool,
+        functions: &[String],
+        response: &serde_json::Value,
+        temp_dir_prefix: &str,
+    ) -> (serde_json::Value, Option<String>) {
+        let source = match client.print_source().await {
+            Ok(source) if !source.trim().is_empty() => source,
+            Ok(_) => {
+                let reason = "printSource returned nothing, so there is no AST to probe";
+                return (probe_absent(reason, false), None);
+            }
+            Err(error) => return (probe_absent(format!("printSource failed: {error}"), false), None),
+        };
+
+        // Asked before the AST is written out, and after it is printed. A run
+        // with no target the probe can name has its answer already, so writing
+        // a whole AST to disk for it is work for a known result; the print
+        // itself still has to happen, because the receipt digests those bytes
+        // whether or not a probe follows.
+        //
+        // An empty list means "no target this probe could describe" rather than
+        // "the whole file". Nothing asks for a whole-file probe: an unscoped
+        // run passes every defined function by name, so falling through to an
+        // unrestricted frama-c would attribute some other function's separation
+        // to a run that never proved it.
+        if functions.is_empty() {
+            return (
+                probe_absent("the run named no defined function for the probe to describe", true),
+                Some(source),
+            );
+        }
+
+        // Bounded by the same semaphore as every other extra front end this
+        // server starts. parse_probe_slots exists because a Frama-C front end
+        // is a few hundred megabytes and what matters is how many exist at
+        // once; a probe per run_wp is exactly that, and a sandbox scope can
+        // have max_sandboxes of them in flight, each already holding its own
+        // process. Taken before the file is written so a waiter is not also
+        // holding a temp directory of printed AST open for the length of the
+        // wait, which is what a permit taken after the write costs.
+        let _probe_slot = self.parse_probe_slots.clone().acquire_owned().await.ok();
+
+        // The guard lives to the end of this function, which is past the await
+        // below, so the file is still there while frama-c reads it.
+        let (path, _dir) = match write_ast_source_file(&source, temp_dir_prefix) {
+            Ok(written) => written,
+
+            // The print itself succeeded, so it still travels: the digest wants
+            // those bytes and only the probe needed them on disk. Answering
+            // None here made a failure to create a temp directory cost the
+            // caller a second sixty-second printSource.
+            Err(error) => {
+                let reason = format!("the printed AST could not be written: {error}");
+                return (probe_absent(reason, false), Some(source));
+            }
+        };
+
+        let probe = run_wp_memory_model_probe(
+            &self.frama_c_path,
+            std::slice::from_ref(&path),
+            &printed_source_options(project_options),
+            rte,
+            response
+                .pointer("/effective_wp_config/model")
+                .and_then(|value| value.as_str()),
+            functions,
+            response
+                .pointer("/effective_wp_config/prop/effective")
+                .and_then(|value| value.as_str()),
+        )
+        .await;
+        (probe, Some(source))
+    }
+
+    /// What WP assumed about the memory model on this run, or why nobody asked.
+    ///
+    /// A reader, not a prober, despite the name it kept. run_wp runs the probe
+    /// inside the lock that makes its inputs agree with the goals, so this
+    /// takes the answer off the wp payload and supplies only the two cases
+    /// there is no payload for: the caller wanted no WP, and WP did not finish.
+    ///
+    /// Every arm says why rather than answering with an empty hypothesis list,
+    /// because "nothing was assumed" and "nobody looked" are the two answers
+    /// this whole payload exists to keep apart. An empty list under ran: false
+    /// would collapse them.
+    pub async fn memory_model_probe(
+        &self,
+        wanted: WantedAnalyses,
+        wp: &serde_json::Value,
+    ) -> serde_json::Value {
+        if !wanted.wp {
+            return probe_absent("check did not run WP", true);
+        }
+        if wp.get("ok").and_then(|ok| ok.as_bool()) == Some(false) {
+            return probe_absent("WP did not complete", true);
+        }
+
+        // The run's own answer, and the only one. run_wp probes under the WP
+        // lock with the files and options it proved from, so nothing this
+        // function could reconstruct would be more exact, and a second probe
+        // would cost a second frama-c process per check.
+        //
+        // This used to rebuild the arguments from the run's receipt and probe
+        // again. That path is unreachable now, and unreachable code that looks
+        // like a fallback is worse than none: a reader takes it for a case that
+        // happens. If a WP payload ever arrives without the key, that is a
+        // build whose run_wp did not probe, and saying so is the honest answer
+        // rather than quietly probing on its behalf under arguments this side
+        // of the lock cannot vouch for.
+        match wp.get("memory_model_probe") {
+            Some(probe) if !probe.is_null() => probe.clone(),
+
+            // Not a nothing_was_proved case: WP ran, and only the reading is
+            // missing, which is exactly the gap the unchecked code reports.
+            _ => probe_absent("the WP run reported no memory-model probe", false),
+        }
+    }
+
+    /// The calls run_wp answers without proving anything on the main instance.
+    ///
+    /// Three of them, and each returns a whole alternative answer rather than a
+    /// step, which is why they are gathered here instead of reading as stages
+    /// of the transaction below. A sandbox target is a different instance; a
+    /// sandbox target with a verify_profile is a category error, since a
+    /// profile labels proofs of the loaded main project and a sandbox proof is
+    /// not target evidence; and a cancel is the way out of a run rather than a
+    /// run, which is why it is answered before the project lock and before any
+    /// config, a caller reaching for it being by definition not in a position
+    /// to satisfy preconditions.
+    ///
+    /// None means this is a main-instance proof and the caller should carry on.
+    async fn run_wp_answered_without_a_main_run(
+        &self,
+        params: &RunWpParams,
+    ) -> Option<Result<CallToolResult, McpError>> {
+        match run_wp_target_scope(params) {
+            Err(error) => return Some(Err(error)),
+            Ok(RunWpScope::Sandbox) => {
+                if params.verify_profile.is_some() {
+                    return Some(Err(McpError::invalid_params(
+                        "verify_profile only labels proofs of the loaded main project; sandbox proofs are not target evidence",
+                        None,
+                    )));
+                }
+                return Some(self.run_wp_on_sandbox(params).await);
+            }
+            Ok(RunWpScope::Main) => {}
+        }
+        if params.cancel == Some(true) {
+            return Some(self.cancel_wp_queue().await);
+        }
+        None
+    }
+
+    /// Refuse a main-instance WP run while phase two owns the project.
+    ///
+    /// Asked twice by run_wp, once before it waits for the WP lock and once
+    /// after: verify_program_step can set the flag while a run queues behind
+    /// another, so the first answer is stale by the time the lock is held. The
+    /// message is long enough that stating it twice made the second check read
+    /// as a different rule.
+    async fn refuse_run_wp_while_project_locked(&self) -> Result<(), McpError> {
+        if *self.project_locked.read().await {
+            return Err(project_locked_error(
+                "run_wp",
+                "Project is locked. run_wp is blocked during Phase 2 to prevent state pollution. \
+                 If you are in verify-function, pass sandbox-prefixed functions. \
+                 Do NOT touch the main Frama-C instance. Call verify_program_step with lock_project=false first if this is the final main-project gate.",
+            ));
+        }
+        Ok(())
     }
 
     pub async fn check_payload(&self, params: CheckParams) -> Result<serde_json::Value, McpError> {
@@ -2557,6 +2957,15 @@ impl FramaCMcpServer {
             }));
         }
 
+        // Not from the drain, though it took a measurement to learn that. WP
+        // emits its memory-model hypotheses from the batch entry point, and the
+        // server request that runs proofs never reaches that code, so the
+        // socket carries nothing to classify. A fresh Frama-C with provers off
+        // is the only source, and it is one process rather than one per goal.
+        let memory_model = self.memory_model_probe(wanted, &wp).await;
+        incomplete.extend(memory_model_hypothesis_gap(&memory_model));
+        incomplete.extend(memory_model_unchecked_gap(&memory_model, wanted));
+
         let recommended_next_call = check_next_call(NextCallInputs {
             backend_diagnosis: &backend_diagnosis,
             anomaly_left_goals_unjudged,
@@ -2612,6 +3021,12 @@ impl FramaCMcpServer {
             "wp": wp,
             "wp_goals": reported_goals,
             "wp_backend_diagnosis": backend_diagnosis,
+
+            // Provenance for the one answer in this payload that did not come
+            // through the socket. Carries the command, the model and the exit
+            // code when it ran, and the reason when it did not, so a reader can
+            // tell "nothing was assumed" from "nobody could look".
+            "memory_model_probe": memory_model,
             "messages": messages,
             "messages_truncated": messages_truncated,
             "recommended_next_call": recommended_next_call,
@@ -2683,6 +3098,21 @@ impl FramaCMcpServer {
                 "wp_failure_kind": wp.get("failure_kind").cloned().unwrap_or_else(|| json!(null)),
             }),
             properties,
+
+            // check never prints the AST itself. It reaches WP through run_wp,
+            // which prints once for its memory-model probe and digests that
+            // same text into its own receipt, and nothing between the two
+            // mutates the AST. Reading the answer off the WP payload is what
+            // keeps a check to one print instead of two, each of which ships
+            // the whole AST over the socket under a sixty-second budget.
+            //
+            // None when the run produced no digest, which puts the print back
+            // where it was: a nested receipt that could not digest is not a
+            // reason for this one to give up.
+            ast_source: None,
+            ast_digest: wp
+                .pointer("/proof_receipt/subject/ast_digest")
+                .and_then(|value| value.as_str()),
         })
         .await
     }
@@ -3400,24 +3830,8 @@ impl FramaCMcpServer {
         &self,
         Parameters(mut params): Parameters<RunWpParams>,
     ) -> Result<CallToolResult, McpError> {
-        match run_wp_target_scope(&params)? {
-            RunWpScope::Sandbox => {
-                if params.verify_profile.is_some() {
-                    return Err(McpError::invalid_params(
-                        "verify_profile only labels proofs of the loaded main project; sandbox proofs are not target evidence",
-                        None,
-                    ));
-                }
-                return self.run_wp_on_sandbox(&params).await;
-            }
-            RunWpScope::Main => {}
-        }
-
-        // Before the project lock and before any config: cancelling is not a
-        // proof run, it is the way out of one, and a caller reaching for it is
-        // by definition not in a position to satisfy preconditions.
-        if params.cancel == Some(true) {
-            return self.cancel_wp_queue().await;
+        if let Some(answer) = self.run_wp_answered_without_a_main_run(&params).await {
+            return answer;
         }
 
         // After the cancel above, for the reason stated there: resolving a
@@ -3437,14 +3851,7 @@ impl FramaCMcpServer {
         let profile_applied = self.apply_verify_profile(&mut params).await?;
 
         // Check project lock for main instance WP
-        if *self.project_locked.read().await {
-            return Err(project_locked_error(
-                "run_wp",
-                "Project is locked. run_wp is blocked during Phase 2 to prevent state pollution. \
-                 If you are in verify-function, pass sandbox-prefixed functions. \
-                 Do NOT touch the main Frama-C instance. Call verify_program_step with lock_project=false first if this is the final main-project gate.",
-            ));
-        }
+        self.refuse_run_wp_while_project_locked().await?;
         let requested_provers = effective_wp_provers(&params)?;
 
         // The guard stays here, where a reader of run_wp can see that this is a
@@ -3462,6 +3869,19 @@ impl FramaCMcpServer {
         // two concurrent runs overwrite each other's config mid-flight and each
         // reports the union of both runs' goals. cancel_wp_queue takes no lock,
         // so a run stuck in drain can still be cancelled.
+        //
+        // The memory-model probe is inside it too, and that is a cost paid
+        // deliberately rather than an oversight. The probe prints this AST and
+        // spawns a frama-c over the print, measured at 2.3 s on the two
+        // function fixture and capped by EXTERNAL_COMMAND_BUDGET at 60 s, and
+        // for all of that time reload_project and every other WP call queue
+        // behind this one. Holding the lock is what makes the probe describe
+        // the program the goals were proved against: released first, a
+        // concurrent reload_project would swap the AST out from under the
+        // print, and the probe would answer about a different program while
+        // reporting it beside this run's goals. That failure is silent in the
+        // worst direction, since a newly loaded project needing no separation
+        // reads as a proof that assumed nothing.
         let _wp_op_guard = if profile_wp_guard.is_none() {
             Some(self.main_wp_lock.lock().await)
         } else {
@@ -3471,14 +3891,7 @@ impl FramaCMcpServer {
         // Rechecked under the lock: verify_program_step can set the flag while
         // this call waits for a run ahead of it, and the check at the top of
         // the handler was read before that wait.
-        if *self.project_locked.read().await {
-            return Err(project_locked_error(
-                "run_wp",
-                "Project is locked. run_wp is blocked during Phase 2 to prevent state pollution. \
-                 If you are in verify-function, pass sandbox-prefixed functions. \
-                 Do NOT touch the main Frama-C instance. Call verify_program_step with lock_project=false first if this is the final main-project gate.",
-            ));
-        }
+        self.refuse_run_wp_while_project_locked().await?;
 
         // Recorded, not enforced. Frama-C aborts on SOME memory model changes
         // within one process and not others: Typed+cast to Typed+nocast is
@@ -3487,30 +3900,13 @@ impl FramaCMcpServer {
         // which is which would block calls that work, so this only remembers
         // what ran, and the error path below uses it to explain an abort that
         // has already happened.
-        let requested_model = params
-            .model
-            .clone()
-            .unwrap_or_else(|| default_wp_model().to_string());
-
-        // Read here and written after the proofs are scheduled, not before. A
-        // run that fails in configuration or in target resolution never reached
-        // WP, so recording its model would make the next abort blame a change
-        // from a model this process never used.
-        let (rte_enabled, source_files, previous_model) = {
-            let main_state = self.main_frama_c_state.lock().await;
-            let state = main_state.as_ref().ok_or_else(no_project_loaded_err)?;
-            (
-                state.project_options.rte,
-                state.files.clone(),
-                state.wp_model_used.clone(),
-            )
-        };
-
-        // The model this process last proved under, kept only when it differs
-        // from the one asked for now. None covers both "first run in this
-        // process" and "same model again", which are exactly the two cases an
-        // abort must not be blamed on.
-        let changed_from = previous_model.filter(|previous| *previous != requested_model);
+        let WpRunSubject {
+            requested_model,
+            rte_enabled,
+            source_files,
+            project_options,
+            changed_from,
+        } = self.wp_run_subject(&params).await?;
         let client = self.require_client().await?;
         self.apply_wp_config(&client, &params, requested_provers.as_ref())
             .await?;
@@ -3591,6 +3987,19 @@ impl FramaCMcpServer {
             .iter()
             .map(|info| info.name.clone())
             .collect::<Vec<_>>();
+
+        // The defined subset, for the memory-model probe alone. The reported
+        // config keeps every target, because that is the scope the caller asked
+        // for and a reader diffing two runs needs it whole; the probe cannot
+        // take the same list, because -wp-fct on a declared-but-undefined name
+        // is "no function 'f'" and a Frama-C that aborts before printing
+        // anything. generate_rte_guards filters on the same flag and for the
+        // same reason: only a defined function has obligations to carry.
+        let probe_functions = targets
+            .iter()
+            .filter(|info| info.defined)
+            .map(|info| info.name.clone())
+            .collect::<Vec<_>>();
         let report_function = (function_names.len() == 1).then(|| function_names[0].as_str());
         let wp_goals =
             reload_fetch(&client, "plugins.wp.reloadGoals", "plugins.wp.fetchGoals").await?;
@@ -3658,13 +4067,27 @@ impl FramaCMcpServer {
         response["rte_guarded_in_place"] = json!(rte_guarded);
         response["timeout_retry"] = timeout_retry;
 
-        self.attach_run_wp_receipt(
-            &client,
-            &mut response,
+        // What WP assumed about the memory model, on the tool that produced the
+        // proof rather than only on check. The rte value passed is wider than
+        // the project's own flag on purpose: run_wp generates WP's guards in
+        // place for a main-instance run, so a project loaded without rte still
+        // proves them and a probe told otherwise would describe a smaller
+        // program.
+        //
+        // Over the printed AST rather than over state.files. See
+        // memory_model_probe_over_printed_ast for why the files on disk are the
+        // wrong program to ask.
+        self.attach_probe_and_receipt(ProbeAndReceipt {
+            client: &client,
+            response: &mut response,
+            project_options: &project_options,
+            rte: rte_enabled || !rte_guarded.is_empty(),
+            probe_functions: &probe_functions,
+            temp_dir_prefix: "frama-c-mcp-wp-probe-ast-",
             source_files,
-            &wp_goals,
+            wp_goals: &wp_goals,
             report_function,
-        )
+        })
         .await?;
 
         // Beside the goals rather than in the receipt: the receipt already

--- a/src/mcp/checkgaps.rs
+++ b/src/mcp/checkgaps.rs
@@ -170,6 +170,8 @@ pub mod incomplete_code {
     pub const EVA_NOT_REQUESTED: &str = "EVA_NOT_REQUESTED";
     pub const WP_NOT_REQUESTED: &str = "WP_NOT_REQUESTED";
     pub const WP_BACKEND_ANOMALY: &str = "WP_BACKEND_ANOMALY";
+    pub const WP_MEMORY_MODEL_HYPOTHESIS: &str = "WP_MEMORY_MODEL_HYPOTHESIS";
+    pub const WP_MEMORY_MODEL_UNCHECKED: &str = "WP_MEMORY_MODEL_UNCHECKED";
     pub const AST_ASM_CLOBBER: &str = "AST_ASM_CLOBBER";
     pub const AST_UNKNOWN_ATTRIBUTE: &str = "AST_UNKNOWN_ATTRIBUTE";
     pub const AST_UNCLASSIFIED_WARNING: &str = "AST_UNCLASSIFIED_WARNING";
@@ -202,6 +204,8 @@ pub mod incomplete_code {
         EVA_NOT_REQUESTED,
         WP_NOT_REQUESTED,
         WP_BACKEND_ANOMALY,
+        WP_MEMORY_MODEL_HYPOTHESIS,
+        WP_MEMORY_MODEL_UNCHECKED,
         AST_ASM_CLOBBER,
         AST_UNKNOWN_ATTRIBUTE,
         AST_UNCLASSIFIED_WARNING,
@@ -279,13 +283,13 @@ fn unrequested_analysis_gaps(
     }
     if rte == Some(false) {
         // Which half of the check the gap is about depends on what WP did.
-        // run_wp generates WP's own RTE guards for every main-instance run,
-        // so its goals cover runtime errors whatever the load said, while EVA
-        // ran before them and its alarms do not. Saying both were excluded was
-        // true while the kernel's -rte at load was the only source of these
+        // run_wp generates WP's own RTE guards for every main-instance run, so
+        // its goals cover runtime errors whatever the load said, while EVA ran
+        // before them and its alarms do not. Saying both were excluded was true
+        // while the kernel's -rte at load was the only source of these
         // annotations, and it now tells a caller to discard a WP verdict that
-        // is sound. Read off the run rather than off the load flag, because
-        // the run is what decided it.
+        // is sound. Read off the run rather than off the load flag, because the
+        // run is what decided it.
         let wp_covered_runtime_errors = wanted.wp
             && wp.pointer("/effective_wp_config/rte").and_then(serde_json::Value::as_bool)
                 == Some(true);
@@ -390,9 +394,241 @@ pub fn gap_guidance(code: &str) -> serde_json::Value {
              Raising the prover timeout closes neither: the open goals are unprovable rather than \
              slow."
         }
+        incomplete_code::WP_MEMORY_MODEL_UNCHECKED => {
+            "This is not a finding about the code; it is the absence of one. The separate run that \
+             reads WP's memory-model hypotheses did not complete, so whether the proof rests on an \
+             unstated separation is unknown rather than answered. Check that the loaded sources \
+             still exist and that the memory model this run used is one the command-line Frama-C \
+             accepts, then run check again."
+        }
+        incomplete_code::WP_MEMORY_MODEL_HYPOTHESIS => {
+            "WP's memory model needed these separations and assumed them; no goal in this run \
+             checks one. Put each clause into the function's own requires, which turns it into an \
+             obligation every caller has to discharge. Leave it out and the proof holds only for \
+             callers that happen to keep the locations apart, which nothing here verifies: a \
+             caller passing the address of the global the function also writes proves too, and \
+             is wrong at run time."
+        }
         _ => return serde_json::Value::Null,
     };
     json!(guidance)
+}
+
+/// The probe entries that name a function and the separations WP assumed for
+/// it, as opposed to the parser's sentinel for a keyed warning whose wording it
+/// could not read.
+///
+/// The sentinel carries a null function, an empty clause list and a count. It
+/// is evidence that WP said something, which is why the parser keeps it rather
+/// than dropping it, and it is not evidence of any particular separation. Told
+/// apart here so one is not reported as the other.
+fn parsed_hypothesis_entries(probe: &serde_json::Value) -> Vec<serde_json::Value> {
+    hypothesis_entries(probe)
+        .iter()
+        .filter(|entry| entry.get("function").is_some_and(|name| !name.is_null()))
+        .cloned()
+        .collect()
+}
+
+/// How many keyed memory-model warnings the parser could not read.
+fn unparsed_hypothesis_warnings(probe: &serde_json::Value) -> u64 {
+    hypothesis_entries(probe)
+        .iter()
+        .filter_map(|entry| entry.get("unparsed_warning_count").and_then(serde_json::Value::as_u64))
+        .sum()
+}
+
+/// Whether any entry names a function, without building the list to find out.
+fn has_parsed_hypothesis_entry(probe: &serde_json::Value) -> bool {
+    hypothesis_entries(probe)
+        .iter()
+        .any(|entry| entry.get("function").is_some_and(|name| !name.is_null()))
+}
+
+fn hypothesis_entries(probe: &serde_json::Value) -> &[serde_json::Value] {
+    const NONE: &[serde_json::Value] = &[];
+    probe
+        .get("hypotheses")
+        .and_then(serde_json::Value::as_array)
+        .map_or(NONE, Vec::as_slice)
+}
+
+/// The hypotheses WP assumed about the memory model, as an incomplete[] entry.
+///
+/// A memory-model hypothesis is worst exactly when every goal is valid, so
+/// unlike WP_BACKEND_ANOMALY there is no "left something unjudged" test to
+/// gate on: a run with nothing unproved is the run this has to fire on.
+///
+/// One aggregate entry rather than one per function. The hypothesis is a
+/// property of the model this run used and a reader needs the list once, while
+/// an entry per function would grow with the program inside the payload that
+/// already has a size problem. The sample is bounded for the same reason and
+/// the untruncated count travels with it.
+pub fn memory_model_hypothesis_gap(probe: &serde_json::Value) -> Option<serde_json::Value> {
+    // Twenty functions is already more than a reader acts on in one sitting,
+    // and the count below says how many there were.
+    const HYPOTHESIS_SAMPLE: usize = 20;
+
+    // A probe that did not run has not shown that the run assumed nothing, so
+    // it produces no entry here and says why on the payload instead. The
+    // reasons are the probe's, not this function's: no WP, no project, a
+    // Frama-C that would not start, a timeout.
+    if probe.get("ran").and_then(|ran| ran.as_bool()) != Some(true) {
+        return None;
+    }
+
+    // The parsed entries only. A keyed warning this server could not read is a
+    // sentinel with a null function and no clauses, and counting it here would
+    // report a separation nobody read as one WP assumed, under a reason that
+    // tells the caller to write requires clauses it has no text for. That case
+    // is memory_model_unchecked_gap's, which says the hypotheses are unknown.
+    let mut sample = parsed_hypothesis_entries(probe);
+    if sample.is_empty() {
+        return None;
+    }
+    let total = sample.len();
+    sample.truncate(HYPOTHESIS_SAMPLE);
+    let unparsed = unparsed_hypothesis_warnings(probe);
+    Some(json!({
+        "code": incomplete_code::WP_MEMORY_MODEL_HYPOTHESIS,
+        "reason": "WP's memory model assumed these separations to discharge this run's goals, and \
+                   emitted no obligation for any of them. A goal reported valid here is valid only \
+                   for callers that satisfy them.",
+        "function_count": total,
+        "functions": sample,
+        "functions_truncated": total > HYPOTHESIS_SAMPLE,
+
+        // Beside the parsed ones rather than mixed into them: WP printed this
+        // many more that the parser could not read, so the list above is
+        // incomplete in a way the count alone would not show.
+        "unparsed_warning_count": unparsed,
+
+        // Where the answer came from, because it is not where a reader of the
+        // rest of this payload would look. The socket never carries these.
+        //
+        // The producer's own word for it. Every producer sets the key, so there
+        // is no default here to go stale. See PROBE_READ_FROM_*.
+        "read_from": probe.get("read_from").cloned().unwrap_or(serde_json::Value::Null),
+    }))
+}
+
+/// Where a probe's hypotheses were read, in the producer's own words.
+///
+/// Two producers answer the same question by different means, and the reader
+/// used to paper over that with a default: run_wp and the sandbox spawn a
+/// frama-c with provers off over the printed AST, while the isolated CLI retry
+/// reads the warning out of output it already had, from runs that did have
+/// provers and from no extra process at all. Defaulting described the retry as
+/// a run that never happened, so each producer states its own.
+///
+/// Set by every producer that read anything, which is every arm that reaches
+/// frama-c. probe_absent below carries no such key, because a probe that never
+/// started read from nowhere; only memory_model_hypothesis_gap looks, and it
+/// looks only at a probe whose ran flag is true.
+pub const PROBE_READ_FROM_SEPARATE_RUN: &str = "a separate frama-c run with provers off";
+pub const PROBE_READ_FROM_RETRY_OUTPUT: &str = "the isolated retry's own captured output";
+
+/// The shape every producer writes when the probe did not read anything.
+///
+/// Twelve sites spelled this literal before it had a name, across three
+/// modules, and the readers below guess nothing: a producer that omitted
+/// "hypotheses" or spelled "ran" differently was invisible until a gap reader
+/// silently dropped it. eva_config_absent is the same idiom for the same
+/// reason one module over.
+///
+/// nothing_was_proved is the flag rather than the sentence. The reader used to
+/// suppress its gap by comparing the reason against a list of exact strings,
+/// which coupled two modules through prose: a typo on either side turned a run
+/// that proved nothing into a report that goals were proved under unread
+/// assumptions, and the list was already missing the fourth such reason. The
+/// producer knows which case it is in, so it says so.
+pub fn probe_absent(reason: impl Into<String>, nothing_was_proved: bool) -> serde_json::Value {
+    json!({
+        "ran": false,
+        "reason": reason.into(),
+        "nothing_was_proved": nothing_was_proved,
+        "hypotheses": [],
+    })
+}
+
+/// A WP run whose memory-model assumptions nobody could read.
+///
+/// The other half of the entry above, and the half that matters more. WP
+/// proving every goal while the probe failed is a proof whose assumptions are
+/// unknown, and an empty hypothesis list would report it as a proof that
+/// assumed nothing. The two are told apart here rather than left to a reader
+/// noticing which fields the probe payload carries.
+///
+/// Silent when the caller wanted no WP, because there is then no proof for an
+/// assumption to own and every EVA-only check would otherwise carry this.
+pub fn memory_model_unchecked_gap(
+    probe: &serde_json::Value,
+    wanted: WantedAnalyses,
+) -> Option<serde_json::Value> {
+    if !wanted.wp {
+        return None;
+    }
+
+    // A probe that ran and parsed nothing is the other half of the split
+    // memory_model_hypothesis_gap makes. WP printed keyed memory-model warnings
+    // whose wording this server does not read, so the separations it assumed
+    // are unknown rather than absent, which is exactly what this code says.
+    // Silent when something did parse, because the entry above then carries the
+    // unread count beside the clauses it did read.
+    if probe.get("ran").and_then(|ran| ran.as_bool()) == Some(true) {
+        let unparsed = unparsed_hypothesis_warnings(probe);
+        if unparsed == 0 || has_parsed_hypothesis_entry(probe) {
+            return None;
+        }
+        return Some(json!({
+            "code": incomplete_code::WP_MEMORY_MODEL_UNCHECKED,
+            "reason": format!(
+                "WP printed {unparsed} memory-model hypothesis warning(s) whose wording this \
+                 server could not parse, so the separations it assumed are unknown rather than \
+                 absent. A goal reported valid here is not evidence that the model assumed \
+                 nothing."
+            ),
+            "probe_reason": "the probe ran and could not parse what WP printed",
+            "unparsed_warning_count": unparsed,
+            "exit_code": probe.get("exit_code").cloned().unwrap_or_else(|| json!(null)),
+        }));
+    }
+
+    // A probe skipped because WP itself did not run is not a second gap: the
+    // run already carries WP_NOT_RUN, and reporting both would say twice that
+    // nothing was proved. A run whose every target was a bare declaration is
+    // the same case reached differently: WP had no body to prove, so there is
+    // no proof for an unread assumption to undermine, and the sentence below
+    // would say goals were proved when none were. So is a failed reload.
+    //
+    // Read off the flag the producer set rather than off its prose. See
+    // probe_absent.
+    let reason = probe.get("reason").and_then(|value| value.as_str())?;
+    if probe
+        .get("nothing_was_proved")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    Some(json!({
+        "code": incomplete_code::WP_MEMORY_MODEL_UNCHECKED,
+
+        // Says the hypotheses are unknown rather than that goals were proved
+        // under them. Not every producer that reaches here proved anything: the
+        // isolated CLI retry reports ran:false when no attempt exited 0, and
+        // frama-c exits 0 with unproved goals, so a nonzero exit on every
+        // attempt is a run that errored rather than one that proved. Claiming a
+        // proof there is the false statement this payload exists to avoid, and
+        // the sentence below is true in both cases.
+        "reason": format!(
+            "WP's memory-model hypotheses are unknown for this run: the probe could not read \
+             them ({reason}). A goal reported valid here is not evidence that the model \
+             assumed nothing."
+        ),
+        "probe_reason": reason,
+        "exit_code": probe.get("exit_code").cloned().unwrap_or_else(|| json!(null)),
+    }))
 }
 
 /// Gaps carried by rows of the property table itself, which is where EVA

--- a/src/mcp/checkgaps.rs
+++ b/src/mcp/checkgaps.rs
@@ -162,6 +162,7 @@ pub mod incomplete_code {
     pub const LEMMA_NOT_PROVED: &str = "LEMMA_NOT_PROVED";
     pub const ASSUMED_VALID: &str = "ASSUMED_VALID";
     pub const ASSUMED_CALLEE_CONTRACT: &str = "ASSUMED_CALLEE_CONTRACT";
+    pub const INDIRECT_CALL_UNRESOLVED: &str = "INDIRECT_CALL_UNRESOLVED";
     pub const UNCONSTRAINED_ASSIGNS: &str = "UNCONSTRAINED_ASSIGNS";
     pub const RESULT_UNCONSTRAINED: &str = "RESULT_UNCONSTRAINED";
     pub const UNPROVED_ASSUMPTION: &str = "UNPROVED_ASSUMPTION";
@@ -193,6 +194,7 @@ pub mod incomplete_code {
         LEMMA_NOT_PROVED,
         ASSUMED_VALID,
         ASSUMED_CALLEE_CONTRACT,
+        INDIRECT_CALL_UNRESOLVED,
         UNCONSTRAINED_ASSIGNS,
         RESULT_UNCONSTRAINED,
         UNPROVED_ASSUMPTION,
@@ -378,6 +380,15 @@ pub fn gap_guidance(code: &str) -> serde_json::Value {
             "Two emitters ruled opposite ways on this property, so the consolidated verdict cannot \
              be trusted in either direction. Find the disagreement before writing any annotation \
              that rests on it; a contract built on an inconsistent property proves nothing."
+        }
+        incomplete_code::INDIRECT_CALL_UNRESOLVED => {
+            "Two annotations close this, and one alone does not. Name the callee set at the call \
+             site, as in a calls clause listing every function the pointer may hold, which stops \
+             WP assuming it can reach anything including the caller itself. Then constrain the \
+             pointer in the function's own contract, because the calls clause leaves a goal \
+             proving the pointer really holds one of those functions and nothing has said so yet. \
+             Raising the prover timeout closes neither: the open goals are unprovable rather than \
+             slow."
         }
         _ => return serde_json::Value::Null,
     };
@@ -736,6 +747,28 @@ fn proofread_finding_gaps(
                     )),
                     "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
                     "assigns_target": finding.get("assigns_target").cloned().unwrap_or_else(|| json!(null)),
+                }));
+                continue;
+            }
+            if category == Some("unresolved_call") {
+                // Not gated on any goal. WP's answer to a call it cannot name
+                // is to assume the worst callee set, which leaves goals that
+                // look like prover timeouts, so the run this has to fire on is
+                // exactly the one whose goals all carry another code already.
+                incomplete.push(json!({
+                    "code": incomplete_code::INDIRECT_CALL_UNRESOLVED,
+                    "reason": finding.get("message").cloned().unwrap_or_else(|| json!(
+                        "A call names no callee, so WP assumed it could reach any function."
+                    )),
+                    "function": finding.get("function").cloned().unwrap_or_else(|| json!(null)),
+                    "callee_expression": finding.get("callee_expression").cloned().unwrap_or_else(|| json!(null)),
+                    "stmt_id": finding.get("stmt_id").cloned().unwrap_or_else(|| json!(null)),
+                    "source_location": finding.get("source_location").cloned().unwrap_or_else(|| json!(null)),
+
+                    // Says plainly that this reads the call shape and not the
+                    // annotation, so a reader who has already written the
+                    // clause is not left thinking it did not take.
+                    "reports": "the call shape, not whether a calls clause is present",
                 }));
                 continue;
             }

--- a/src/mcp/project.rs
+++ b/src/mcp/project.rs
@@ -1009,6 +1009,40 @@ impl FramaCMcpServer {
         Ok(json!(globals))
     }
 
+    /// The functions a proof of this program still needs a contract for.
+    ///
+    /// Whole-program and answered in one request, because the alternative is
+    /// one getContractContext per defined function: a thousand round trips for
+    /// a payload of a few hundred rows, which is one action one bounded payload
+    /// inverted.
+    ///
+    /// A list rather than a check gap. A function two hops down with no
+    /// contract is not a gap in any caller's proof, since WP used the direct
+    /// callee's contract and ASSUMED_CALLEE_CONTRACT already covers the case
+    /// where that contract is vacuous. What this answers is what a person still
+    /// has to write, which is a work list rather than a verdict.
+    async fn list_contract_frontier_payload(&self) -> Result<serde_json::Value, McpError> {
+        (self.require_client().await?)
+            .get("plugins.ast-utils.getContractFrontier", json!(null))
+            .await
+            .map_err(|error| {
+                // What actually happened first, then the likely cause. A
+                // request this plug-in does not register is the common failure
+                // and worth naming, but a timeout, a dropped connection and a
+                // plug-in error all arrive here too, and reporting those as a
+                // version mismatch sends the reader to reinstall something that
+                // is already correct.
+                McpError::internal_error(
+                    format!(
+                        "plugins.ast-utils.getContractFrontier failed: {error}. If the request is \
+                         unknown, the ast-utils plug-in installed in this switch is older than \
+                         this server"
+                    ),
+                    None,
+                )
+            })
+    }
+
     async fn list_declarations_payload(&self) -> Result<serde_json::Value, McpError> {
         (self.require_client().await?)
             .get("kernel.ast.getDeclarations", json!(null))
@@ -1128,6 +1162,7 @@ impl FramaCMcpServer {
             ListKind::Declarations => self.list_declarations_payload().await?,
             ListKind::Sandboxes => self.sandbox_list_payload().await?,
             ListKind::Conclusions => self.conclusions_payload(params.status, params.function).await?,
+            ListKind::ContractFrontier => self.list_contract_frontier_payload().await?,
         };
         Ok(json_result(result))
     }

--- a/src/mcp/receipt.rs
+++ b/src/mcp/receipt.rs
@@ -257,6 +257,29 @@ pub struct ProofReceiptRequest<'a> {
     pub goals_status_source: &'a str,
     pub reported: serde_json::Value,
     pub properties: &'a HashMap<String, serde_json::Value>,
+
+    /// The printed AST this run already has in hand, when the caller printed it
+    /// for another purpose.
+    ///
+    /// printSource ships the whole AST over the socket and is given sixty
+    /// seconds for it, so a caller that has already paid once should not pay
+    /// again. run_wp is that caller: it prints to give the memory-model probe
+    /// the program the proofs actually ran against, and the digest below wants
+    /// the identical bytes. Sharing them is not only cheaper, it is what makes
+    /// the receipt's digest and the probe describe one AST rather than two
+    /// prints that a concurrent injection could have separated.
+    ///
+    /// None means print it here, which is what every caller that has no copy
+    /// does.
+    pub ast_source: Option<&'a str>,
+
+    /// The digest of that AST, when a nested run already computed it.
+    ///
+    /// check is the caller: it runs WP through run_wp, which prints the AST
+    /// once for its memory-model probe and digests it for its own receipt, so
+    /// by the time check builds its receipt the answer is already in the WP
+    /// payload. Taking it means one print per check instead of two.
+    pub ast_digest: Option<&'a str>,
 }
 
 /// The same thing once the server has resolved what it alone can: the
@@ -374,6 +397,14 @@ pub fn incomplete_digest(incomplete: &serde_json::Value) -> serde_json::Value {
     })
 }
 
+/// What a receipt records where a field cannot describe the run at all.
+///
+/// The isolated CLI retry proves the files on disk in a separate process while
+/// the live AST here carries whatever this session injected, so neither the
+/// contracts nor the AST digest describe it. Spelled once, because a typo in
+/// any of the comparisons against it fails open.
+pub const ISOLATED_RETRY_NO_AST: &str = "unavailable_isolated_cli_retry";
+
 /// Why a receipt carries no EVA configuration.
 ///
 /// Same argument as ast_digest_unavailable_reason below: a receipt travels and
@@ -382,6 +413,28 @@ pub fn incomplete_digest(incomplete: &serde_json::Value) -> serde_json::Value {
 /// and four different runs collapse into one shape.
 pub fn eva_config_absent(reason: &str) -> serde_json::Value {
     json!({"ran": false, "reason": reason})
+}
+
+/// One printed AST, as the receipt records it: a digest, or the reason there is
+/// none.
+///
+/// Shared because the supplied-text arm and the print arm must agree exactly.
+/// A receipt that digests differently depending on whether the caller happened
+/// to have a print in hand is a receipt that cannot be compared, which is the
+/// only thing a receipt is for.
+///
+/// Empty covers both a request that answered with something other than a
+/// string, which print_source reports as "", and a project with nothing in it.
+/// Neither is a digest, and telling them apart would mean print_source
+/// returning the raw Value, which no other caller wants.
+fn digest_of_printed_ast(text: &str) -> (serde_json::Value, serde_json::Value) {
+    if text.is_empty() {
+        return (serde_json::Value::Null, json!("request_answered_empty"));
+    }
+    (
+        json!(sha256_hex(canonical_ast_for_digest(text).as_bytes())),
+        serde_json::Value::Null,
+    )
 }
 
 /// Not a pure function of its input: a null ast_digest draws a fresh nonce, so
@@ -587,8 +640,8 @@ impl FramaCMcpServer {
         // session, which that run never saw, so snapshotting it would put a
         // contract in the receipt that is not the one proved. The same reason
         // that path already reports its goals source as unavailable.
-        if goals_status_source == "unavailable_isolated_cli_retry" {
-            return json!("unavailable_isolated_cli_retry");
+        if goals_status_source == ISOLATED_RETRY_NO_AST {
+            return json!(ISOLATED_RETRY_NO_AST);
         }
 
         let functions = wp_config
@@ -700,16 +753,45 @@ impl FramaCMcpServer {
     /// printSource runs the printer over the whole AST and ships the result
     /// back over the socket. On a large project ten seconds expires, and the
     /// failure is silent: every receipt from then on carries a fresh nonce.
+    ///
+    /// A caller that already printed the AST hands the text over instead, and
+    /// then no request is issued at all. See ProofReceiptRequest::ast_source.
     pub async fn proof_receipt_ast_digest(
         &self,
         client: Option<&FramaCClient>,
         goals_status_source: &str,
+        ast_source: Option<&str>,
+        ast_digest: Option<&str>,
     ) -> (serde_json::Value, serde_json::Value) {
-        if goals_status_source == "unavailable_isolated_cli_retry" {
-            return (
-                json!("unavailable_isolated_cli_retry"),
-                serde_json::Value::Null,
-            );
+        if goals_status_source == ISOLATED_RETRY_NO_AST {
+            return (json!(ISOLATED_RETRY_NO_AST), serde_json::Value::Null);
+        }
+
+        // A digest the caller already computed over this AST. check reaches
+        // here through run_wp, which printed the AST for its memory-model probe
+        // and digested it for its own receipt; nothing between the two mutates
+        // the AST, so printing it again would ship the whole thing over the
+        // socket a second time under a sixty-second budget, on the tool agents
+        // call most.
+        //
+        // The marker above is not a digest, and a nested receipt carrying it is
+        // not an answer this one can reuse. check forwards its caller's
+        // provers, so run_wp routes the run to the isolated CLI retry and
+        // records that its receipt cannot describe an AST. check still can: it
+        // is connected to the project that retry ran beside, and before this
+        // argument existed it printed and digested exactly that. Accepting the
+        // marker here would put it in a field that could have carried a real
+        // digest, and two checks over different programs would then agree on
+        // it.
+        if let Some(digest) = ast_digest.filter(|digest| *digest != ISOLATED_RETRY_NO_AST) {
+            return (json!(digest), serde_json::Value::Null);
+        }
+
+        // Checked before the reload-failed arm below only because a supplied
+        // text cannot coexist with one: a caller has a print in hand exactly
+        // when its run reached the AST.
+        if let Some(source) = ast_source {
+            return digest_of_printed_ast(source);
         }
 
         // A failed reload leaves Frama-C's previous project resident. Its AST
@@ -734,17 +816,7 @@ impl FramaCMcpServer {
             },
         };
         match client.print_source().await {
-            Ok(text) if !text.is_empty() => (
-                json!(sha256_hex(canonical_ast_for_digest(&text).as_bytes())),
-                serde_json::Value::Null,
-            ),
-
-            // Empty covers both a request that answered with something other
-            // than a string, which print_source reports as "", and a project
-            // with nothing in it. Neither is a digest, and telling them apart
-            // would mean print_source returning the raw Value, which no other
-            // caller wants.
-            Ok(_) => (serde_json::Value::Null, json!("request_answered_empty")),
+            Ok(text) => digest_of_printed_ast(&text),
 
             // One reason covers the plug-in being absent and the print
             // outrunning its budget, because the client reports both as a
@@ -772,6 +844,8 @@ impl FramaCMcpServer {
             goals_status_source,
             reported,
             properties,
+            ast_source,
+            ast_digest,
         } = request;
 
         // Probed per receipt, deliberately, and not cached across them. Doing
@@ -802,7 +876,8 @@ impl FramaCMcpServer {
             .proof_receipt_contracts(&wp_config, goals_status_source)
             .await;
         let (ast_digest, ast_digest_unavailable_reason) =
-            self.proof_receipt_ast_digest(client, goals_status_source).await;
+            self.proof_receipt_ast_digest(client, goals_status_source, ast_source, ast_digest)
+                .await;
         let project_load = self
             .main_frama_c_state
             .lock()

--- a/src/mcp/selfcheck.rs
+++ b/src/mcp/selfcheck.rs
@@ -36,6 +36,10 @@ pub const AST_UTILS_REQUESTS: &[AstUtilsSpec] = &[
     ("plugins.ast-utils.getCilContext", ProbeKind::Get, true),
     ("plugins.ast-utils.getContractContext", ProbeKind::Get, true),
 
+    // Whole-program, so it takes null rather than a function name and the
+    // default probe payload is already right for it.
+    ("plugins.ast-utils.getContractFrontier", ProbeKind::Get, true),
+
     // Backs list {kind: "declarations"} through clause_origin_payload. It was
     // absent here while the count assertions all read this table's own length,
     // so they compared the constant against itself and a plug-in too old to

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2330,6 +2330,12 @@ impl Drop for MainFramaCState {
 /// instead of a silently weaker answer. Every one of them fails open when a
 /// field is forgotten, which is why the discipline is stated once here rather
 /// than argued four times.
+///
+/// Serialize only. The memory-model probe takes its options from the value the
+/// session already holds, read under the WP lock that makes them agree with
+/// the goals, so nothing reads one back out of a receipt and a Deserialize
+/// here would be an unused door into a struct whose whole point is that every
+/// reader of it is a compile error away from the truth.
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize)]
 pub struct ProjectLoadOptions {
     pub include_paths: Vec<String>,
@@ -3063,6 +3069,12 @@ impl FramaCMcpServer {
         source_files: Vec<String>,
         wp_goals: &[serde_json::Value],
         report_function: Option<&str>,
+
+        // What the caller's memory-model probe was run over, when it got that
+        // far. Passing it means one printSource for the run instead of two, and
+        // means the digest and the probe describe the same AST rather than two
+        // prints with a window between them.
+        ast_source: Option<&str>,
     ) -> Result<(), McpError> {
         // The raw rows, not fetch_properties: a receipt keys goals by their own
         // identity and never reads the ordered-instance vacuity warning, so the
@@ -3089,6 +3101,8 @@ impl FramaCMcpServer {
                     "wp_timeout_triage": response["wp_timeout_triage"].clone(),
                 }),
                 properties: &receipt_properties,
+                ast_source,
+                ast_digest: None,
             })
             .await;
         Ok(())
@@ -3419,22 +3433,43 @@ impl FramaCMcpServer {
         )
         .await?;
 
+        // One index over the fetched rows, read twice below. Both answers are
+        // per target name and both used to walk the whole array for each one,
+        // which is the same scan written twice.
+        let by_name: HashMap<&str, &serde_json::Value> = funcs
+            .iter()
+            .filter_map(|f| f.get("name").and_then(|v| v.as_str()).map(|name| (name, f)))
+            .collect();
+
         // Resolve every marker before starting any proof: a miss part-way
         // through would otherwise leave the sandbox holding goals from a
         // half-run, indistinguishable from a complete one.
         let decl_markers = target_names
             .iter()
             .map(|function| {
-                funcs
-                    .iter()
-                    .find_map(|f| {
-                        let name = f.get("name").and_then(|v| v.as_str());
-                        let decl = f.get("decl").and_then(|v| v.as_str());
-                        (name == Some(function.as_str())).then(|| decl.map(str::to_string))?
-                    })
+                by_name
+                    .get(function.as_str())
+                    .and_then(|f| f.get("decl").and_then(|v| v.as_str()).map(str::to_string))
                     .ok_or_else(|| McpError::from(FramaCError::FunctionNotFound(function.clone())))
             })
             .collect::<Result<Vec<_>, _>>()?;
+
+        // The defined subset, for the memory-model probe alone, filtered for
+        // the same reason the main path filters its own targets: -wp-fct on a
+        // declared-but-undefined name is "no function 'f'" and a Frama-C that
+        // aborts before printing anything. A sandbox can hold a bare
+        // declaration, since extraction leaves a callee that carries an
+        // explicit assigns as one, and a run aimed at that name would otherwise
+        // turn every probe into WP_MEMORY_MODEL_UNCHECKED.
+        let probe_functions = target_names
+            .iter()
+            .filter(|function| {
+                by_name.get(function.as_str()).is_some_and(|f| {
+                    f.get("defined").and_then(|v| v.as_bool()).unwrap_or(false)
+                })
+            })
+            .cloned()
+            .collect::<Vec<_>>();
 
         // Read before any proof is scheduled: after the drain the average is
         // largely this run's own provers. See host_load_per_cpu.
@@ -3470,15 +3505,49 @@ impl FramaCMcpServer {
             host_load,
         });
 
-        // The property table read here is the sandbox's own, which is the only
-        // difference from the main path.
-        self.attach_run_wp_receipt(
-            &client,
-            &mut response,
+        // The same probe the main path runs, because a sandbox hands back a
+        // proof and a receipt like any other run and an unstated separation
+        // does not care which instance proved it. Three differences from the
+        // main path, all of them properties of what a sandbox is.
+        //
+        // Default project options, matching what sandbox_frama_c_command_line
+        // passes the sandbox process itself, which is nothing. Whenever that
+        // command line gains the project's machine model, this call needs the
+        // same value or the probe silently answers under a different model.
+        //
+        // The bare target names, not the prefixed ones, and only the defined
+        // ones. The sandbox process knows its functions by their own names, and
+        // -wp-fct takes those; the prefixed form is this server's addressing,
+        // not Frama-C's. See probe_functions above for why a declaration is
+        // kept off that command line.
+        //
+        // And run before the receipt, which consumes source_files.
+        //
+        // Over this sandbox's printed AST rather than its sandbox.c, and the
+        // sandbox is where that matters most: sandbox.c is written once, at
+        // creation, and the whole point of a sandbox is to iterate ACSL into
+        // the AST above it. Probing the file would describe the extraction as
+        // it was before the first annotation landed.
+        //
+        // The property table the receipt reads is the sandbox's own, which is
+        // the only difference from the main path.
+        //
+        // Defaults, matching what sandbox_frama_c_command_line passes the
+        // sandbox's own process. The narrowing to what a printed AST can use
+        // happens inside the probe rather than here, so if that command line
+        // ever gains the project's machine model this call inherits the same
+        // treatment instead of needing to be remembered.
+        self.attach_probe_and_receipt(crate::mcp::server::analysis::ProbeAndReceipt {
+            client: &client,
+            response: &mut response,
+            project_options: &ProjectLoadOptions::default(),
+            rte: true,
+            probe_functions: &probe_functions,
+            temp_dir_prefix: "frama-c-mcp-sandbox-probe-ast-",
             source_files,
-            &wp_goals,
+            wp_goals: &wp_goals,
             report_function,
-        )
+        })
         .await?;
         Ok(json_result(response))
     }
@@ -4544,7 +4613,7 @@ use receipt::{eva_config_absent, incomplete_digest, proof_receipt_goals, ProofRe
 pub mod eacsl;
 #[path = "wpcli.rs"]
 pub mod wpcli;
-use wpcli::{run_wp_counter_examples, run_why3_dump, run_wp_print, IsolatedWpRetry};
+use wpcli::{run_wp_counter_examples, run_wp_memory_model_probe, run_why3_dump, run_wp_print, IsolatedWpRetry};
 use eacsl::run_e_acsl_counterexample;
 
 #[path = "selfcheck.rs"]

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -701,12 +701,17 @@ pub enum ListKind {
     Declarations,
     Sandboxes,
     Conclusions,
+
+    // Not a doc comment, for the reason ContextKind below records: schemars
+    // turns an annotated variant into a oneOf of consts and that changes the
+    // published schema. The functions a proof still needs a contract for.
+    ContractFrontier,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListParams {
     /// List kind: "files", "functions", "globals", "declarations",
-    /// "sandboxes", or "conclusions".
+    /// "sandboxes", "conclusions", or "contract_frontier".
     pub kind: ListKind,
     /// Filter conclusions by status: "verified" | "failed" | "unsound" |
     /// "blocked_on_callee" | "in_progress".

--- a/src/mcp/wpclass.rs
+++ b/src/mcp/wpclass.rs
@@ -1771,6 +1771,339 @@ pub fn wp_backend_diagnosis(
     })
 }
 
+/// The memory-model hypotheses WP assumed while discharging this run's goals.
+///
+/// WP's Typed model is sound for a function only under separation conditions it
+/// does not derive: a pointer formal and a global address in one frame are
+/// distinct locations to the model whether or not the caller keeps them apart.
+/// WP states them and proves the function anyway. Measured on Frama-C 32.1,
+/// "void two(int *p) { g = 1; *p = 2; }" with a contract over both locations
+/// proves every goal, and a caller passing "&g" proves too, while at run time
+/// the postcondition is false. So a goal record cannot carry this: every goal
+/// is valid, and the only evidence is the warning.
+///
+/// Read off the message stream for the same reason "wp_backend_diagnosis" is,
+/// and it is the whole reason "drain_messages" keeps WARNING records.
+///
+/// Two matchers, in that order, and both require the record to be WP's. The
+/// structural one is a "category" of "hypothesis", which is what the log record
+/// getLogs returns carries for a warning emitted under a warning key. Measured
+/// on 32.1 that is not this warning: "-wp-warn-key hypothesis=inactive" leaves
+/// it in place and only "-wp-no-warn-memory-model" removes it, so the category
+/// is absent and the text matcher is what fires. The structural branch is kept
+/// because it costs one comparison and a later Frama-C giving this warning a
+/// key would otherwise be a silent regression to prose matching. Each entry
+/// says which branch produced it, so an empty result and a missed category are
+/// different answers.
+///
+/// Ordered by function name rather than by arrival. The result reaches a
+/// receipt through the incomplete[] digest, which hashes this array as it
+/// stands, and WP's warning order is not a property of the program.
+pub fn wp_memory_model_hypotheses(messages: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    collect_memory_model_hypotheses(messages)
+}
+
+/// A hypothesis entry's function, borrowed.
+///
+/// as_str already yields a slice of the entry and every caller only reads it,
+/// so the owned form allocated and freed twice per comparison for an ordering
+/// that never needed one.
+fn hypothesis_function_name(entry: &serde_json::Value) -> &str {
+    entry.get("function").and_then(|value| value.as_str()).unwrap_or_default()
+}
+
+/// Two readings of the same program's hypotheses, merged.
+///
+/// For the isolated retry, which runs one frama-c per prover and can have
+/// several die at different points, each printing a different prefix of what
+/// WP had to say. Keeping one reading drops what another got further to reach,
+/// and keeping every attempt's raw output to parse at the end grows with the
+/// number of attempts times the size of a WP log.
+///
+/// The rules are the collector's, applied to records instead of to text.
+/// Deduplicated by function, because a hypothesis is a property of the
+/// function and the model rather than of the prover an attempt used.
+///
+/// Where both readings name one function the longer wins, not the first. An
+/// attempt that died inside a block printed a prefix of it, so two readings of
+/// one function are not interchangeable, and taking the first is the same
+/// under-report this merge exists to prevent, one level down. The whole entry
+/// is replaced rather than the clause lists unioned, because hypothesis_count,
+/// the bounded sample and the truncation flag are three views of one parse and
+/// mixing two parses makes them disagree.
+///
+/// The unparsed count is the larger of the two rather than the sum, because
+/// every attempt analyses the same program and prints the same unreadable
+/// warnings, so adding them would report one warning as several.
+///
+/// Sorted by name with the sentinel last, because this array is hashed into
+/// the receipt through incomplete[] and which prover died first is not a
+/// property of the program.
+pub fn merge_memory_model_hypotheses(
+    into: Vec<serde_json::Value>,
+    from: Vec<serde_json::Value>,
+) -> Vec<serde_json::Value> {
+    let unparsed_of = |entries: &[serde_json::Value]| -> u64 {
+        entries
+            .iter()
+            .filter_map(|entry| {
+                entry.get("unparsed_warning_count").and_then(serde_json::Value::as_u64)
+            })
+            .sum()
+    };
+    let unparsed = unparsed_of(&into).max(unparsed_of(&from));
+    let named =
+        |entry: &serde_json::Value| entry.get("function").is_some_and(|name| !name.is_null());
+
+    let clauses = |entry: &serde_json::Value| -> u64 {
+        entry.get("hypothesis_count").and_then(serde_json::Value::as_u64).unwrap_or(0)
+    };
+    let mut merged: Vec<serde_json::Value> = into.into_iter().filter(named).collect();
+    for entry in from.into_iter().filter(named) {
+        match merged.iter_mut().find(|kept| kept.get("function") == entry.get("function")) {
+            Some(kept) if clauses(&entry) > clauses(kept) => *kept = entry,
+            Some(_) => {}
+            None => merged.push(entry),
+        }
+    }
+    merged
+        .sort_by(|left, right| hypothesis_function_name(left).cmp(hypothesis_function_name(right)));
+    if unparsed > 0 {
+        merged.push(json!({
+            "function": null,
+            "hypotheses": [],
+            "hypothesis_count": 0,
+            "hypotheses_truncated": false,
+            "unparsed_warning_count": unparsed,
+            "source_location": serde_json::Value::Null,
+            "matched_by": "log_category",
+        }));
+    }
+    merged
+}
+
+/// The same reading, over the raw output of a command-line Frama-C run.
+///
+/// This is the entry point that has input in practice. The socket never
+/// carries the warning, so the record-level reader above answers empty on
+/// every real session and is kept for the one path that does see WP warnings
+/// as records, and as the place the record shape is pinned by tests.
+///
+/// The text arrives as one blob rather than as log records, so it is wrapped in
+/// a single synthetic record carrying WP's plug-in name. The block scoping
+/// inside does the rest: a command-line run prints every function's block into
+/// one stream, and the parse is per block rather than per record.
+pub fn wp_memory_model_hypotheses_in_text(text: &str) -> Vec<serde_json::Value> {
+    collect_memory_model_hypotheses(&[json!({
+        "kind": "WARNING",
+        "plugin": "wp",
+        "message": text,
+    })])
+}
+
+fn collect_memory_model_hypotheses(messages: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    // The fixed prefix WP prints before the function name. Unlike the abort
+    // wording, this is not a label drawn from a table of goal kinds: it is
+    // emitted once per function, and the function's own name follows it in
+    // quotes, so the match identifies a function rather than a class of goals.
+    const MARKER: &str = "Memory model hypotheses for function";
+
+    let mut found: Vec<serde_json::Value> = Vec::new();
+    let mut unparsed = 0usize;
+    let mut unparsed_source = json!(null);
+    let mut unparsed_matched_by = "log_category";
+
+    for message in messages {
+        // Both branches require WP. Another plug-in quoting this text in a
+        // message of its own is not a statement about WP's memory model, and
+        // another plug-in's "hypothesis" category is its own.
+        if message.get("plugin").and_then(|value| value.as_str()) != Some("wp") {
+            continue;
+        }
+        let text = message
+            .get("message")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        let by_category =
+            message.get("category").and_then(|value| value.as_str()) == Some("hypothesis");
+        let blocks = hypothesis_blocks(text, MARKER);
+        if !by_category && blocks.is_empty() {
+            continue;
+        }
+        let matched_by = if by_category { "log_category" } else { "message_text" };
+
+        // A record matched on category alone whose wording this cannot parse is
+        // counted rather than dropped, because dropping it would be the silence
+        // the fail-loud rule forbids, and counted rather than listed because
+        // repeats of it would otherwise consume the bounded sample below.
+        if blocks.is_empty() {
+            unparsed += 1;
+            if unparsed == 1 {
+                unparsed_source = message.get("source").cloned().unwrap_or_else(|| json!(null));
+                unparsed_matched_by = matched_by;
+            }
+            continue;
+        }
+
+        for (function, block) in blocks {
+            // One entry per function. WP prints this once per function per run,
+            // and a check drains once, so a repeat here is a second run_wp in
+            // the same call rather than a second hypothesis.
+            if found
+                .iter()
+                .any(|entry| entry.get("function").and_then(|f| f.as_str()) == Some(&*function))
+            {
+                continue;
+            }
+            let (hypotheses, total) = hypothesis_clauses(&block);
+            found.push(json!({
+                "function": function,
+                "hypotheses": hypotheses,
+                "hypothesis_count": total,
+                "hypotheses_truncated": total > hypotheses.len(),
+                "source_location": message.get("source").cloned().unwrap_or_else(|| json!(null)),
+                "matched_by": matched_by,
+            }));
+        }
+    }
+
+    found.sort_by(|left, right| {
+        hypothesis_function_name(left).cmp(hypothesis_function_name(right))
+    });
+
+    if unparsed > 0 {
+        found.push(json!({
+            "function": null,
+            "hypotheses": [],
+            "hypothesis_count": 0,
+            "hypotheses_truncated": false,
+            "unparsed_warning_count": unparsed,
+            "source_location": unparsed_source,
+            "matched_by": unparsed_matched_by,
+        }));
+    }
+    found
+}
+
+/// Every hypothesis block in one warning, as (function, block text) pairs.
+///
+/// Scoped to the block rather than to the record. A clause line anywhere else
+/// in the message is not a hypothesis, and a record carrying the marker twice
+/// would otherwise pair the first function with every clause in it.
+///
+/// The block runs from the marker to the closing "*/" of the behavior comment
+/// WP prints, or to the next marker when there is no closing token, so a
+/// truncated message yields the clauses it does carry rather than nothing.
+fn hypothesis_blocks(text: &str, marker: &str) -> Vec<(String, String)> {
+    let mut blocks = Vec::new();
+    let mut rest = text;
+    while let Some(at) = rest.find(marker) {
+        let after = &rest[at + marker.len()..];
+        let Some(function) = quoted_name(after) else {
+            rest = after;
+            continue;
+        };
+        let stop = match (after.find("*/"), after.find(marker)) {
+            (Some(close), Some(next)) => close.min(next),
+            (Some(close), None) => close,
+            (None, Some(next)) => next,
+            (None, None) => after.len(),
+        };
+        blocks.push((function, after[..stop].to_string()));
+        rest = &after[stop..];
+    }
+    blocks
+}
+
+/// The name between the first pair of single quotes.
+///
+/// Returns None rather than a guess when the shape is not the one measured,
+/// which is what makes a category-only match visible in the payload instead of
+/// inventing a name.
+fn quoted_name(text: &str) -> Option<String> {
+    let open = text.find('\'')?;
+    let rest = &text[open + 1..];
+    let close = rest.find('\'')?;
+    let name = &rest[..close];
+    if name.is_empty() {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+/// Where a clause keyword starts in a collapsed segment, at a word boundary.
+///
+/// A boundary check rather than a bare find, so an identifier ending in one of
+/// these words does not open a clause that then swallows the text before it.
+fn clause_keyword_at(text: &str, keyword: &str) -> Option<usize> {
+    let mut from = 0usize;
+    while let Some(at) = text[from..].find(keyword) {
+        let at = from + at;
+        let boundary = at == 0
+            || text[..at]
+                .chars()
+                .next_back()
+                .is_some_and(|previous| !previous.is_alphanumeric() && previous != '_');
+        if boundary {
+            return Some(at);
+        }
+        from = at + keyword.len();
+    }
+    None
+}
+
+/// The clause list of one hypothesis block, with the untruncated count.
+///
+/// Split on the statement terminator rather than on lines, because a clause WP
+/// wraps over two lines is one clause and a line-wise reader drops it silently.
+/// The behavior wrapper and the redeclared prototype are not clauses: pasting
+/// either into a contract is a syntax error, and the point of carrying the text
+/// is that a caller can paste it.
+fn hypothesis_clauses(block: &str) -> (Vec<String>, usize) {
+    // Bounded because this goes in a payload. WP prints one clause per
+    // separated pair, so a function with many pointer formals over many globals
+    // is quadratic in principle; measured runs print one or two. The caller
+    // reports the untruncated count beside the sample.
+    const CLAUSE_SAMPLE: usize = 16;
+
+    let mut clauses: Vec<String> = Vec::new();
+
+    // Dedup against every clause seen, not against the bounded sample. Reading
+    // the sample was wrong past its cap: once it stops growing, a repeat of a
+    // clause that never made it in is no longer recognised as a repeat, and the
+    // count reported beside the sample rises for text WP printed twice.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut total = 0usize;
+    for statement in block.split(';') {
+        // Collapse the whitespace WP uses to indent a wrapped clause, so a
+        // two-line clause reads as the one line a caller pastes.
+        let collapsed = statement.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        // The clause does not start the segment. WP opens the block with the
+        // function name and a "behavior wp_typed:" header, and the split leaves
+        // both glued to the first clause, so the keyword is found rather than
+        // matched at position zero. Earliest keyword, because the header
+        // precedes it; at a word boundary, so a predicate mentioning one of
+        // these words inside an identifier does not start a clause.
+        let Some(at) = ["requires ", "ensures ", "assigns "]
+            .iter()
+            .filter_map(|keyword| clause_keyword_at(&collapsed, keyword))
+            .min()
+        else {
+            continue;
+        };
+        let clause = format!("{};", &collapsed[at..]);
+        if !seen.insert(clause.clone()) {
+            continue;
+        }
+        total += 1;
+        if clauses.len() < CLAUSE_SAMPLE {
+            clauses.push(clause);
+        }
+    }
+    (clauses, total)
+}
+
 pub fn wp_failure_kind_from_tasks(tasks: &serde_json::Value, triage: &serde_json::Value) -> &'static str {
     let triage_kind = triage
         .get("kind")

--- a/src/mcp/wpcli.rs
+++ b/src/mcp/wpcli.rs
@@ -1,13 +1,23 @@
 //! Running Frama-C as a command line rather than through the server socket.
 //!
-//! Four things need a fresh process: printing a WP goal, dumping Why3 output,
-//! asking for counter-examples, and retrying a proof under one prover at a
-//! time. All four exist because the session's WP settings are process state,
-//! so applying them to answer one question would change what every later
-//! request in that session proves. A separate process answers the question and
-//! takes its settings with it when it exits.
+//! Five things need a fresh process: printing a WP goal, dumping Why3 output,
+//! asking for counter-examples, retrying a proof under one prover at a time,
+//! and reading the memory-model hypotheses WP took. The first four exist
+//! because the session's WP settings are process state, so applying them to
+//! answer one question would change what every later request in that session
+//! proves. A separate process answers the question and takes its settings with
+//! it when it exits.
+//!
+//! The fifth is different and stronger: the hypotheses are not reachable over
+//! the socket at any cost. WP emits them from its batch entry point, and the
+//! server request that runs proofs never calls that code. See
+//! run_wp_memory_model_probe.
 
 use super::*;
+use crate::mcp::server::receipt::ISOLATED_RETRY_NO_AST;
+use crate::mcp::server::checkgaps::{
+    probe_absent, PROBE_READ_FROM_RETRY_OUTPUT, PROBE_READ_FROM_SEPARATE_RUN,
+};
 
 /// One isolated CLI retry: which files to load, what to prove in them, and
 /// under which provers.
@@ -43,6 +53,29 @@ impl FramaCMcpServer {
             scope,
         } = retry;
         let mut attempts = Vec::new();
+
+        // Accumulated across provers, because the combined text below is per
+        // attempt and dies with its iteration. Every attempt is a batch frama-c
+        // over the same files under the same model, so they print the same
+        // hypotheses; the classifier deduplicates by function and the first
+        // attempt to supply them wins.
+        //
+        // Two lists rather than one, because which attempt printed a list is
+        // part of what the list is worth. A frama-c that exited 0 read the
+        // whole program, so its answer is complete even when it is empty; one
+        // that died printed whatever it reached before dying, which is true as
+        // far as it goes and may be short. Merging them lets a failing
+        // attempt's partial list travel under the ran flag that a later
+        // successful attempt raised, which is the one combination that claims
+        // more than was measured.
+        //
+        // The complete side is an Option rather than a Vec with a flag beside
+        // it, so "no attempt succeeded" and "an attempt succeeded and printed
+        // nothing" are different values rather than the same empty vector told
+        // apart by a second variable. It also stops the parser rerunning over
+        // every later attempt's output once an empty reading is in hand.
+        let mut complete: Option<Vec<serde_json::Value>> = None;
+        let mut partial: Vec<serde_json::Value> = Vec::new();
         let timeout = effective_wp_timeout(params)?;
         let par = effective_wp_par(params)?;
         // Frama-C spells the CLI values in lower case.
@@ -109,6 +142,37 @@ impl FramaCMcpServer {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             let combined = format!("{stdout}\n{stderr}");
+
+            // This path is the one place the hypotheses arrive for free. It
+            // runs a batch frama-c, which is where WP emits them, so unlike the
+            // main and sandbox paths no extra process is needed: the text is
+            // already in hand.
+            //
+            // Parsed whatever the exit status, reported as read only on a
+            // success. A hypothesis frama-c printed is one WP took, and losing
+            // it because the process later failed hides a real assumption; the
+            // ran flag beside it already says the reading is incomplete. This
+            // is the same split run_wp_memory_model_probe makes below, and the
+            // two paths answer the same question, so they answer it the same
+            // way.
+            if output.status.success() {
+                complete.get_or_insert_with(|| {
+                    crate::mcp::server::wpclass::wp_memory_model_hypotheses_in_text(&combined)
+                });
+            } else {
+                // Every failing attempt, merged as records rather than by
+                // keeping each attempt's raw output to parse at the end: two
+                // that die at different points print different prefixes of the
+                // same list, and holding all of them costs the number of
+                // attempts times the size of a WP log. merge_memory_model_
+                // hypotheses lives beside the parser because the rules are the
+                // parser's, and this is the one caller that has two readings of
+                // one program to reconcile.
+                partial = crate::mcp::server::wpclass::merge_memory_model_hypotheses(
+                    partial,
+                    crate::mcp::server::wpclass::wp_memory_model_hypotheses_in_text(&combined),
+                );
+            }
             let (proved_goals, total_goals) = parse_proved_goals(&combined);
             let attempt_triage = if combined.to_ascii_lowercase().contains("timeout") {
                 wp_timeout_triage(
@@ -189,6 +253,42 @@ impl FramaCMcpServer {
                 vec![],
                 "not_available_for_isolated_cli_retry",
             ),
+
+            // Under its own key, and the basis field above is left alone. That
+            // field describes where the findings came from, findings is still
+            // empty on this path, and renaming it would claim a derivation
+            // nobody made.
+            //
+            // Ran means at least one Frama-C invocation completed successfully,
+            // not merely that an attempt produced output. A failed run can
+            // print an empty diagnostic stream, which is not evidence that the
+            // model had no hypotheses. Its exit status is retained in
+            // wp_attempts for diagnosis. Anything a failed run did print is
+            // still carried below: an unread list and an empty one are told
+            // apart by this flag, not by dropping what was seen.
+            //
+            // The list comes from a successful attempt whenever there was one,
+            // including when that attempt printed nothing. A frama-c that
+            // exited 0 read the whole program, so its silence is a complete
+            // answer and outranks a partial list from an attempt that died. A
+            // failed attempt's list travels only when no attempt succeeded,
+            // where the ran flag beside it already says the reading is short.
+            "memory_model_probe": match complete {
+                Some(hypotheses) => json!({
+                    "ran": true,
+                    "reason": serde_json::Value::Null,
+                    "read_from": PROBE_READ_FROM_RETRY_OUTPUT,
+                    "model": params.model.as_deref().unwrap_or(default_wp_model()),
+                    "hypotheses": hypotheses,
+                }),
+                None => json!({
+                    "ran": false,
+                    "reason": "no isolated Frama-C attempt completed successfully; see wp_attempts for exit_code",
+                    "read_from": PROBE_READ_FROM_RETRY_OUTPUT,
+                    "model": params.model.as_deref().unwrap_or(default_wp_model()),
+                    "hypotheses": partial,
+                }),
+            },
         });
         let receipt = self
             .proof_receipt(None, ProofReceiptRequest {
@@ -198,7 +298,7 @@ impl FramaCMcpServer {
                 eva_config: eva_config_absent("tool_does_not_run_eva"),
                 goals: &[],
                 stable_scope: None,
-                goals_status_source: "unavailable_isolated_cli_retry",
+                goals_status_source: ISOLATED_RETRY_NO_AST,
                 reported: json!({
                     "failure_kind": response["failure_kind"].clone(),
                     "wp_timeout_triage": response["wp_timeout_triage"].clone(),
@@ -206,6 +306,12 @@ impl FramaCMcpServer {
                 }),
                 // No goals in an isolated CLI retry payload.
                 properties: &HashMap::new(),
+
+                // The isolated retry proves the files on disk in its own
+                // processes and never asks this server's Frama-C for anything,
+                // so there is no print in hand to share.
+                ast_source: None,
+                ast_digest: None,
             })
             .await;
         response["proof_receipt"] = receipt;
@@ -272,6 +378,158 @@ pub async fn run_wp_print(
             "status": "timeout",
             "timeout_seconds": EXTERNAL_COMMAND_BUDGET.as_secs(),
         }),
+    }
+}
+
+/// Ask a fresh Frama-C which memory-model hypotheses WP takes for these files.
+///
+/// A fifth thing that needs its own process, and for a harder reason than the
+/// four above: this one cannot be asked over the socket at all. WP emits the
+/// hypotheses from "do_wp_report", which runs inside the batch entry point
+/// registered with "Boot.Main.extend"; the server request "startProofs" in
+/// wpApi.ml reaches "VC.command" and never touches MemoryContext. Verified by
+/// reading frama-c-wp 33.0's own sources, and measured: a check that proves
+/// every goal over a file whose warning the command line prints receives an
+/// empty message stream. So the socket is not a slower way to get this, it is
+/// no way to get it.
+///
+/// Cheap on purpose. Provers are off, because the hypotheses are a property of
+/// the function and the model rather than of any proof: measured at 2.3 s on
+/// the two-function fixture against 33.0, where "do_wp_report" still runs and
+/// still warns with no prover configured.
+///
+/// The model and the project options come from the run being described. A
+/// probe under a different memory model answers a different question, since
+/// which separations the model needs is exactly what varies.
+pub async fn run_wp_memory_model_probe(
+    frama_c_path: &str,
+    files: &[String],
+    project_options: &ProjectLoadOptions,
+    rte: bool,
+    model: Option<&str>,
+    functions: &[String],
+    prop: Option<&str>,
+) -> serde_json::Value {
+    if files.is_empty() {
+        return probe_absent("no source files available", false);
+    }
+    let mut args = project_cli_args(project_options);
+    args.extend(files.iter().cloned());
+    args.extend([
+        "-wp".to_string(),
+        "-wp-prover".to_string(),
+        "none".to_string(),
+    ]);
+    if let Some(model) = model {
+        args.extend(["-wp-model".to_string(), model.to_string()]);
+    }
+    if rte {
+        args.push("-wp-rte".to_string());
+    }
+
+    // The same targets the run proved, because WP warns about the functions it
+    // was asked to process. Without this the probe walks the whole file and
+    // attributes a callee's separation to a run that never proved the callee,
+    // which is the wrong answer in the direction that invents an assumption.
+    for function in functions {
+        args.extend(["-wp-fct".to_string(), function.clone()]);
+    }
+    if let Some(prop) = prop {
+        args.extend(["-wp-prop".to_string(), prop.to_string()]);
+    }
+
+    let mut cmd = tokio::process::Command::new(frama_c_path);
+    cmd.args(&args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    match tokio::time::timeout(EXTERNAL_COMMAND_BUDGET, cmd.output()).await {
+        Ok(Ok(output)) => {
+            // Both streams. Frama-C writes diagnostics to stdout and this
+            // warning has been seen on each, so reading one of them is how a
+            // probe reports no hypotheses for a file that has them. Joined with
+            // a newline, as the retry path joins them, because an unterminated
+            // last stdout line would otherwise be glued to the first stderr
+            // line and the pair parsed as one.
+            let text = format!(
+                "{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let hypotheses =
+                crate::mcp::server::wpclass::wp_memory_model_hypotheses_in_text(&text);
+            let command: Vec<String> = std::iter::once(frama_c_path.to_string())
+                .chain(args)
+                .collect();
+
+            // A Frama-C that failed has not shown that the run assumed nothing.
+            // The source may be gone, the database may not cover it, the model
+            // may be one this build rejects; in every case the main server can
+            // still hold a parsed AST and valid goals, so a clean-looking empty
+            // list here is a proof whose assumptions nobody could read. The
+            // hypotheses parsed before the failure travel anyway, since
+            // whatever was printed is still true.
+            if !output.status.success() {
+                // Capped. A Frama-C that fails on a large file set can print
+                // pages, and this travels in a payload that already has a size
+                // problem; the truncation is named rather than silent.
+                const MAX_PROBE_STDERR_BYTES: usize = 4096;
+                let (stderr_excerpt, stderr_truncated) =
+                    capped_lossy_string(&output.stderr, MAX_PROBE_STDERR_BYTES);
+                let stderr_excerpt = stderr_excerpt.trim().to_string();
+
+                // Both streams, and stdout is the one that carries the answer.
+                // Frama-C writes its diagnostics to stdout: a printed AST that
+                // will not re-parse says "Invalid symbol" there, and a -wp-fct
+                // naming a function this AST does not define says "no function
+                // 'f'" there, both with an empty stderr. Reporting stderr alone
+                // left the only two failures this probe actually hits as a bare
+                // "frama-c exited 1" with nothing to act on.
+                let (stdout_excerpt, stdout_truncated) =
+                    capped_lossy_string(&output.stdout, MAX_PROBE_STDERR_BYTES);
+                let stdout_excerpt = stdout_excerpt.trim().to_string();
+                return json!({
+                    "ran": false,
+                    "read_from": PROBE_READ_FROM_SEPARATE_RUN,
+                    "reason": format!(
+                        "frama-c exited {} during the memory-model probe",
+                        output
+                            .status
+                            .code()
+                            .map(|code| code.to_string())
+                            .unwrap_or_else(|| "on a signal".to_string())
+                    ),
+                    "model": model,
+                    "command": command,
+                    "exit_code": output.status.code(),
+                    "stdout": stdout_excerpt,
+                    "stdout_truncated": stdout_truncated,
+                    "stderr": stderr_excerpt,
+                    "stderr_truncated": stderr_truncated,
+                    "hypotheses": hypotheses,
+                });
+            }
+            json!({
+                "ran": true,
+                "read_from": PROBE_READ_FROM_SEPARATE_RUN,
+                "model": model,
+                "command": command,
+                "exit_code": output.status.code(),
+                "hypotheses": hypotheses,
+            })
+        }
+
+        // Both arms report a reason rather than an empty hypothesis list,
+        // because a probe that could not run has not shown that the run assumed
+        // nothing.
+        Ok(Err(error)) => probe_absent(format!("frama-c could not be started: {error}"), false),
+        Err(_) => probe_absent(
+            format!(
+                "the memory-model probe exceeded {} seconds",
+                EXTERNAL_COMMAND_BUDGET.as_secs()
+            ),
+            false,
+        ),
     }
 }
 

--- a/tests/fixtures/contract-frontier.c
+++ b/tests/fixtures/contract-frontier.c
@@ -1,0 +1,41 @@
+/* The specification frontier of a partly contracted program.
+ *
+ * "entry" carries a contract and calls "helper", which carries one too and
+ * calls "deep_a" and "deep_b", which carry none. Those two are the frontier:
+ * defined, reachable from a contract, and unspecified.
+ *
+ * "orphan" is defined and unspecified and nothing contracted reaches it, so it
+ * is not on the frontier. That is the discriminator: seeding from every
+ * defined function instead of from the contracted ones would report it.
+ */
+
+int deep_a(int x)
+{
+  return x + 1;
+}
+
+int deep_b(int x)
+{
+  return x * 2;
+}
+
+/*@ assigns \nothing;
+    ensures \result >= 0; */
+int helper(int x)
+{
+  if (x < 0)
+    return 0;
+  return deep_a(x) + deep_b(x);
+}
+
+/*@ assigns \nothing;
+    ensures \result >= 0; */
+int entry(int x)
+{
+  return helper(x);
+}
+
+int orphan(int x)
+{
+  return x - 1;
+}

--- a/tests/fixtures/indirect-call-annotated.c
+++ b/tests/fixtures/indirect-call-annotated.c
@@ -1,0 +1,28 @@
+/* indirect-call.c with both halves of the fix.
+ *
+ * The calls clause names the callee set, which stops WP assuming the pointer
+ * may reach anything; the precondition says which function it actually holds,
+ * without which the call-point goal stays open. Measured on Frama-C 32.1:
+ * 9 of 10 with the calls clause alone, 10 of 10 with both.
+ *
+ * The call is still indirect, so this server still reports it: the AST is what
+ * the plug-in walks and a statement's annotations are not part of that.
+ */
+
+int g;
+
+/*@ assigns g;
+    ensures g == 1; */
+void seta(void)
+{
+  g = 1;
+}
+
+/*@ requires f == &seta;
+    assigns g;
+    ensures g == 1; */
+void run(void (*f)(void))
+{
+  /*@ calls seta; */
+  f();
+}

--- a/tests/fixtures/indirect-call.c
+++ b/tests/fixtures/indirect-call.c
@@ -1,0 +1,29 @@
+/* A call through a function pointer, with no calls clause.
+ *
+ * WP's answer to a call it cannot name is to assume the pointer may reach any
+ * function, including "run" itself, which makes "run" recursive and pulls in a
+ * decreases obligation nothing can discharge. Measured on Frama-C 32.1:
+ * 5 of 9 goals, four at Timeout, with the warnings "Missing 'calls' for
+ * default behavior", "Unknown callee, considering non-terminating call", and
+ * "no 'calls' specification for statement(s) on line(s): ... Assuming that
+ * they can call 'run'".
+ *
+ * The paired fixture indirect-call-annotated.c is the same file with both
+ * halves of the fix.
+ */
+
+int g;
+
+/*@ assigns g;
+    ensures g == 1; */
+void seta(void)
+{
+  g = 1;
+}
+
+/*@ assigns g;
+    ensures g == 1; */
+void run(void (*f)(void))
+{
+  f();
+}

--- a/tests/fixtures/memory-model-hypothesis-injected.c
+++ b/tests/fixtures/memory-model-hypothesis-injected.c
@@ -1,0 +1,22 @@
+/* A separation that exists only once a contract has been injected.
+ *
+ * "bump" writes the global and never touches "p", so the file as written gives
+ * the Typed model no reason to relate the two and Frama-C prints no memory
+ * model hypothesis. A contract that names "*p" puts the pointer in the frame,
+ * and the same model then needs "\separated(p, &g)" and says so.
+ *
+ * That gap is the point. Annotations reach Frama-C through the server protocol
+ * and are never written back to this file, so a probe that re-parses the file
+ * describes the program above rather than the one that was proved, and reports
+ * no hypotheses for a proof that rested on one.
+ *
+ * Measured on Frama-C 33.0: no hypothesis warning for the file as it stands,
+ * "requires \separated(p, &g);" once the contract below is in the AST.
+ */
+
+int g;
+
+void bump(int *p)
+{
+  g = 1;
+}

--- a/tests/fixtures/memory-model-hypothesis.c
+++ b/tests/fixtures/memory-model-hypothesis.c
@@ -1,0 +1,27 @@
+/* WP proves every goal here and assumes a separation it never checks.
+ *
+ * The Typed memory model treats "p" and "&g" as distinct locations because it
+ * has no reason not to. Frama-C says so, as a warning naming the hypothesis it
+ * took, and proves both functions anyway. "caller" passes "&g", which violates
+ * it: at run time "g" is 2 and "caller"'s own postcondition is false.
+ *
+ * Measured on Frama-C 32.1: 11 of 11 goals, every one by Qed.
+ */
+
+int g;
+
+/*@ requires \valid(p);
+    assigns g, *p;
+    ensures g == 1 && *p == 2; */
+void two(int *p)
+{
+  g = 1;
+  *p = 2;
+}
+
+/*@ assigns g;
+    ensures g == 1; */
+void caller(void)
+{
+  two(&g);
+}

--- a/tests/fixtures/memory-model-no-hypothesis.c
+++ b/tests/fixtures/memory-model-no-hypothesis.c
@@ -1,0 +1,14 @@
+/* The negative control for memory-model-hypothesis.c.
+ *
+ * One pointer formal and no global in the same frame, so the Typed model needs
+ * no separation and Frama-C prints none. Measured on Frama-C 32.1: 4 of 4
+ * goals and no hypothesis warning.
+ */
+
+/*@ requires \valid(p);
+    assigns *p;
+    ensures *p == 1; */
+void one(int *p)
+{
+  *p = 1;
+}

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -1,0 +1,31 @@
+//! A server with no Frama-C behind it, for tests that only exercise payload
+//! logic.
+//!
+//! One definition, included by every unit module that needs one. There were
+//! five, in unit/server.rs, unit/check-gaps.rs and unit/wp-classify.rs, each
+//! repeating the same Arc/RwLock/SessionState construction and the same
+//! sentinel binary name. The name matters: it has to be a path that cannot
+//! exist, and five copies of that promise are five chances to spell one of
+//! them as something that does.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use frama_c_mcp::mcp::server::FramaCMcpServer;
+use frama_c_mcp::state::SessionState;
+
+/// The path no binary is installed at, for a server that must not spawn one.
+pub const MISSING_FRAMA_C: &str = "__frama_c_mcp_missing_binary__";
+
+/// A lazily-spawning server over an empty session, pointed at `frama_c`.
+///
+/// Lazy is what makes this cheap: nothing is started until a call needs a
+/// client, so a test that only reads payloads never pays for a process.
+pub fn lazy_server(frama_c: impl Into<String>) -> FramaCMcpServer {
+    FramaCMcpServer::new_lazy(
+        Arc::new(RwLock::new(SessionState::default())),
+        frama_c.into(),
+        4,
+    )
+}

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -34,7 +34,7 @@ mod harness;
 #[path = "support/receipt.rs"]
 mod receipt_fixture;
 
-use frama_c_mcp::mcp::server::receipt::RECEIPT_SCHEMA;
+use frama_c_mcp::mcp::server::receipt::{ISOLATED_RETRY_NO_AST, RECEIPT_SCHEMA};
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -7792,6 +7792,7 @@ async fn check_returns_one_field_set_on_both_paths() {
         "eva_alarms",
         "incomplete",
         "incomplete_guidance",
+        "memory_model_probe",
         "messages",
         "messages_truncated",
         "proof_receipt",
@@ -7813,6 +7814,15 @@ async fn check_returns_one_field_set_on_both_paths() {
     std::fs::write(&bad, "int broken(void) { return\n").expect("write bad");
 
     let client = spawn_mcp_client(good.to_str().unwrap()).await;
+
+    // The key order each path emitted, kept to be compared with the other after
+    // the loop. serde_json runs with preserve_order here, so the order is part
+    // of what a caller receives, and a sorted comparison cannot see a key that
+    // moved: memory_model_probe was added between "detail" and "reload" on one
+    // path and between "wp_backend_diagnosis" and "messages" on the other,
+    // under a comment claiming the two matched, and this assertion passed.
+    let mut orders: Vec<(&str, Vec<String>)> = Vec::new();
+
     for (label, file) in [("analysis ran", &good), ("reload failed", &bad)] {
         let payload = call_tool_json(&client, "check", json!({
             "files": [file.to_str().unwrap()],
@@ -7820,12 +7830,11 @@ async fn check_returns_one_field_set_on_both_paths() {
         }))
         .await
         .unwrap_or_else(|e| panic!("check on the {label} path: {e}"));
-        let mut fields = payload
+        let object = payload
             .as_object()
-            .unwrap_or_else(|| panic!("{label}: not an object: {payload:?}"))
-            .keys()
-            .map(String::as_str)
-            .collect::<Vec<_>>();
+            .unwrap_or_else(|| panic!("{label}: not an object: {payload:?}"));
+        orders.push((label, object.keys().cloned().collect()));
+        let mut fields = object.keys().map(String::as_str).collect::<Vec<_>>();
         fields.sort_unstable();
         assert_eq!(fields, expected, "{label} path field set moved");
         assert_eq!(payload["schema"], "frama-c-mcp.check.v2", "{label}");
@@ -7856,6 +7865,15 @@ async fn check_returns_one_field_set_on_both_paths() {
             "{label}: proved and an empty incomplete array must agree: {payload:?}"
         );
     }
+
+    // One field set is half the promise; one order is the other half.
+    let [(first_label, first_order), (second_label, second_order)] = &orders[..] else {
+        panic!("expected exactly two payloads, got {}", orders.len());
+    };
+    assert_eq!(
+        first_order, second_order,
+        "the {first_label} and {second_label} paths emit their fields in different orders"
+    );
 
     let _ = client.cancel().await;
 }
@@ -7965,7 +7983,7 @@ async fn the_receipt_records_the_contract_it_proved_under() {
     .unwrap()["proof_receipt"]
         .clone();
     assert_eq!(
-        isolated["subject"]["contracts"], "unavailable_isolated_cli_retry",
+        isolated["subject"]["contracts"], ISOLATED_RETRY_NO_AST,
         "the isolated retry claimed a contract it did not prove: {isolated:?}"
     );
 
@@ -10211,6 +10229,113 @@ async fn naming_a_profile_does_not_turn_off_the_runtime_error_checks() {
     );
 }
 
+/// The whole point of the code: a run with nothing unproved is still
+/// incomplete.
+///
+/// The fixture memory-model-hypothesis.c proves 11 of 11 goals on Frama-C
+/// 32.1 while WP assumes \separated(p, &g), and "caller" in that file violates
+/// the hypothesis by passing &g. Without this code the payload reads
+/// as a clean proof of a function whose postcondition is false at run time.
+#[tokio::test]
+async fn a_memory_model_hypothesis_makes_a_fully_proved_run_incomplete() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    // No function filter, so WP proves both. Scoping to one function would
+    // scope the warning too: WP prints the hypothesis for the function it is
+    // processing, and "caller" has no pointer formal of its own. The unsound
+    // pair only exists when both are proved, which is the run a caller makes.
+    let check = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "want": ["wp"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    // Every goal valid, and incomplete anyway. Both halves matter: a code that
+    // only fired alongside an unproved goal would miss this run entirely. Every
+    // count key ends in "/valid", so nothing is unproved. Named by suffix
+    // rather than by the exact key set, which carries the goal kinds WP
+    // happened to generate and moves with the Frama-C version.
+    let counts = check["wp_goals"]["counts"].as_object().expect("counts");
+    assert!(!counts.is_empty(), "{check:?}");
+    assert!(
+        counts.keys().all(|key| key.ends_with("/valid")),
+        "{check:?}"
+    );
+    assert!(check["wp_goals"]["total"].as_u64().is_some_and(|total| total > 0), "{check:?}");
+    assert_eq!(check["verdict"], "incomplete", "{check:?}");
+
+    let entry = check["incomplete"]
+        .as_array()
+        .expect("incomplete array")
+        .iter()
+        .find(|item| item["code"] == "WP_MEMORY_MODEL_HYPOTHESIS")
+        .unwrap_or_else(|| panic!("no memory-model entry: {check:?}"));
+
+    assert_eq!(entry["function_count"], json!(1), "{entry:?}");
+    assert_eq!(entry["functions"][0]["function"], json!("two"), "{entry:?}");
+
+    // The clause verbatim, because what a caller does with this is paste it
+    // into a precondition.
+    assert_eq!(
+        entry["functions"][0]["hypotheses"],
+        json!(["requires \\separated(p, &g);"]),
+        "{entry:?}"
+    );
+    assert_eq!(
+        entry["read_from"],
+        json!("a separate frama-c run with provers off"),
+        "{entry:?}"
+    );
+
+    // The guidance says what to do about it, keyed by code like every other.
+    assert!(
+        check["incomplete_guidance"]["WP_MEMORY_MODEL_HYPOTHESIS"]
+            .as_str()
+            .is_some_and(|text| text.contains("requires")),
+        "{check:?}"
+    );
+
+    let _ = client.cancel().await;
+}
+
+/// The negative control, so the code is not simply always on.
+///
+/// One pointer formal and no global in the same frame needs no separation, and
+/// Frama-C prints none. Measured at 4 of 4 goals on 32.1.
+#[tokio::test]
+async fn a_function_needing_no_separation_carries_no_memory_model_entry() {
+    let c_file = workspace_path("tests/fixtures/memory-model-no-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let check = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "want": ["wp"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    // The control has to actually prove something, or its silence proves
+    // nothing: a run where WP never started would carry no entry either.
+    assert!(check["wp_goals"]["total"].as_u64().is_some_and(|total| total > 0), "{check:?}");
+
+    assert!(
+        !check["incomplete"]
+            .as_array()
+            .expect("incomplete array")
+            .iter()
+            .any(|item| item["code"] == "WP_MEMORY_MODEL_HYPOTHESIS"),
+        "{check:?}"
+    );
+
+    let _ = client.cancel().await;
+}
+
 /// An indirect call is reported as a missing annotation, not as a slow prover.
 ///
 /// The fixture is a function whose body is one call through a pointer formal.
@@ -10320,6 +10445,142 @@ async fn a_direct_call_graph_carries_no_indirect_call_gap() {
             .iter()
             .any(|item| item["code"] == "INDIRECT_CALL_UNRESOLVED"),
         "{check:?}"
+    );
+
+    let _ = client.cancel().await;
+}
+
+/// The probe asks WP the question this run asked, not a broader one.
+///
+/// The probe is a second Frama-C run, and an unscoped one walks the whole file.
+/// So it carries the run's own WP scope onto the command line, and this pins
+/// that it does.
+///
+/// What that scope does not do is narrow the answer to the target's own frame,
+/// and the measurement is worth keeping because it is the opposite of what a
+/// reader expects. Frama-C 33.0, over the two-function fixture: both
+/// "-wp-fct caller" and "-wp-fct two" report the hypothesis for "two". Proving
+/// "caller" uses "two"'s contract, and the separation the model needs for
+/// "two"'s frame is part of what "caller"'s proof rests on, so WP names it
+/// under either scope. Reporting it for a scoped check is therefore right, and
+/// the scope still matters: it is what makes the probe describe this run.
+#[tokio::test]
+async fn a_scoped_check_probes_under_its_own_wp_scope() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let scoped = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "function": "caller", "want": ["wp"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    // The scope reached the command line. Without this the probe answers about
+    // the whole file for a run that proved one function.
+    let command = probe_command(&scoped["memory_model_probe"]);
+    assert!(
+        command.windows(2).any(|pair| pair == ["-wp-fct", "caller"]),
+        "{command:?}"
+    );
+    assert!(
+        !command.contains(&"two"),
+        "the probe named a function this run did not prove: {command:?}"
+    );
+
+    // And the hypothesis is reported, because WP reports it under this scope.
+    let entry = scoped["incomplete"]
+        .as_array()
+        .expect("incomplete array")
+        .iter()
+        .find(|item| item["code"] == "WP_MEMORY_MODEL_HYPOTHESIS")
+        .unwrap_or_else(|| panic!("no memory-model entry: {scoped:?}"));
+    assert_eq!(entry["functions"][0]["function"], json!("two"), "{entry:?}");
+
+    let _ = client.cancel().await;
+}
+
+/// A run over a file with no separation to assume carries neither half.
+///
+/// The control for the probe itself: it ran, it exited zero, and it found
+/// nothing, which is a different answer from not having looked.
+#[tokio::test]
+async fn a_probe_that_finds_nothing_reports_that_it_looked() {
+    let c_file = workspace_path("tests/fixtures/memory-model-no-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let check = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "want": ["wp"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(check["memory_model_probe"]["ran"], json!(true), "{check:?}");
+    assert_eq!(check["memory_model_probe"]["hypotheses"], json!([]), "{check:?}");
+    let codes: Vec<&str> = check["incomplete"]
+        .as_array()
+        .expect("incomplete array")
+        .iter()
+        .filter_map(|item| item["code"].as_str())
+        .collect();
+    assert!(!codes.contains(&"WP_MEMORY_MODEL_HYPOTHESIS"), "{codes:?}");
+    assert!(!codes.contains(&"WP_MEMORY_MODEL_UNCHECKED"), "{codes:?}");
+
+    let _ = client.cancel().await;
+}
+
+/// The probe's provenance is on the payload, because it is the one answer here
+/// that did not come through the socket.
+#[tokio::test]
+async fn the_memory_model_probe_reports_how_it_was_run() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let check = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "want": ["wp"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    let probe = &check["memory_model_probe"];
+    assert_eq!(probe["ran"], json!(true), "{check:?}");
+    assert_eq!(probe["exit_code"], json!(0), "{probe:?}");
+    assert_eq!(probe["model"], check["wp"]["effective_wp_config"]["model"], "{check:?}");
+
+    // Provers off, because the hypotheses are a property of the function and
+    // the model rather than of any proof.
+    let command = probe_command(probe);
+    assert!(command.windows(2).any(|pair| pair == ["-wp-prover", "none"]), "{command:?}");
+
+    // An EVA-only check pays for no process at all, and says why.
+    let eva_only = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "want": ["eva"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(eva_only["memory_model_probe"]["ran"], json!(false), "{eva_only:?}");
+    assert_eq!(
+        eva_only["memory_model_probe"]["reason"],
+        json!("check did not run WP"),
+        "{eva_only:?}"
+    );
+    assert!(
+        !eva_only["incomplete"]
+            .as_array()
+            .expect("incomplete array")
+            .iter()
+            .any(|item| item["code"] == "WP_MEMORY_MODEL_UNCHECKED"),
+        "{eva_only:?}"
     );
 
     let _ = client.cancel().await;
@@ -10446,6 +10707,392 @@ async fn the_contract_frontier_is_not_a_check_gap() {
     assert!(
         !codes.iter().any(|code| code.contains("FRONTIER")),
         "{codes:?}"
+    );
+
+    let _ = client.cancel().await;
+}
+
+/// run_wp reports the assumption its own proof rests on.
+///
+/// The defect fixed for check, reached by the tool call the playbook has an
+/// agent make directly. A run_wp that reports every goal valid and omits the
+/// separation WP assumed is the same wrong answer by a different route.
+#[tokio::test]
+async fn run_wp_reports_the_memory_model_hypothesis_it_proved_under() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let wp = call_tool_json(&client, "run_wp", json!({"timeout": 10}))
+        .await
+        .unwrap();
+
+    let probe = &wp["memory_model_probe"];
+    assert_eq!(probe["ran"], json!(true), "{wp:?}");
+    assert_eq!(
+        probe["hypotheses"][0]["function"],
+        json!("two"),
+        "{probe:?}"
+    );
+    assert_eq!(
+        probe["hypotheses"][0]["hypotheses"],
+        json!(["requires \\separated(p, &g);"]),
+        "{probe:?}"
+    );
+
+    // Under the model the run used, not a default, since which separations the
+    // model needs is exactly what varies between models.
+    assert_eq!(probe["model"], wp["effective_wp_config"]["model"], "{wp:?}");
+
+    let _ = client.cancel().await;
+}
+
+/// check reads that probe rather than paying for a second process.
+///
+/// Two probes per check would cost another Frama-C run, measured at 2.3
+/// seconds, and would put the same answer under two keys. The command on the
+/// check payload is the one run_wp issued, which is how this tells a
+/// read-through from a second run.
+#[tokio::test]
+async fn a_check_does_not_probe_twice_for_one_wp_run() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let check = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "want": ["wp"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    // The same object, by value, on both levels.
+    assert_eq!(
+        check["memory_model_probe"],
+        check["wp"]["memory_model_probe"],
+        "check ran its own probe instead of reading the run's: {check:?}"
+    );
+    assert_eq!(check["memory_model_probe"]["ran"], json!(true), "{check:?}");
+
+    // And the gap still lands exactly once.
+    let entries: Vec<&serde_json::Value> = check["incomplete"]
+        .as_array()
+        .expect("incomplete array")
+        .iter()
+        .filter(|item| item["code"] == "WP_MEMORY_MODEL_HYPOTHESIS")
+        .collect();
+    assert_eq!(entries.len(), 1, "{check:?}");
+
+    let _ = client.cancel().await;
+}
+
+/// A sandbox hands back a proof like any other run, and now says what it
+/// assumed.
+///
+/// It cannot use check's reconstruction: a sandbox's files are a temporary
+/// sandbox.c rather than the session's, so the receipt carries no project
+/// options to rebuild from. It calls the probe with the defaults its own
+/// process was started with, and with the bare target names, which are what
+/// its Frama-C knows its functions by.
+#[tokio::test]
+async fn a_sandbox_run_reports_its_own_memory_model_hypothesis() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let experiment_id = unique_experiment_id("mm");
+    let created = call_tool_json(
+        &client,
+        "create_sandbox",
+        json!({"function": "two", "experiment_id": experiment_id}),
+    )
+    .await
+    .unwrap();
+    let sandbox = created["sandbox_name"].as_str().expect("sandbox_name").to_string();
+
+    let wp = call_tool_json(
+        &client,
+        "run_wp",
+        json!({"functions": [sandbox.clone()], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    let probe = &wp["memory_model_probe"];
+    assert_eq!(probe["ran"], json!(true), "{wp:?}");
+    assert_eq!(probe["hypotheses"][0]["function"], json!("two"), "{probe:?}");
+
+    // The bare name reached the command line. The prefixed form is this
+    // server's addressing and the sandbox's Frama-C has never heard of it.
+    let command = probe_command(probe);
+    assert!(command.windows(2).any(|pair| pair == ["-wp-fct", "two"]), "{command:?}");
+
+    let _ = call_tool_json(&client, "delete_sandbox", json!({"sandbox_name": sandbox})).await;
+    let _ = client.cancel().await;
+}
+
+/// The probe describes the run's guards, not the project's flag.
+///
+/// run_wp generates WP's runtime-error guards in place for a main-instance
+/// run, so a project loaded without rte still proves them. A probe told the
+/// project's own flag would analyse a smaller program than the one that was
+/// proved, and could miss a separation the guards introduce.
+///
+/// Loaded with rte:false on purpose, and that is the whole test. The helper
+/// reloads with rte:true, so under it the project's own flag is already set,
+/// "-wp-rte" reaches the command line either way, and the assertion below held
+/// for the narrow expression it exists to rule out. The two readings only
+/// disagree when the flag is off and the guards were generated anyway.
+#[tokio::test]
+async fn the_probe_analyses_the_program_the_run_actually_guarded() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let reloaded = call_tool_json(
+        &client,
+        "reload_project",
+        json!({"files": [c_file], "rte": false}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        reloaded["rte"],
+        json!(false),
+        "the project has to be loaded without rte for this to mean anything: {reloaded:?}"
+    );
+
+    let wp = call_tool_json(&client, "run_wp", json!({"timeout": 10}))
+        .await
+        .unwrap();
+
+    let command = probe_command(&wp["memory_model_probe"]);
+    assert!(
+        wp["rte_guarded_in_place"]
+            .as_array()
+            .is_some_and(|guarded| !guarded.is_empty()),
+        "the run has to have guarded something for this to mean anything: {wp:?}"
+    );
+    assert!(command.contains(&"-wp-rte"), "{command:?}");
+
+    let _ = client.cancel().await;
+}
+
+/// Adding the probe to the response does not move a run_wp receipt.
+///
+/// The probe is provenance for a payload, not part of what was proved:
+/// attach_run_wp_receipt copies the effective config, the failure kind and the
+/// timeout triage, and nothing else. Two runs of the same file therefore still
+/// digest the same, which is what makes a receipt comparable at all.
+#[tokio::test]
+async fn the_probe_does_not_change_a_run_wp_receipt() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let first = call_tool_json(&client, "run_wp", json!({"timeout": 10}))
+        .await
+        .unwrap();
+    let second = call_tool_json(&client, "run_wp", json!({"timeout": 10}))
+        .await
+        .unwrap();
+
+    assert!(
+        first["memory_model_probe"]["ran"] == json!(true),
+        "{first:?}"
+    );
+    assert_eq!(
+        first["proof_receipt"]["sha256"],
+        second["proof_receipt"]["sha256"],
+        "two runs of one file digested differently"
+    );
+
+    // And the probe is not inside the digested part.
+    assert!(
+        first["proof_receipt"]["reported"]["memory_model_probe"].is_null(),
+        "{first:?}"
+    );
+
+    let _ = client.cancel().await;
+}
+
+/// The probe's command line as a borrowed argv.
+///
+/// Five tests read this the same way and differed only in the panic message.
+fn probe_command(probe: &Value) -> Vec<&str> {
+    probe["command"]
+        .as_array()
+        .unwrap_or_else(|| panic!("a probe that ran carries its command: {probe:?}"))
+        .iter()
+        .filter_map(|arg| arg.as_str())
+        .collect()
+}
+
+/// A declared-but-undefined callee does not kill the probe.
+///
+/// An unscoped run proves every function resolve_wp_targets returns, and that
+/// list keeps declarations: uncontracted-callee.c has "helper" with no body.
+/// Passing that name to -wp-fct is "no function 'helper'" and a Frama-C that
+/// aborts with exit 1 before printing a hypothesis, so the probe answered
+/// ran:false for every program with an external callee and check turned that
+/// into WP_MEMORY_MODEL_UNCHECKED. Measured against 33.0: exit 1 with the
+/// undefined name on the command line, exit 0 without it.
+#[tokio::test]
+async fn an_undefined_callee_is_kept_off_the_probe_command_line() {
+    let c_file = workspace_path("tests/fixtures/uncontracted-callee.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let wp = call_tool_json(&client, "run_wp", json!({"timeout": 10}))
+        .await
+        .unwrap();
+
+    let probe = &wp["memory_model_probe"];
+    assert_eq!(probe["ran"], json!(true), "{probe:?}");
+
+    let command = probe_command(probe);
+
+    // The defined functions are addressed and the declaration is not. Both
+    // halves matter: dropping every name would probe the whole file and
+    // attribute a separation to a run that never proved its owner.
+    assert!(command.contains(&"compute"), "{command:?}");
+    assert!(!command.contains(&"helper"), "{command:?}");
+
+    let _ = client.cancel().await;
+}
+
+/// The probe describes the AST that was proved, not the file on disk.
+///
+/// Annotations reach Frama-C through execAddAnnotation and the ghost
+/// insertions. Neither writes the source back: a sandbox's sandbox.c is
+/// written once, at creation, and a main-project file is never written at all.
+/// A probe that re-parses those files therefore analyses the program as it was
+/// before the session injected anything, and a contract that introduces a
+/// separation is invisible to it. The run reports every goal valid and the
+/// probe reports no hypotheses, which is exactly the false clean the payload
+/// exists to prevent, and it is the shape the CEGIS loop runs in: inject, then
+/// run_wp, with no reload between.
+///
+/// The fixture is chosen so the two answers differ. "bump" writes the global
+/// and never touches "p", so the file as it stands needs no separation;
+/// naming "*p" in a contract puts the pointer in the frame and the Typed model
+/// then needs one.
+#[tokio::test]
+async fn the_probe_sees_a_separation_that_only_the_injected_contract_introduces() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis-injected.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let experiment_id = unique_experiment_id("inj");
+    let created = call_tool_json(
+        &client,
+        "create_sandbox",
+        json!({"function": "bump", "experiment_id": experiment_id}),
+    )
+    .await
+    .unwrap();
+    let sandbox = created["sandbox_name"].as_str().expect("sandbox_name").to_string();
+
+    // The control, in the same test rather than in prose: before the contract
+    // lands the probe has to find nothing, or the assertion below would pass
+    // for a fixture that always had a hypothesis.
+    let before = call_tool_json(
+        &client,
+        "run_wp",
+        json!({"functions": [sandbox.clone()], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(before["memory_model_probe"]["ran"], json!(true), "{before:?}");
+    assert_eq!(
+        before["memory_model_probe"]["hypotheses"],
+        json!([]),
+        "the fixture must need no separation until the contract is injected: {before:?}"
+    );
+
+    let injected = call_tool_json(
+        &client,
+        "inject_all_annotations",
+        json!({
+            "sandbox_name": sandbox.clone(),
+            "proposed_requires": [{"acsl": "\\valid_read(p)", "necessity": "brings p into the frame"}],
+            "proposed_assigns": [{"acsl": "g"}],
+            "proposed_ensures": [{"acsl": "*p == \\old(*p)"}],
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(injected["status"], json!("success"), "{injected:?}");
+
+    let after = call_tool_json(
+        &client,
+        "run_wp",
+        json!({"functions": [sandbox.clone()], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    let probe = &after["memory_model_probe"];
+    assert_eq!(probe["ran"], json!(true), "{after:?}");
+    assert_eq!(
+        probe["hypotheses"][0]["function"],
+        json!("bump"),
+        "the contract is in the AST and the probe has to see it: {probe:?}"
+    );
+    let separations = probe["hypotheses"][0]["hypotheses"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no hypotheses array: {probe:?}"))
+        .iter()
+        .filter_map(|entry| entry.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        separations.iter().any(|text| text.contains("\\separated")),
+        "{separations:?}"
+    );
+
+    let _ = call_tool_json(&client, "delete_sandbox", json!({"sandbox_name": sandbox})).await;
+    let _ = client.cancel().await;
+}
+
+/// check digests its own AST even when the run it wrapped could not.
+///
+/// check forwards its caller's provers, and run_wp answers any call carrying
+/// provers with the isolated CLI retry, whose receipt records the marker
+/// instead of a digest: that run proved the files on disk in another process
+/// while the live AST here carries whatever this session injected. check is
+/// still connected to the project, so its own receipt can describe its own
+/// AST, and before it read the digest off the run it printed and digested
+/// exactly that. Reusing the marker would put it in a field that could carry a
+/// real digest, and two checks over different programs would then agree on it.
+#[tokio::test]
+async fn a_retry_that_cannot_digest_does_not_erase_the_checks_own_digest() {
+    let c_file = workspace_path("tests/fixtures/memory-model-hypothesis.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let retried = call_tool_json(
+        &client,
+        "check",
+        json!({"provers": ["alt-ergo"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    // The run really did take the retry path, or this asserts nothing.
+    assert_eq!(
+        retried["wp"]["proof_receipt"]["subject"]["ast_digest"],
+        json!(ISOLATED_RETRY_NO_AST),
+        "the run did not go through the isolated retry, so this test is vacuous: {retried:?}"
+    );
+
+    let digest = retried["proof_receipt"]["subject"]["ast_digest"]
+        .as_str()
+        .unwrap_or_else(|| panic!("check's own receipt has no digest: {retried:?}"));
+    assert_ne!(digest, ISOLATED_RETRY_NO_AST, "{retried:?}");
+    assert!(
+        digest.len() == 64 && digest.chars().all(|c| c.is_ascii_hexdigit()),
+        "not a sha256 over the printed AST: {digest}"
     );
 
     let _ = client.cancel().await;

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -10210,3 +10210,117 @@ async fn naming_a_profile_does_not_turn_off_the_runtime_error_checks() {
         "{with_rte:?}"
     );
 }
+
+/// An indirect call is reported as a missing annotation, not as a slow prover.
+///
+/// The fixture is a function whose body is one call through a pointer formal.
+/// Measured on Frama-C 33.0, WP leaves goals open there because with no calls
+/// clause it assumes the pointer may reach any function, including the caller
+/// itself, which makes the caller recursive. Those open goals reach the caller
+/// as GOAL_NOT_VALID with PROVER_TIMEOUT beside them, and the next action a
+/// prover timeout invites, more time, cannot close them.
+#[tokio::test]
+async fn an_indirect_call_is_reported_as_its_own_gap() {
+    let c_file = workspace_path("tests/fixtures/indirect-call.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let check = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "function": "run", "want": ["wp"], "timeout": 5}),
+    )
+    .await
+    .unwrap();
+
+    let entry = check["incomplete"]
+        .as_array()
+        .expect("incomplete array")
+        .iter()
+        .find(|item| item["code"] == "INDIRECT_CALL_UNRESOLVED")
+        .unwrap_or_else(|| panic!("no indirect-call entry: {check:?}"));
+
+    assert_eq!(entry["function"], json!("run"), "{entry:?}");
+    assert!(
+        entry["callee_expression"].as_str().is_some_and(|text| text.contains('f')),
+        "{entry:?}"
+    );
+    assert!(entry["source_location"]["line"].as_u64().is_some(), "{entry:?}");
+
+    // The guidance names both halves of the fix and rules out the one a prover
+    // timeout would send a caller to.
+    let guidance = check["incomplete_guidance"]["INDIRECT_CALL_UNRESOLVED"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no guidance: {check:?}"));
+    assert!(guidance.contains("calls"), "{guidance}");
+    assert!(guidance.contains("timeout"), "{guidance}");
+
+    let _ = client.cancel().await;
+}
+
+/// The annotated fixture proves, and still carries the code.
+///
+/// That is the over-report this item accepts rather than hides: the plug-in
+/// walks the AST and a statement's own annotations are not part of what it
+/// walks, so the finding reports the call shape and says so in its own text.
+/// Pinned because the alternative, a code that silently stops firing, would be
+/// a claim about the annotation that nothing here checks.
+#[tokio::test]
+async fn an_annotated_indirect_call_proves_and_still_reports_the_call_shape() {
+    let c_file = workspace_path("tests/fixtures/indirect-call-annotated.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let check = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "function": "run", "want": ["wp"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    let counts = check["wp_goals"]["counts"].as_object().expect("counts");
+    assert!(!counts.is_empty(), "{check:?}");
+    assert!(counts.keys().all(|key| key.ends_with("/valid")), "{check:?}");
+
+    let entry = check["incomplete"]
+        .as_array()
+        .expect("incomplete array")
+        .iter()
+        .find(|item| item["code"] == "INDIRECT_CALL_UNRESOLVED")
+        .unwrap_or_else(|| panic!("the call is still indirect: {check:?}"));
+    assert!(
+        entry["reports"].as_str().is_some_and(|text| text.contains("call shape")),
+        "{entry:?}"
+    );
+
+    let _ = client.cancel().await;
+}
+
+/// A function with no indirect call carries no such code, so it is not simply
+/// always on.
+#[tokio::test]
+async fn a_direct_call_graph_carries_no_indirect_call_gap() {
+    let c_file = workspace_path("tests/fixtures/abs-int-fixed.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let check = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "function": "main", "want": ["wp"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        !check["incomplete"]
+            .as_array()
+            .expect("incomplete array")
+            .iter()
+            .any(|item| item["code"] == "INDIRECT_CALL_UNRESOLVED"),
+        "{check:?}"
+    );
+
+    let _ = client.cancel().await;
+}

--- a/tests/test-mcp-stdio.rs
+++ b/tests/test-mcp-stdio.rs
@@ -10324,3 +10324,129 @@ async fn a_direct_call_graph_carries_no_indirect_call_gap() {
 
     let _ = client.cancel().await;
 }
+
+/// The contract frontier, whole-program and in one call.
+///
+/// The question an agent has on a file it has not seen: which functions does a
+/// proof of this program still need a contract for. Answered by one request
+/// rather than one getContractContext per defined function, which on a
+/// thousand-function program is a thousand round trips for a payload of a few
+/// hundred rows.
+#[tokio::test]
+async fn the_contract_frontier_names_what_still_needs_a_contract() {
+    let c_file = workspace_path("tests/fixtures/contract-frontier.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let frontier = call_tool_json(&client, "list", json!({"kind": "contract_frontier"}))
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = frontier["missing"]
+        .as_array()
+        .expect("missing array")
+        .iter()
+        .filter_map(|entry| entry["function"].as_str())
+        .collect();
+
+    // The two functions two hops down, which ASSUMED_CALLEE_CONTRACT cannot
+    // see: it reads one hop from whatever a check happened to target.
+    assert_eq!(names, ["deep_a", "deep_b"], "{frontier:?}");
+
+    // And not the unreachable one. Seeding from every defined function rather
+    // than from the contracted ones would report it, which is the difference
+    // between a work list and a list of every function without a contract.
+    assert!(!names.contains(&"orphan"), "{frontier:?}");
+
+    assert_eq!(frontier["missing_count"], json!(2), "{frontier:?}");
+    assert_eq!(frontier["contracted_count"], json!(2), "{frontier:?}");
+    assert_eq!(frontier["defined_count"], json!(5), "{frontier:?}");
+
+    // Each row carries what a person needs to go and write the contract.
+    let first = &frontier["missing"][0];
+    assert_eq!(first["called_by"], json!(["helper"]), "{first:?}");
+    assert!(first["loc"]["line"].as_u64().is_some(), "{first:?}");
+
+    // A frontier computed over a call graph that dropped the indirect edges
+    // would be a work list that under-reports, and a short one looks the same
+    // as a complete one, so the walk says whether it followed everything.
+    assert_eq!(frontier["call_graph_complete"], json!(true), "{frontier:?}");
+    assert_eq!(frontier["unresolved_call_sites"], json!([]), "{frontier:?}");
+
+    let _ = client.cancel().await;
+}
+
+/// Writing one of the missing contracts takes that function off the frontier
+/// and leaves the other, which is what makes it a work list rather than a
+/// static property of the file.
+#[tokio::test]
+async fn a_contract_written_leaves_the_frontier() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let c_file = tmp.path().join("frontier.c");
+    std::fs::write(
+        &c_file,
+        r#"
+int deep_a(int x) { return x + 1; }
+
+/*@ assigns \nothing; ensures \result == x * 2; */
+int deep_b(int x) { return x * 2; }
+
+/*@ assigns \nothing; ensures \result >= 0; */
+int helper(int x)
+{
+    if (x < 0) return 0;
+    return deep_a(x) + deep_b(x);
+}
+"#,
+    )
+    .expect("write fixture");
+
+    let client = spawn_mcp_client(c_file.to_str().unwrap()).await;
+    let frontier = call_tool_json(&client, "list", json!({"kind": "contract_frontier"}))
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = frontier["missing"]
+        .as_array()
+        .expect("missing array")
+        .iter()
+        .filter_map(|entry| entry["function"].as_str())
+        .collect();
+    assert_eq!(names, ["deep_a"], "{frontier:?}");
+
+    let _ = client.cancel().await;
+}
+
+/// The frontier is a work list, not a verdict, so it produces no gap code.
+///
+/// Stated as a test because the opposite is the tempting change: a function
+/// two hops down with no contract is not a gap in any caller's proof, since WP
+/// used the direct callee's contract and ASSUMED_CALLEE_CONTRACT already
+/// covers the case where that contract is vacuous.
+#[tokio::test]
+async fn the_contract_frontier_is_not_a_check_gap() {
+    let c_file = workspace_path("tests/fixtures/contract-frontier.c");
+    let c_file = c_file.to_str().expect("fixture path is utf-8");
+    let client = spawn_mcp_client(c_file).await;
+
+    let check = call_tool_json(
+        &client,
+        "check",
+        json!({"files": [c_file], "function": "entry", "want": ["wp"], "timeout": 10}),
+    )
+    .await
+    .unwrap();
+
+    let codes: Vec<&str> = check["incomplete"]
+        .as_array()
+        .expect("incomplete array")
+        .iter()
+        .filter_map(|item| item["code"].as_str())
+        .collect();
+    assert!(
+        !codes.iter().any(|code| code.contains("FRONTIER")),
+        "{codes:?}"
+    );
+
+    let _ = client.cancel().await;
+}

--- a/tests/test-process-lifecycle.rs
+++ b/tests/test-process-lifecycle.rs
@@ -620,7 +620,8 @@ fn tool_registry_count_matches_declared_snapshots() {
             "globals",
             "declarations",
             "sandboxes",
-            "conclusions"
+            "conclusions",
+            "contract_frontier"
         ])
     );
     assert_eq!(
@@ -1848,7 +1849,7 @@ fn self_check_reports_capabilities_over_stdio() {
     // (self_check_shape_with_missing_frama_c and its capabilities twin).
     // Removing a plug-in request means changing all three; missing one costs a
     // full gate run to find, which is how this comment came to exist.
-    assert_eq!(capabilities["ast_utils"]["registered_request_count"], 28);
+    assert_eq!(capabilities["ast_utils"]["registered_request_count"], 29);
     for request in [
         "plugins.ast-utils.getCilContext",
         "plugins.ast-utils.getContractContext",

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -10,6 +10,8 @@
 
 #[path = "support/receipt.rs"]
 mod receipt_fixture;
+#[path = "support/server.rs"]
+mod server_fixture;
 
 #[path = "unit/acsl-shapes.rs"]
 mod acsl_shapes;

--- a/tests/unit/check-gaps.rs
+++ b/tests/unit/check-gaps.rs
@@ -1595,3 +1595,61 @@ fn a_vacuously_discharged_property_is_reported_rather_than_counted_as_proved() {
     );
     assert!(clean.is_empty(), "{clean:?}");
 }
+
+/// An unresolved-call finding reaches the verdict as its own code.
+///
+/// The dispatch in proofread_finding_gaps ends with a negative guard, so a
+/// category added anywhere below it is dropped with no warning at all. This
+/// pins that the arm sits above that guard.
+#[test]
+fn an_unresolved_call_finding_becomes_an_incomplete_entry() {
+    let wp = json!({
+        "ok": true,
+        "proofread_report": {
+            "findings": [{
+                "id": "unresolved-call:run:5",
+                "severity": "high",
+                "category": "unresolved_call",
+                "function": "run",
+                "callee_expression": "*f",
+                "stmt_id": 5,
+                "source_location": {"file": "indirect-call.c", "line": 28},
+                "message": "run calls through *f, which names no callee.",
+            }]
+        }
+    });
+    let items = check_incomplete_items(
+        Some(true),
+        &json!({"ok": true}),
+        &json!({"ok": true}),
+        &json!([]),
+        &wp,
+        &json!({"entries": []}),
+        WantedAnalyses::BOTH,
+    );
+    let entry = items
+        .iter()
+        .find(|item| item["code"] == json!(incomplete_code::INDIRECT_CALL_UNRESOLVED))
+        .unwrap_or_else(|| panic!("no indirect-call entry: {items:?}"));
+    assert_eq!(entry["function"], json!("run"));
+    assert_eq!(entry["callee_expression"], json!("*f"));
+    assert_eq!(entry["stmt_id"], json!(5));
+    assert_eq!(entry["source_location"]["line"], json!(28));
+
+    // Says plainly what it read, so a caller who has already written the clause
+    // is not left thinking the annotation did not take.
+    assert!(
+        entry["reports"].as_str().is_some_and(|text| text.contains("call shape")),
+        "{entry:?}"
+    );
+}
+
+/// The guidance names both halves of the fix and rules out the one a prover
+/// timeout would suggest.
+#[test]
+fn the_indirect_call_guidance_rules_out_a_longer_timeout() {
+    let text = gap_guidance(incomplete_code::INDIRECT_CALL_UNRESOLVED);
+    let text = text.as_str().expect("guidance is a string");
+    assert!(text.contains("calls"), "{text}");
+    assert!(text.contains("timeout"), "{text}");
+}

--- a/tests/unit/check-gaps.rs
+++ b/tests/unit/check-gaps.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 use serde_json::json;
+use crate::server_fixture::{lazy_server, MISSING_FRAMA_C};
 use frama_c_mcp::error::FramaCError;
 
 use frama_c_mcp::mcp::server::*;
@@ -17,6 +18,9 @@ use frama_c_mcp::mcp::server::checkgaps::{
     check_variants_summary,
     gap_guidance,
     incomplete_guidance,
+    memory_model_hypothesis_gap,
+    memory_model_unchecked_gap,
+    probe_absent,
     check_next_call, incomplete_code, wp_goal_gaps, NextCallInputs,
     WantedAnalyses,
 };
@@ -1596,6 +1600,164 @@ fn a_vacuously_discharged_property_is_reported_rather_than_counted_as_proved() {
     assert!(clean.is_empty(), "{clean:?}");
 }
 
+/// The probe payload for a run whose named functions each carry a hypothesis.
+///
+/// The probe is a separate frama-c run because the socket never carries these:
+/// WP emits them from its batch entry point and the request that runs proofs
+/// never reaches that code.
+fn hypothesis_probe(functions: &[&str]) -> serde_json::Value {
+    let text: String = functions
+        .iter()
+        .map(|function| {
+            format!(
+                "Memory model hypotheses for function '{function}':\n\
+                 /*@ behavior wp_typed:\n\
+                 \x20     requires \\separated(p, &g); */\n\
+                 void {function}(int *p);\n"
+            )
+        })
+        .collect();
+    json!({
+        "ran": true,
+        "read_from": frama_c_mcp::mcp::server::checkgaps::PROBE_READ_FROM_SEPARATE_RUN,
+        "model": "Typed+nocast",
+        "hypotheses": frama_c_mcp::mcp::server::wpclass::wp_memory_model_hypotheses_in_text(&text),
+    })
+}
+
+/// The case the whole item exists for: nothing is unproved, and the entry fires
+/// anyway. A gate that only reported this alongside an unproved goal would skip
+/// the run where the hypothesis does damage.
+#[test]
+fn a_memory_model_hypothesis_is_a_gap_even_when_every_goal_is_valid() {
+    let gap = memory_model_hypothesis_gap(&hypothesis_probe(&["two"]))
+        .expect("a hypothesis warning is a gap");
+    assert_eq!(gap["code"], json!(incomplete_code::WP_MEMORY_MODEL_HYPOTHESIS));
+    assert_eq!(gap["function_count"], json!(1));
+    assert_eq!(gap["functions"][0]["function"], json!("two"));
+    assert_eq!(
+        gap["functions"][0]["hypotheses"],
+        json!(["requires \\separated(p, &g);"])
+    );
+    assert_eq!(gap["functions_truncated"], json!(false));
+
+    // Says where the answer came from, because it is not where a reader of the
+    // rest of the payload would look.
+    assert_eq!(
+        gap["read_from"],
+        json!("a separate frama-c run with provers off")
+    );
+}
+
+/// A run WP printed no hypothesis for is not a run with an empty hypothesis
+/// list; it carries no entry at all.
+///
+/// Both shapes of that: a probe whose output held no hypothesis block, and a
+/// probe whose output held only WP's other warnings.
+#[test]
+fn a_run_with_no_hypothesis_carries_no_entry() {
+    assert!(memory_model_hypothesis_gap(&hypothesis_probe(&[])).is_none());
+
+    let noise = json!({
+        "ran": true,
+        "hypotheses": frama_c_mcp::mcp::server::wpclass::wp_memory_model_hypotheses_in_text(
+            "[wp] Warning: Missing RTE guards\n[wp] Proved goals: 4 / 4\n"
+        ),
+    });
+    assert!(memory_model_hypothesis_gap(&noise).is_none(), "{noise:?}");
+}
+
+/// One entry per run rather than one per function, with the untruncated count
+/// beside a bounded sample. An entry per function would grow with the program
+/// inside the payload that already has a size problem.
+#[test]
+fn the_function_sample_is_bounded_and_says_how_many_it_dropped() {
+    let names: Vec<String> = (0..25).map(|n| format!("f{n:02}")).collect();
+    let probe = hypothesis_probe(&names.iter().map(String::as_str).collect::<Vec<_>>());
+    let gap = memory_model_hypothesis_gap(&probe).expect("gap");
+    assert_eq!(gap["function_count"], json!(25));
+    assert_eq!(gap["functions"].as_array().expect("array").len(), 20);
+    assert_eq!(gap["functions_truncated"], json!(true));
+}
+
+/// A probe that ran and found nothing is evidence of absence, and says so by
+/// producing no entry rather than an entry with an empty list.
+///
+/// This is the pair to the test below: ran-and-empty and did-not-run both give
+/// no entry here, and the two are told apart on the probe payload itself,
+/// which carries a reason for the second and none for the first.
+#[test]
+fn a_probe_that_ran_and_found_nothing_produces_no_entry() {
+    let clean = json!({"ran": true, "model": "Typed+nocast", "hypotheses": []});
+    assert!(memory_model_hypothesis_gap(&clean).is_none());
+}
+
+/// The code carries guidance, because knowing a separation was assumed does not
+/// tell a caller that the fix is a requires on the function rather than a
+/// longer timeout.
+#[test]
+fn the_memory_model_hypothesis_code_carries_guidance() {
+    let guidance = gap_guidance(incomplete_code::WP_MEMORY_MODEL_HYPOTHESIS);
+    let text = guidance.as_str().expect("guidance is a string");
+    assert!(text.contains("requires"), "{text}");
+    assert!(!text.is_empty());
+}
+
+/// The guidance map is keyed by code, so an entry produced by this builder
+/// resolves through the same lookup every other entry uses.
+#[test]
+fn the_memory_model_hypothesis_entry_resolves_its_guidance_by_code() {
+    let gap = memory_model_hypothesis_gap(&hypothesis_probe(&["two"])).expect("gap");
+    let guidance = incomplete_guidance(&[gap]);
+    assert!(
+        guidance
+            .get(incomplete_code::WP_MEMORY_MODEL_HYPOTHESIS)
+            .and_then(|entry| entry.as_str())
+            .is_some_and(|text| text.contains("requires")),
+        "{guidance:?}"
+    );
+}
+
+/// A probe that did not run produces no entry, whatever the reason.
+///
+/// The two answers this payload exists to keep apart are "nothing was assumed"
+/// and "nobody looked". A probe skipped because the caller wanted no WP, or
+/// because WP failed, or because frama-c would not start, is the second, and
+/// its reason travels on the payload rather than becoming a silent empty list.
+#[test]
+fn a_probe_that_did_not_run_produces_no_entry() {
+    for reason in ["check did not run WP", "WP did not complete", "no project is loaded"] {
+        let skipped = json!({"ran": false, "reason": reason, "hypotheses": []});
+        assert!(memory_model_hypothesis_gap(&skipped).is_none(), "{reason}");
+    }
+    assert!(memory_model_hypothesis_gap(&hypothesis_probe(&["two"])).is_some());
+}
+
+/// The functions array is ordered by name, because it is hashed into the
+/// receipt and WP's warning order is not a property of the program.
+#[test]
+fn the_reported_functions_are_ordered_by_name() {
+    let probe = hypothesis_probe(&["zeta", "alpha", "mu"]);
+    let gap = memory_model_hypothesis_gap(&probe).expect("gap");
+    let names: Vec<&str> = gap["functions"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|entry| entry["function"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(names, ["alpha", "mu", "zeta"]);
+}
+
+/// Two runs over the same warnings in different arrival orders digest the same,
+/// which is what makes two receipts comparable.
+#[test]
+fn arrival_order_does_not_change_the_entry() {
+    assert_eq!(
+        memory_model_hypothesis_gap(&hypothesis_probe(&["alpha", "zeta"])),
+        memory_model_hypothesis_gap(&hypothesis_probe(&["zeta", "alpha"]))
+    );
+}
+
 /// An unresolved-call finding reaches the verdict as its own code.
 ///
 /// The dispatch in proofread_finding_gaps ends with a negative guard, so a
@@ -1652,4 +1814,191 @@ fn the_indirect_call_guidance_rules_out_a_longer_timeout() {
     let text = text.as_str().expect("guidance is a string");
     assert!(text.contains("calls"), "{text}");
     assert!(text.contains("timeout"), "{text}");
+}
+
+/// A probe that could not run makes the run loud rather than clean.
+///
+/// This is the half that matters more. WP proving every goal while the probe
+/// failed is a proof whose assumptions are unknown, and an empty hypothesis
+/// list would report it as a proof that assumed nothing.
+#[test]
+fn a_failed_probe_is_reported_as_an_unread_assumption() {
+    let failed = json!({
+        "ran": false,
+        "reason": "frama-c exited 1 during the memory-model probe",
+        "exit_code": 1,
+        "hypotheses": [],
+    });
+    let gap = memory_model_unchecked_gap(&failed, WantedAnalyses::BOTH).expect("gap");
+    assert_eq!(gap["code"], json!(incomplete_code::WP_MEMORY_MODEL_UNCHECKED));
+    assert_eq!(gap["exit_code"], json!(1));
+    assert!(
+        gap["reason"].as_str().is_some_and(|text| text.contains("could not read")),
+        "{gap:?}"
+    );
+}
+
+/// A probe that ran carries no unread-assumption gap, whether or not it found
+/// anything: that case is answered by the entry above it.
+#[test]
+fn a_probe_that_ran_is_not_an_unread_assumption() {
+    let ran = json!({"ran": true, "hypotheses": []});
+    assert!(memory_model_unchecked_gap(&ran, WantedAnalyses::BOTH).is_none());
+}
+
+/// A check that wanted no WP has no proof for an assumption to own, so it
+/// carries neither half.
+#[test]
+fn an_eva_only_check_carries_no_memory_model_gap() {
+    let skipped = probe_absent("check did not run WP", true);
+    let eva_only = WantedAnalyses { eva: true, wp: false };
+    assert!(memory_model_unchecked_gap(&skipped, eva_only).is_none());
+    assert!(memory_model_unchecked_gap(&skipped, WantedAnalyses::BOTH).is_none());
+}
+
+/// A run where WP itself failed already says so, and saying it twice would
+/// report one absence as two gaps.
+#[test]
+fn a_run_where_wp_failed_does_not_also_report_an_unread_assumption() {
+    let skipped = probe_absent("WP did not complete", true);
+    assert!(memory_model_unchecked_gap(&skipped, WantedAnalyses::BOTH).is_none());
+}
+
+/// check reads the run's own probe rather than paying for a second one.
+///
+/// run_wp probes inside the WP lock, over the AST it proved. Running a second
+/// probe in check would cost another frama-c process per call, measured at 2.3
+/// seconds, would put the same answer under two keys, and would run outside
+/// that lock, so it could describe a project loaded after the proofs.
+///
+/// Through the reader rather than around it. This asserted on
+/// memory_model_hypothesis_gap with a hand-built pointer, which is the gap
+/// formatter and not the read-through: it passed with every line of the
+/// read-through reverted. The frama-c path is a name no process is spawned
+/// under, because a payload carrying a probe never reaches one.
+#[tokio::test]
+async fn a_check_reads_the_probe_its_wp_run_already_made() {
+    let server = lazy_server(MISSING_FRAMA_C);
+    let wp = json!({
+        "ok": true,
+        "memory_model_probe": {
+            "ran": true,
+            "model": "Typed+nocast",
+            "hypotheses": [{"function": "two", "hypotheses": ["requires \\separated(p, &g);"]}],
+        },
+    });
+
+    let probe = server.memory_model_probe(WantedAnalyses::BOTH, &wp).await;
+    assert_eq!(probe, wp["memory_model_probe"], "{probe:?}");
+
+    let gap = memory_model_hypothesis_gap(&probe).expect("gap");
+    assert_eq!(gap["functions"][0]["function"], json!("two"), "{gap:?}");
+}
+
+/// A WP payload from a build that did not probe is not a probe that found
+/// nothing.
+///
+/// The reader turns a missing key into a stated ran:false, which
+/// memory_model_unchecked_gap then reports. Asserting instead that a bare null
+/// yields no gap tested the formatter's tolerance of a null and described the
+/// opposite of what check does with a payload that carries no probe.
+#[tokio::test]
+async fn a_wp_payload_without_a_probe_key_is_not_a_clean_probe() {
+    let server = lazy_server(MISSING_FRAMA_C);
+
+    let probe = server
+        .memory_model_probe(WantedAnalyses::BOTH, &json!({"ok": true}))
+        .await;
+    assert_eq!(probe["ran"], json!(false), "{probe:?}");
+    assert_eq!(
+        probe["reason"],
+        json!("the WP run reported no memory-model probe"),
+        "{probe:?}"
+    );
+
+    // No hypothesis entry, because none was read, and an unchecked entry
+    // instead, because a run whose assumptions nobody read is a gap.
+    assert!(memory_model_hypothesis_gap(&probe).is_none(), "{probe:?}");
+    assert!(
+        memory_model_unchecked_gap(&probe, WantedAnalyses::BOTH).is_some(),
+        "{probe:?}"
+    );
+}
+
+/// The parser's sentinel for a warning it could not read is not a hypothesis.
+///
+/// WP keys the record as a memory-model hypothesis and the parser keeps it,
+/// because a warning it cannot read is still evidence WP said something. It
+/// names no function and carries no clause, so counting it as a separation
+/// would claim one nobody read, under a reason telling the caller to write a
+/// requires it has no text for.
+#[test]
+fn an_unparsed_warning_is_not_reported_as_an_assumed_separation() {
+    let probe = json!({
+        "ran": true,
+        "read_from": "a separate frama-c run with provers off",
+        "hypotheses": [{
+            "function": null,
+            "hypotheses": [],
+            "hypothesis_count": 0,
+            "hypotheses_truncated": false,
+            "unparsed_warning_count": 2,
+            "source_location": null,
+            "matched_by": "log_category",
+        }],
+    });
+    assert!(memory_model_hypothesis_gap(&probe).is_none(), "{probe:?}");
+
+    // And it is not silence either: unread is its own answer.
+    let unchecked = memory_model_unchecked_gap(&probe, WantedAnalyses::BOTH)
+        .unwrap_or_else(|| panic!("an unread warning vanished: {probe:?}"));
+    assert_eq!(
+        unchecked["code"],
+        json!(incomplete_code::WP_MEMORY_MODEL_UNCHECKED)
+    );
+    assert_eq!(unchecked["unparsed_warning_count"], json!(2));
+}
+
+/// A run with both reports the clauses it read and says how many it did not.
+///
+/// The sample would otherwise look complete, since the count beside it counts
+/// only what parsed.
+#[test]
+fn an_unread_warning_travels_beside_the_clauses_that_were_read() {
+    let probe = json!({
+        "ran": true,
+        "read_from": "a separate frama-c run with provers off",
+        "hypotheses": [
+            {
+                "function": "two",
+                "hypotheses": ["requires \\separated(p, &g);"],
+                "hypothesis_count": 1,
+                "hypotheses_truncated": false,
+                "source_location": null,
+                "matched_by": "message_text",
+            },
+            {
+                "function": null,
+                "hypotheses": [],
+                "hypothesis_count": 0,
+                "hypotheses_truncated": false,
+                "unparsed_warning_count": 3,
+                "source_location": null,
+                "matched_by": "log_category",
+            },
+        ],
+    });
+    let gap = memory_model_hypothesis_gap(&probe).expect("a parsed clause is still a gap");
+
+    // One function, not two: the sentinel is not one of them.
+    assert_eq!(gap["function_count"], json!(1), "{gap:?}");
+    assert_eq!(gap["functions"].as_array().map(Vec::len), Some(1), "{gap:?}");
+    assert_eq!(gap["functions"][0]["function"], json!("two"), "{gap:?}");
+    assert_eq!(gap["unparsed_warning_count"], json!(3), "{gap:?}");
+
+    // The unread half is already reported here, so it is not a second entry.
+    assert!(
+        memory_model_unchecked_gap(&probe, WantedAnalyses::BOTH).is_none(),
+        "{probe:?}"
+    );
 }

--- a/tests/unit/server.rs
+++ b/tests/unit/server.rs
@@ -1,10 +1,9 @@
 use std::collections::{BTreeSet, HashMap};
-use std::sync::Arc;
-use tokio::sync::RwLock;
+
+use crate::server_fixture::{lazy_server, MISSING_FRAMA_C};
 use rmcp::ErrorData as McpError;
 use serde_json::json;
 use frama_c_mcp::error::FramaCError;
-use frama_c_mcp::state::SessionState;
 use frama_c_mcp::mcp::server::contracts::{result_unconstrained_findings, unconstrained_assigns_findings};
 use frama_c_mcp::mcp::server::eacsl::run_e_acsl_counterexample;
 use frama_c_mcp::mcp::server::wpclass::*;
@@ -204,12 +203,7 @@ fn wp_model_support_parses_bases_and_modifiers() {
 
 #[tokio::test]
 async fn self_check_shape_with_missing_frama_c() {
-    let state = Arc::new(RwLock::new(SessionState::default()));
-    let server = FramaCMcpServer::new_lazy(
-        state,
-        "__frama_c_mcp_missing_binary__".to_string(),
-        4,
-    );
+    let server = lazy_server(MISSING_FRAMA_C);
     let payload = server.self_check_payload().await;
     assert_eq!(payload["server"]["version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(payload["frama_c"]["status"], "missing");
@@ -335,12 +329,7 @@ fn probe_that_did_not_run_reports_why() {
 
 #[tokio::test]
 async fn self_check_capabilities_shape_with_missing_frama_c() {
-    let state = Arc::new(RwLock::new(SessionState::default()));
-    let server = FramaCMcpServer::new_lazy(
-        state,
-        "__frama_c_mcp_missing_binary__".to_string(),
-        4,
-    );
+    let server = lazy_server(MISSING_FRAMA_C);
     let payload = server.self_check_payload().await;
     let payload = &payload["capabilities"];
 
@@ -408,8 +397,7 @@ async fn self_check_live_reports_frama_c_when_available() {
     {
         return;
     }
-    let state = Arc::new(RwLock::new(SessionState::default()));
-    let server = FramaCMcpServer::new_lazy(state, "frama-c".to_string(), 4);
+    let server = lazy_server("frama-c");
     let payload = server.self_check_payload().await;
     assert_eq!(payload["frama_c"]["status"], "ok");
     assert_eq!(payload["temp_dir_writeability"]["status"], "ok");

--- a/tests/unit/server.rs
+++ b/tests/unit/server.rs
@@ -13,7 +13,7 @@ use frama_c_mcp::mcp::server::checkgaps::{check_incomplete_items, WantedAnalyses
 
 use frama_c_mcp::mcp::server::*;
 use frama_c_mcp::mcp::server::analysis::{
-    append_to_error_message, assumed_callee_contract_findings,
+    append_to_error_message, assumed_callee_contract_findings, unresolved_call_findings,
     finish_verify_program_step_response, goal_status_matches, present_statuses, reject_unknown_status,
     wp_timed_out,
     GOAL_STATUS_UNPROVED, VERIFY_PROGRAM_STEP_RESPONSE_CAP_BYTES,
@@ -2358,4 +2358,82 @@ fn concurrent_sandbox_writers_do_not_drop_each_others_entries() {
     let mut want: Vec<String> = (0..WRITERS).map(|n| format!("exp{n}")).collect();
     want.sort();
     assert_eq!(ids, want, "a concurrent writer's entry was dropped");
+}
+
+/// A getContractContext payload with one indirect call, as the plug-in builds
+/// it.
+fn context_with_indirect_call() -> serde_json::Value {
+    json!({
+        "function": {"function": "run", "contract": {"assigns": {"kind": "list", "assigns": []}}},
+        "callers": [],
+        "callees": [],
+        "unresolved_callees": [
+            {"sid": 5, "loc": {"file": "indirect-call.c", "line": 28, "col": 2}, "callee": "*f"}
+        ],
+        "callee_resolution_complete": false,
+    })
+}
+
+#[test]
+fn an_indirect_call_becomes_a_finding() {
+    let findings = unresolved_call_findings("run", &context_with_indirect_call());
+    assert_eq!(findings.len(), 1, "{findings:?}");
+    assert_eq!(findings[0]["category"], json!("unresolved_call"));
+    assert_eq!(findings[0]["function"], json!("run"));
+    assert_eq!(findings[0]["callee_expression"], json!("*f"));
+    assert_eq!(findings[0]["stmt_id"], json!(5));
+    assert_eq!(findings[0]["source_location"]["line"], json!(28));
+}
+
+/// Both halves of the fix, because the calls clause alone leaves the
+/// call-point goal open. Measured: 5 of 9 bare, 9 of 10 with calls, 10 of 10
+/// with the precondition too.
+#[test]
+fn the_suggested_fix_names_the_calls_clause_and_the_precondition() {
+    let findings = unresolved_call_findings("run", &context_with_indirect_call());
+    let fix = findings[0]["suggested_fix"].as_str().expect("suggested_fix");
+    assert!(fix.contains("calls"), "{fix}");
+    assert!(fix.contains("requires"), "{fix}");
+}
+
+/// A function with every callee resolved carries no finding, so the code is
+/// not simply always on.
+#[test]
+fn a_fully_resolved_call_graph_yields_no_unresolved_finding() {
+    let context = json!({
+        "function": {"function": "caller"},
+        "callees": [{"function": "inc", "contract": {"assigns": {"kind": "list", "assigns": []}}}],
+        "unresolved_callees": [],
+        "callee_resolution_complete": true,
+    });
+    assert!(unresolved_call_findings("caller", &context).is_empty());
+}
+
+/// A payload from a plug-in too old to carry the field is not a payload with
+/// no indirect calls, and returning findings for it would invent them.
+#[test]
+fn a_context_without_the_field_yields_no_finding() {
+    let context = json!({"function": {"function": "caller"}, "callees": []});
+    assert!(unresolved_call_findings("caller", &context).is_empty());
+}
+
+/// Two indirect calls in one function need two clauses, so they need two
+/// findings with distinct ids: findings are deduplicated by id downstream and
+/// an id naming only the caller would drop the second call.
+#[test]
+fn two_indirect_calls_in_one_function_get_distinct_ids() {
+    let context = json!({
+        "function": {"function": "run"},
+        "callees": [],
+        "unresolved_callees": [
+            {"sid": 5, "loc": {"file": "a.c", "line": 10, "col": 2}, "callee": "*f"},
+            {"sid": 9, "loc": {"file": "a.c", "line": 12, "col": 2}, "callee": "*g"}
+        ],
+        "callee_resolution_complete": false,
+    });
+    let findings = unresolved_call_findings("run", &context);
+    assert_eq!(findings.len(), 2, "{findings:?}");
+    assert_ne!(findings[0]["id"], findings[1]["id"], "{findings:?}");
+    assert_eq!(findings[0]["stmt_id"], json!(5));
+    assert_eq!(findings[1]["stmt_id"], json!(9));
 }

--- a/tests/unit/server.rs
+++ b/tests/unit/server.rs
@@ -236,7 +236,7 @@ async fn self_check_shape_with_missing_frama_c() {
     let ast_requests = payload["ast_utils_registered_requests"]
         .as_array()
         .expect("ast-utils registered requests");
-    assert_eq!(ast_requests.len(), 28);
+    assert_eq!(ast_requests.len(), 29);
     assert!(ast_requests.iter().any(|r| r["request"] == "plugins.ast-utils.dumpProject"));
     assert!(ast_requests
         .iter()
@@ -378,7 +378,7 @@ async fn self_check_capabilities_shape_with_missing_frama_c() {
         .is_some_and(|warning| warning.contains("executed paths")
             && warning.contains("assigns clauses")));
     // Also pinned in test-process-lifecycle.rs; see the note there.
-    assert_eq!(payload["ast_utils"]["registered_request_count"], 28);
+    assert_eq!(payload["ast_utils"]["registered_request_count"], 29);
     assert!(payload["ast_utils"]["registered_requests"]
         .as_array()
         .expect("ast-utils requests")

--- a/tests/unit/wp-classify.rs
+++ b/tests/unit/wp-classify.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use serde_json::json;
+use crate::server_fixture::lazy_server;
 use frama_c_mcp::mcp::types::*;
 use frama_c_mcp::mcp::server::receipt::proof_receipt_goals;
 use frama_c_mcp::mcp::server::analysis::{profile_covers_exactly, profile_matches_loaded_project};
@@ -2764,5 +2765,640 @@ fn a_model_frama_c_accepts_is_not_called_invalid() {
         }
         // Still a closed set: a name Frama-C would reject is refused here too.
         assert!(support.validate("NotAModel").is_err());
+    }
+}
+
+/// One log record as the getLogs request returns it.
+///
+/// The category is an option because the measurement that motivated this says
+/// WP does not set one for the memory-model warning: "-wp-warn-key
+/// hypothesis=inactive" leaves the warning in place on 32.1, and only
+/// "-wp-no-warn-memory-model" removes it.
+fn wp_log(message: &str, category: Option<&str>) -> serde_json::Value {
+    let mut record = json!({
+        "kind": "WARNING",
+        "plugin": "wp",
+        "message": message,
+        "source": {"file": "sep.c", "line": 6},
+    });
+    if let Some(category) = category {
+        record["category"] = json!(category);
+    }
+    record
+}
+
+/// The warning WP prints, verbatim from a Frama-C 32.1 run over
+/// "void two(int *p) { g = 1; *p = 2; }" with a contract over both locations.
+const HYPOTHESIS_WARNING: &str = "Memory model hypotheses for function 'two':\n\
+                                  /*@ behavior wp_typed:\n\
+                                  \x20     requires \\separated(p, &g); */\n\
+                                  void two(int *p);";
+
+#[test]
+fn a_memory_model_hypothesis_is_read_off_the_message_stream() {
+    let found = wp_memory_model_hypotheses(&[wp_log(HYPOTHESIS_WARNING, None)]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0]["function"], json!("two"));
+    assert_eq!(found[0]["hypotheses"], json!(["requires \\separated(p, &g);"]));
+    assert_eq!(found[0]["matched_by"], json!("message_text"));
+
+    // The location comes off the record rather than the text, because the
+    // server strips the "file:line:" prefix into its own field.
+    assert_eq!(found[0]["source_location"]["line"], json!(6));
+}
+
+/// The behavior wrapper and the redeclared prototype are not clauses.
+///
+/// Pasting either into a contract is a syntax error, and the whole point of
+/// carrying the text is that a caller can paste it.
+#[test]
+fn only_the_clause_lines_of_the_hypothesis_block_are_kept() {
+    let found = wp_memory_model_hypotheses(&[wp_log(HYPOTHESIS_WARNING, None)]);
+    let clauses = found[0]["hypotheses"].as_array().expect("array").clone();
+    assert!(
+        clauses.iter().all(|clause| clause.as_str().is_some_and(|c| c.starts_with("requires "))),
+        "{clauses:?}"
+    );
+    assert!(
+        !clauses.iter().any(|clause| clause.as_str().is_some_and(|c| c.contains("behavior")
+            || c.contains("void two"))),
+        "{clauses:?}"
+    );
+}
+
+/// A future Frama-C giving this warning a key must not silently fall back to
+/// prose matching, so the branch that fired is on the entry.
+#[test]
+fn a_keyed_hypothesis_warning_reports_that_it_matched_structurally() {
+    let found = wp_memory_model_hypotheses(&[wp_log(HYPOTHESIS_WARNING, Some("hypothesis"))]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0]["matched_by"], json!("log_category"));
+    assert_eq!(found[0]["function"], json!("two"));
+}
+
+/// The other WP warnings on the same stream are not hypotheses.
+///
+/// drain_messages keeps every WARNING, so this classifier sees the abort
+/// wording wp_backend_diagnosis reads and the RTE nag beside it.
+#[test]
+fn other_wp_warnings_are_not_read_as_hypotheses() {
+    let noise = [
+        wp_log("Missing RTE guards", None),
+        wp_log("Goal Preservation: running prover alt-ergo failed (see logs)", None),
+        wp_log("Missing 'calls' for default behavior", None),
+    ];
+    assert!(wp_memory_model_hypotheses(&noise).is_empty());
+}
+
+/// WP prints this once per function, and a check drains once, so a repeat is
+/// a second run_wp in the same call rather than a second hypothesis.
+#[test]
+fn one_function_yields_one_hypothesis_entry() {
+    let found = wp_memory_model_hypotheses(&[
+        wp_log(HYPOTHESIS_WARNING, None),
+        wp_log(HYPOTHESIS_WARNING, None),
+    ]);
+    assert_eq!(found.len(), 1, "{found:?}");
+}
+
+/// Two functions are two entries, in the order WP warned about them.
+#[test]
+fn each_function_with_a_hypothesis_gets_its_own_entry() {
+    let other = "Memory model hypotheses for function 'three':\n\
+                 /*@ behavior wp_typed:\n\
+                 \x20     requires \\separated(q, &h); */\n\
+                 void three(int *q);";
+    let found = wp_memory_model_hypotheses(&[wp_log(HYPOTHESIS_WARNING, None), wp_log(other, None)]);
+    assert_eq!(found.len(), 2, "{found:?}");
+
+    // By function name, not by the order WP happened to warn. This array is
+    // hashed into the receipt through the incomplete[] digest, and WP's warning
+    // order is not a property of the program.
+    assert_eq!(found[0]["function"], json!("three"));
+    assert_eq!(found[1]["function"], json!("two"));
+}
+
+/// A record matched on category alone with wording this does not parse is
+/// reported with a null function rather than dropped, because dropping it
+/// would be the silence the first standing constraint forbids.
+#[test]
+fn a_keyed_warning_this_cannot_parse_is_reported_rather_than_dropped() {
+    let found = wp_memory_model_hypotheses(&[wp_log("some future wording", Some("hypothesis"))]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0]["function"], json!(null));
+    assert_eq!(found[0]["hypotheses"], json!([]));
+    assert_eq!(found[0]["matched_by"], json!("log_category"));
+}
+
+/// The plugin field is part of the structural match, so another plug-in's
+/// "hypothesis" category is not WP's.
+#[test]
+fn another_plugins_hypothesis_category_is_not_a_wp_memory_model_hypothesis() {
+    let mut record = wp_log("some other hypothesis", Some("hypothesis"));
+    record["plugin"] = json!("eva");
+    assert!(wp_memory_model_hypotheses(&[record]).is_empty());
+}
+
+/// A clause line elsewhere in the record is not a hypothesis.
+///
+/// The parse is scoped to the block between the marker and the closing token
+/// of the behavior comment. Before that scoping, any line in the whole record
+/// that ended in a semicolon and began with a clause keyword was reported as an
+/// assumed separation, which is a claim about the proof that WP never made.
+#[test]
+fn a_clause_outside_the_hypothesis_block_is_not_a_hypothesis() {
+    let text = "requires \\valid(q);\n\
+                Memory model hypotheses for function 'two':\n\
+                /*@ behavior wp_typed:\n\
+                \x20     requires \\separated(p, &g); */\n\
+                void two(int *p);\n\
+                ensures \\result == 0;";
+    let found = wp_memory_model_hypotheses(&[wp_log(text, None)]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0]["hypotheses"], json!(["requires \\separated(p, &g);"]));
+}
+
+/// Two blocks in one record are two functions, each with its own clauses.
+///
+/// Taking the first marker and then every clause in the record paired the first
+/// function's name with the second function's separations.
+#[test]
+fn two_hypothesis_blocks_in_one_record_do_not_share_clauses() {
+    let text = "Memory model hypotheses for function 'alpha':\n\
+                /*@ behavior wp_typed:\n\
+                \x20     requires \\separated(p, &g); */\n\
+                void alpha(int *p);\n\
+                Memory model hypotheses for function 'beta':\n\
+                /*@ behavior wp_typed:\n\
+                \x20     requires \\separated(q, &h); */\n\
+                void beta(int *q);";
+    let found = wp_memory_model_hypotheses(&[wp_log(text, None)]);
+    assert_eq!(found.len(), 2, "{found:?}");
+    assert_eq!(found[0]["function"], json!("alpha"));
+    assert_eq!(found[0]["hypotheses"], json!(["requires \\separated(p, &g);"]));
+    assert_eq!(found[1]["function"], json!("beta"));
+    assert_eq!(found[1]["hypotheses"], json!(["requires \\separated(q, &h);"]));
+}
+
+/// WP wraps a long clause, and a wrapped clause is still one clause.
+///
+/// Splitting on lines dropped it silently, which is the worst shape for this:
+/// the entry still appeared, so a reader had no way to tell a function with no
+/// hypotheses from one whose hypothesis was too long to print on one line.
+#[test]
+fn a_clause_wrapped_over_two_lines_is_one_clause() {
+    let text = "Memory model hypotheses for function 'wide':\n\
+                /*@ behavior wp_typed:\n\
+                \x20     requires \\separated(p, &g, &h, &i,\n\
+                \x20                        &j, &k); */\n\
+                void wide(int *p);";
+    let found = wp_memory_model_hypotheses(&[wp_log(text, None)]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(
+        found[0]["hypotheses"],
+        json!(["requires \\separated(p, &g, &h, &i, &j, &k);"])
+    );
+}
+
+/// A CRLF stream is the same stream.
+#[test]
+fn carriage_returns_do_not_change_the_parse() {
+    let text = "Memory model hypotheses for function 'two':\r\n\
+                /*@ behavior wp_typed:\r\n\
+                \x20     requires \\separated(p, &g); */\r\n\
+                void two(int *p);";
+    let found = wp_memory_model_hypotheses(&[wp_log(text, None)]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0]["function"], json!("two"));
+    assert_eq!(found[0]["hypotheses"], json!(["requires \\separated(p, &g);"]));
+}
+
+/// Another plug-in quoting this text is not a statement about WP's model.
+///
+/// The structural branch already required the plug-in; the text branch did not,
+/// so any plug-in whose message contained the marker produced an entry.
+#[test]
+fn another_plugins_message_carrying_the_marker_is_not_a_hypothesis() {
+    let mut record = wp_log(HYPOTHESIS_WARNING, None);
+    record["plugin"] = json!("kernel");
+    assert!(wp_memory_model_hypotheses(&[record]).is_empty());
+}
+
+/// Repeated warnings this cannot parse are counted, not listed.
+///
+/// One entry each would let a stream of them consume the bounded sample and
+/// push out the functions a reader can act on.
+#[test]
+fn unparsed_hypothesis_warnings_are_counted_in_one_entry() {
+    let found = wp_memory_model_hypotheses(&[
+        wp_log("some future wording", Some("hypothesis")),
+        wp_log("some other future wording", Some("hypothesis")),
+        wp_log(HYPOTHESIS_WARNING, None),
+    ]);
+    assert_eq!(found.len(), 2, "{found:?}");
+    let unparsed = found
+        .iter()
+        .find(|entry| entry["function"] == json!(null))
+        .expect("an entry for what could not be parsed");
+    assert_eq!(unparsed["unparsed_warning_count"], json!(2));
+    assert_eq!(unparsed["matched_by"], json!("log_category"));
+}
+
+/// The clause sample is bounded and says how many it dropped, because an
+/// assumption omitted without a count is an assumption nobody knows about.
+#[test]
+fn the_clause_sample_reports_what_it_dropped() {
+    let mut block = String::from(
+        "Memory model hypotheses for function 'many':\n/*@ behavior wp_typed:\n",
+    );
+    for n in 0..20 {
+        block.push_str(&format!("      requires \\separated(p, &g{n});\n"));
+    }
+    block.push_str("*/\nvoid many(int *p);");
+    let found = wp_memory_model_hypotheses(&[wp_log(&block, None)]);
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0]["hypothesis_count"], json!(20));
+    assert_eq!(found[0]["hypotheses"].as_array().expect("array").len(), 16);
+    assert_eq!(found[0]["hypotheses_truncated"], json!(true));
+}
+
+/// A function with one hypothesis says so rather than leaving the reader to
+/// infer it from the sample length.
+#[test]
+fn an_untruncated_clause_list_says_it_is_untruncated() {
+    let found = wp_memory_model_hypotheses(&[wp_log(HYPOTHESIS_WARNING, None)]);
+    assert_eq!(found[0]["hypothesis_count"], json!(1));
+    assert_eq!(found[0]["hypotheses_truncated"], json!(false));
+}
+
+/// The probe wrapper's failure path, exercised rather than hand-built.
+///
+/// A frama-c that exits nonzero has not shown that the run assumed nothing, so
+/// the wrapper reports "ran": false with the exit code and a capped excerpt of
+/// what it said, and still carries whatever it managed to parse first. The
+/// binary here is "false", which exits 1 and prints nothing: the cheapest way
+/// to reach that arm without a Frama-C.
+#[tokio::test]
+async fn a_probe_whose_frama_c_fails_is_not_a_clean_probe() {
+    let options = frama_c_mcp::mcp::server::ProjectLoadOptions::default();
+    let probe = frama_c_mcp::mcp::server::wpcli::run_wp_memory_model_probe(
+        "false",
+        &["a.c".to_string()],
+        &options,
+        false,
+        Some("Typed+nocast"),
+        &[],
+        None,
+    )
+    .await;
+    assert_eq!(probe["ran"], json!(false), "{probe:?}");
+    assert_eq!(probe["exit_code"], json!(1), "{probe:?}");
+    assert_eq!(probe["hypotheses"], json!([]), "{probe:?}");
+    assert!(
+        probe["reason"].as_str().is_some_and(|text| text.contains("exited 1")),
+        "{probe:?}"
+    );
+    assert_eq!(probe["stderr_truncated"], json!(false), "{probe:?}");
+}
+
+/// A binary that is not there at all is a probe that did not run, with the
+/// reason naming the failure rather than an empty list implying none.
+#[tokio::test]
+async fn a_probe_whose_binary_is_missing_is_not_a_clean_probe() {
+    let options = frama_c_mcp::mcp::server::ProjectLoadOptions::default();
+    let probe = frama_c_mcp::mcp::server::wpcli::run_wp_memory_model_probe(
+        "/nonexistent/frama-c-that-is-not-installed",
+        &["a.c".to_string()],
+        &options,
+        false,
+        None,
+        &[],
+        None,
+    )
+    .await;
+    assert_eq!(probe["ran"], json!(false), "{probe:?}");
+    assert_eq!(probe["hypotheses"], json!([]), "{probe:?}");
+    assert!(
+        probe["reason"].as_str().is_some_and(|text| text.contains("could not be started")),
+        "{probe:?}"
+    );
+}
+
+/// No files is a probe with nothing to ask about, and it says so.
+#[tokio::test]
+async fn a_probe_with_no_files_does_not_run() {
+    let options = frama_c_mcp::mcp::server::ProjectLoadOptions::default();
+    let probe = frama_c_mcp::mcp::server::wpcli::run_wp_memory_model_probe(
+        "false", &[], &options, false, None, &[], None,
+    )
+    .await;
+    assert_eq!(probe["ran"], json!(false), "{probe:?}");
+    assert_eq!(probe["reason"], json!("no source files available"), "{probe:?}");
+}
+
+/// A stand-in frama-c whose behaviour depends on which prover it was given.
+///
+/// The isolated retry runs one process per prover and reads the hypotheses out
+/// of their combined output, so pinning what it does with disagreeing attempts
+/// needs the attempts to disagree. Each arm is "printf then exit", which is the
+/// shape of a frama-c that warned and then either finished or died.
+fn fake_frama_c_per_prover(dir: &std::path::Path, arms: &[(&str, &str, i32)]) -> String {
+    let mut script = String::from("#!/bin/sh\nfor a in \"$@\"; do\n  case \"$a\" in\n");
+    for (prover, output, code) in arms {
+        script.push_str(&format!(
+            "    {prover}) printf '%s' \"{output}\"; exit {code};;\n"
+        ));
+    }
+    script.push_str("  esac\ndone\nexit 0\n");
+    write_executable(dir, &script)
+}
+
+/// Put an executable shell script in a directory and answer its path.
+///
+/// Shared because three tests here need a frama-c stand-in and the write plus
+/// chmod plus path conversion is the same three lines each time; only the
+/// script body differs.
+fn write_executable(dir: &std::path::Path, script: &str) -> String {
+    let path = dir.join("fake-frama-c");
+    std::fs::write(&path, script).expect("write");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    }
+    path.display().to_string()
+}
+
+async fn isolated_retry_probe(frama_c_path: String, provers: Vec<String>) -> serde_json::Value {
+    let server = lazy_server(frama_c_path);
+    let params = RunWpParams::default();
+    let result = server
+        .run_isolated_wp_retries(frama_c_mcp::mcp::server::wpcli::IsolatedWpRetry {
+            files: vec!["a.c".to_string()],
+            project_options: frama_c_mcp::mcp::server::ProjectLoadOptions::default(),
+            rte_enabled: false,
+            functions: vec!["two".to_string()],
+            reported_functions: vec!["two".to_string()],
+            provers,
+            params: &params,
+            scope: "main",
+        })
+        .await
+        .expect("the retry path answers with a payload");
+    result
+        .structured_content
+        .expect("a retry payload is an object")["memory_model_probe"]
+        .clone()
+}
+
+/// An isolated retry whose Frama-C attempts all failed has not read the
+/// assumptions, even if one of them emitted an empty diagnostic stream.
+///
+/// Driven through run_isolated_wp_retries rather than asserted on a
+/// hand-written payload. The earlier version built the object the production
+/// code produces and then checked that the gap readers agreed with it, which
+/// passed with the accumulation in wpcli.rs reverted entirely.
+#[tokio::test]
+async fn a_retry_with_only_failed_attempts_is_not_a_clean_probe() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fake = fake_frama_c_per_prover(dir.path(), &[("alt-ergo", "", 3)]);
+    let probe = isolated_retry_probe(fake, vec!["alt-ergo".to_string()]).await;
+
+    assert_eq!(probe["ran"], json!(false), "{probe:?}");
+    assert_eq!(probe["hypotheses"], json!([]), "{probe:?}");
+    assert_eq!(
+        probe["read_from"],
+        json!("the isolated retry's own captured output"),
+        "{probe:?}"
+    );
+
+    assert!(frama_c_mcp::mcp::server::checkgaps::memory_model_hypothesis_gap(&probe).is_none());
+    let gap = frama_c_mcp::mcp::server::checkgaps::memory_model_unchecked_gap(
+        &probe,
+        frama_c_mcp::mcp::server::checkgaps::WantedAnalyses::BOTH,
+    )
+    .expect("an unread assumption is a gap");
+    assert!(
+        gap["reason"].as_str().is_some_and(|text| text.contains("could not read")),
+        "{gap:?}"
+    );
+}
+
+/// A successful attempt's reading outranks a failed attempt's partial one.
+///
+/// The two halves used to be independent: ran came from any attempt exiting 0
+/// and the list came from the first attempt to print anything, whoever that
+/// was. So a prover that printed one separation and then died, followed by one
+/// that succeeded and printed both, answered ran:true beside the short list,
+/// and a caller reading the flag was told a partial reading was complete. A
+/// frama-c that exits 0 read the whole program, so its answer wins even when
+/// the failed attempt printed more.
+#[tokio::test]
+async fn a_successful_attempt_supplies_the_hypotheses_over_a_failed_one() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let partial = "Memory model hypotheses for function 'two':\n                   /*@ behavior wp_typed:\n                   requires \\separated(p, &g); */\n";
+    let complete = "Memory model hypotheses for function 'two':\n                    /*@ behavior wp_typed:\n                    requires \\separated(p, &g);\n                    requires \\separated(p, &h); */\n";
+    let fake = fake_frama_c_per_prover(
+        dir.path(),
+        &[("alt-ergo", partial, 3), ("z3", complete, 0)],
+    );
+    let probe = isolated_retry_probe(fake, vec!["alt-ergo".to_string(), "z3".to_string()]).await;
+
+    assert_eq!(probe["ran"], json!(true), "{probe:?}");
+    let read = probe["hypotheses"][0]["hypotheses"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no hypotheses: {probe:?}"))
+        .len();
+    assert_eq!(read, 2, "the complete reading has to win: {probe:?}");
+}
+
+/// A failing Frama-C that still printed a hypothesis has that hypothesis kept.
+///
+/// The two halves are separate: what was read, and whether the reading was
+/// complete. A hypothesis Frama-C printed is one WP took, so dropping it
+/// because the process later failed would hide a real assumption, while the
+/// ran flag beside it already says the list may be short. Both the isolated
+/// retry and the standalone probe answer this the same way.
+#[tokio::test]
+async fn a_failed_probe_keeps_the_hypotheses_it_managed_to_read() {
+    // A shell that prints the warning and then exits non-zero, which is the
+    // shape of a Frama-C that warned and then died on a later phase.
+    let script = "printf '%s\\n' \"Memory model hypotheses for function 'two':\" \
+                  '/*@ behavior wp_typed:' '      requires \\separated(p, &g); */' \
+                  'void two(int *p);'; exit 3";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fake = write_executable(dir.path(), &format!("#!/bin/sh\n{script}\n"));
+
+    let probe = frama_c_mcp::mcp::server::wpcli::run_wp_memory_model_probe(
+        &fake,
+        &["a.c".to_string()],
+        &frama_c_mcp::mcp::server::ProjectLoadOptions::default(),
+        false,
+        None,
+        &[],
+        None,
+    )
+    .await;
+
+    assert_eq!(probe["ran"], json!(false), "{probe:?}");
+    assert_eq!(probe["exit_code"], json!(3), "{probe:?}");
+    assert_eq!(probe["hypotheses"][0]["function"], json!("two"), "{probe:?}");
+    assert_eq!(
+        probe["hypotheses"][0]["hypotheses"],
+        json!(["requires \\separated(p, &g);"]),
+        "{probe:?}"
+    );
+
+    // The gap builders read it the way the flag says: no hypothesis entry from
+    // an incomplete reading, and an unchecked-assumption entry instead.
+    assert!(frama_c_mcp::mcp::server::checkgaps::memory_model_hypothesis_gap(&probe).is_none());
+    assert!(frama_c_mcp::mcp::server::checkgaps::memory_model_unchecked_gap(
+        &probe,
+        frama_c_mcp::mcp::server::checkgaps::WantedAnalyses::BOTH,
+    )
+    .is_some());
+}
+
+/// Two failing attempts keep both readings, not whichever printed first.
+///
+/// The attempts die at different points, so each prints a different prefix of
+/// what WP had to say, and keeping only the first drops what a later one got
+/// further to reach. The reading over-reports nothing, because a hypothesis is
+/// a property of the function and the model rather than of the prover an
+/// attempt used. The ran flag still says the reading is incomplete.
+///
+/// Ordered by function name, not by which attempt printed first. The failing
+/// attempts are accumulated as text and parsed once, so the sort
+/// collect_memory_model_hypotheses applies is the sort here: this array is
+/// hashed into the receipt through incomplete[], and which prover died first
+/// is not a property of the program.
+#[tokio::test]
+async fn every_failed_attempt_contributes_what_it_printed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let first = "Memory model hypotheses for function 'two':\n                   /*@ behavior wp_typed:\n                   requires \\separated(p, &g); */\n";
+    let second = "Memory model hypotheses for function 'three':\n                   /*@ behavior wp_typed:\n                   requires \\separated(q, &h); */\n";
+    let fake = fake_frama_c_per_prover(
+        dir.path(),
+        &[("alt-ergo", first, 3), ("z3", second, 4)],
+    );
+    let probe = isolated_retry_probe(fake, vec!["alt-ergo".to_string(), "z3".to_string()]).await;
+
+    // Neither attempt exited 0, so the reading is still reported as partial.
+    assert_eq!(probe["ran"], json!(false), "{probe:?}");
+
+    let functions: Vec<&str> = probe["hypotheses"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no hypotheses: {probe:?}"))
+        .iter()
+        .filter_map(|entry| entry["function"].as_str())
+        .collect();
+    assert_eq!(
+        functions,
+        vec!["three", "two"],
+        "both readings, ordered by name rather than by attempt: {probe:?}"
+    );
+}
+
+/// The merge counts one unreadable warning once, however many attempts saw it.
+///
+/// Every attempt analyses the same program under the same model, so each prints
+/// the same warnings. Summing the sentinel counts would report one warning WP
+/// printed twice as two warnings this server could not read, which is the kind
+/// of over-claim the whole payload exists to avoid. The larger of the two is
+/// the honest answer.
+#[test]
+fn merging_two_readings_does_not_multiply_the_unread_count() {
+    let sentinel = |n: u64| {
+        json!([{
+            "function": null,
+            "hypotheses": [],
+            "hypothesis_count": 0,
+            "hypotheses_truncated": false,
+            "unparsed_warning_count": n,
+            "source_location": null,
+            "matched_by": "log_category",
+        }])
+    };
+    let merged = frama_c_mcp::mcp::server::wpclass::merge_memory_model_hypotheses(
+        sentinel(2).as_array().expect("array").clone(),
+        sentinel(2).as_array().expect("array").clone(),
+    );
+    assert_eq!(merged.len(), 1, "{merged:?}");
+    assert_eq!(merged[0]["unparsed_warning_count"], json!(2), "{merged:?}");
+}
+
+/// The merge orders by function name and puts the sentinel last, because this
+/// array is hashed into the receipt and attempt order is not a property of the
+/// program.
+#[test]
+fn merging_two_readings_orders_by_name_with_the_sentinel_last() {
+    let named = |function: &str| {
+        json!([{
+            "function": function,
+            "hypotheses": [format!("requires \\separated({function}, &g);")],
+            "hypothesis_count": 1,
+            "hypotheses_truncated": false,
+            "source_location": null,
+            "matched_by": "message_text",
+        }])
+    };
+    let mut second = named("alpha").as_array().expect("array").clone();
+    second.push(json!({
+        "function": null,
+        "hypotheses": [],
+        "hypothesis_count": 0,
+        "hypotheses_truncated": false,
+        "unparsed_warning_count": 1,
+        "source_location": null,
+        "matched_by": "log_category",
+    }));
+    let merged = frama_c_mcp::mcp::server::wpclass::merge_memory_model_hypotheses(
+        named("zeta").as_array().expect("array").clone(),
+        second,
+    );
+    let order: Vec<&str> = merged
+        .iter()
+        .map(|entry| entry["function"].as_str().unwrap_or("<sentinel>"))
+        .collect();
+    assert_eq!(order, vec!["alpha", "zeta", "<sentinel>"], "{merged:?}");
+}
+
+/// Two readings of one function keep the one that got further into the block.
+///
+/// An attempt that died mid-block printed a prefix of it, so the readings are
+/// not interchangeable and first-wins drops clauses WP really emitted. That is
+/// the same under-report the merge exists to prevent, one level below the
+/// function it was written for.
+#[test]
+fn the_longer_reading_of_a_function_wins_over_the_first() {
+    let reading = |clauses: &[&str]| {
+        json!([{
+            "function": "two",
+            "hypotheses": clauses,
+            "hypothesis_count": clauses.len(),
+            "hypotheses_truncated": false,
+            "source_location": null,
+            "matched_by": "message_text",
+        }])
+        .as_array()
+        .expect("array")
+        .clone()
+    };
+    let died_early = reading(&["requires \\separated(p, &g);"]);
+    let got_further = reading(&["requires \\separated(p, &g);", "requires \\separated(p, &h);"]);
+
+    // Whichever order the attempts arrive in, the longer reading survives.
+    for (first, second) in [
+        (died_early.clone(), got_further.clone()),
+        (got_further.clone(), died_early.clone()),
+    ] {
+        let merged = frama_c_mcp::mcp::server::wpclass::merge_memory_model_hypotheses(first, second);
+        assert_eq!(merged.len(), 1, "{merged:?}");
+        assert_eq!(merged[0]["hypothesis_count"], json!(2), "{merged:?}");
+        assert_eq!(
+            merged[0]["hypotheses"].as_array().map(Vec::len),
+            Some(2),
+            "a clause WP printed was dropped: {merged:?}"
+        );
     }
 }


### PR DESCRIPTION
Three things a caller could not see. Each one names something Frama-C already computes and this server never passed on, so a verdict read narrower than it was: the separations WP assumed while proving, a call through a function pointer that WP could not name a callee for, and the contracts a proof of the program still needs.

The memory-model half is the one whose design differs from the obvious. WP emits its hypotheses from the batch entry point only, and the server request that runs proofs never reaches that code, so the socket carries nothing to classify and a separate frama-c with provers off is the only source. It reads the printed AST rather than the files the run was loaded from, because annotations injected over the socket never reach the source: a probe pointed at those files describes the program as it was before the session touched it, and the run then reports every goal valid beside a probe reporting no hypotheses. That is the false clean this exists to rule out, and it is exactly the shape the CEGIS loop runs in. Measured on Frama-C 33.0 over nine lines, a function taking a pointer and writing a global proves every goal under `\separated(p, &g)`, a caller passing `&g` proves too, and the callee's postcondition is false at run time.

The other two are smaller. `getContractContext` has reported unresolved callees since the plug-in was written and nothing under `src/` read the field; with no `calls` clause WP assumes the pointer may reach any function including the enclosing one, so the goals underneath arrive as prover timeouts that no extra time will close, measured at 5 of 9 bare, 9 of 10 with a `calls` clause, and 10 of 10 once the contract pins the pointer. And `getContractFrontier` answers, whole-program and in one request, which defined functions are reachable from a contracted one and carry no contract themselves, which nothing answered before without one `getContractContext` per defined function.

Verified on Frama-C 33.0 with ast-utils installed in the same switch. All 16 gates in `scripts/run-gates.sh` pass at the tip: `cargo test --test unit` 565, `test-mcp-stdio` 134/134, `scripts/check-tutorial-corpus.sh` 28/28 with `-wp-cache none` so the verdicts are computed rather than replayed, plus clippy, shfmt, the plug-in's own `dune runtest`, and the four remaining Frama-C suites. Each of the three commits also passes `cargo check --all-targets` on its own, so the series bisects.

Three deeper fixes are deliberately not taken, each recorded in the commit where the work landed. The probe is not memoized on the AST digest, so a CEGIS loop running WP repeatedly over an unchanged AST pays for a probe each time, and on a project where parse and VC generation exceed the sixty-second budget the verdict is permanently incomplete with no opt-out. The sandbox mirrors its spawn's options by hand instead of carrying a `ProjectLoadOptions` of its own. And the plug-in's call graph is built per request rather than owned by a `State_builder` keyed on `Ast.self`, so `getContractContext` still pays the per-query walk the frontier no longer does.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces three facts a proof verdict previously hid: WP's assumed memory-model separations, calls through function pointers with no resolvable callee, and the contracts a program still needs. Verdicts now report these as distinct incomplete codes, and a new `contract_frontier` list kind answers the contract question in one request.

**New incomplete codes**
- `WP_MEMORY_MODEL_HYPOTHESIS` reports separations WP assumed but didn't check; a separate probe run reads the printed AST because injected annotations never reach the source.
- `WP_MEMORY_MODEL_UNCHECKED` covers when that probe can't run or reads nothing.
- `INDIRECT_CALL_UNRESOLVED` reports indirect calls with no `calls` clause, which previously surfaced as prover timeouts.
- Failed isolated retries merge their parsed readings through the parser's own merge, keeping the larger unread count and preferring the reading that got further into a partially-printed block.

**Contract frontier**
- `list {kind: "contract_frontier"}` returns defined functions reachable from a contracted one that carry no contract, plus the unresolved call sites along the way.
- A receipt that would adopt the retry's marker as its digest now rejects it and prints its own AST instead.

<sup>Written for commit a0390f07e6f01b743156b0577ad829b34631b547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/frama-c-mcp/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

